### PR TITLE
feat(cargo-tangle)!: use Soldeer for dependencies

### DIFF
--- a/cli/src/deploy.rs
+++ b/cli/src/deploy.rs
@@ -256,7 +256,7 @@ fn build_contracts_if_needed(
     let needs_build = abs_pathes_to_check.iter().any(|path| !path.exists());
 
     if needs_build {
-        let mut foundry = crate::foundry::FoundryToolchain::new();
+        let foundry = crate::foundry::FoundryToolchain::new();
         foundry.check_installed_or_exit();
         foundry.forge.build()?;
     }

--- a/cli/src/foundry/forge.rs
+++ b/cli/src/foundry/forge.rs
@@ -1,7 +1,7 @@
-use color_eyre::{eyre::eyre, Result};
-use std::process::Command;
-
 use super::CommandInstalled;
+use color_eyre::{eyre::eyre, Result};
+use gadget_sdk::tracing;
+use std::process::Command;
 
 pub struct Forge {
     cmd: Command,
@@ -32,7 +32,7 @@ impl Forge {
     }
 
     /// Builds the contracts.
-    pub fn build(&mut self) -> Result<()> {
+    pub fn build(mut self) -> Result<()> {
         eprintln!("Building contracts...");
         let status = self
             .cmd
@@ -43,6 +43,20 @@ impl Forge {
             .wait()?;
         if !status.success() {
             return Err(eyre!("Failed to build contracts"));
+        }
+        Ok(())
+    }
+
+    pub fn install_dependencies(mut self) -> Result<()> {
+        tracing::info!("Installing dependencies...");
+        let output = self
+            .cmd
+            .args(["soldeer", "update", "-d"])
+            .stderr(std::process::Stdio::inherit())
+            .stdout(std::process::Stdio::inherit())
+            .output()?;
+        if !output.status.success() {
+            return Err(eyre!("Failed to install dependencies"));
         }
         Ok(())
     }


### PR DESCRIPTION
Once https://github.com/tangle-network/blueprint-template/pull/36 gets in, a new `cargo-tangle` release should happen ASAP. The CLI depends on the template.