### PR TITLE
refactor: remove `async-trait`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2694,11 +2694,11 @@ dependencies = [
 name = "blueprint-manager"
 version = "0.2.2"
 dependencies = [
- "async-trait",
  "auto_impl",
  "blueprint-sdk",
  "clap",
  "color-eyre",
+ "dynosaur",
  "futures",
  "gadget-clients",
  "gadget-crypto",
@@ -2794,7 +2794,6 @@ version = "0.1.0"
 dependencies = [
  "alloy",
  "alloy-json-abi",
- "async-trait",
  "blueprint-build-utils",
  "blueprint-core",
  "blueprint-evm-extra",
@@ -6817,7 +6816,6 @@ dependencies = [
 name = "gadget-client-core"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "auto_impl",
  "gadget-std",
  "thiserror 2.0.11",
@@ -6865,7 +6863,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-transport",
  "alloy-transport-http",
- "async-trait",
  "blueprint-evm-extra",
  "gadget-anvil-testing-utils",
  "gadget-client-core",
@@ -6885,7 +6882,6 @@ dependencies = [
 name = "gadget-client-tangle"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "auto_impl",
  "blueprint-runner",
  "color-eyre",
@@ -6922,7 +6918,6 @@ dependencies = [
  "alloy-network",
  "alloy-provider",
  "alloy-transport",
- "async-trait",
  "blueprint-sdk",
  "gadget-context-derive",
  "proc-macro2",
@@ -6938,7 +6933,6 @@ dependencies = [
 name = "gadget-contexts"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "blueprint-runner",
  "gadget-clients",
  "gadget-keystore",
@@ -6952,7 +6946,6 @@ dependencies = [
 name = "gadget-core-testing-utils"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "blueprint-core",
  "blueprint-router",
  "blueprint-runner",
@@ -7129,7 +7122,6 @@ dependencies = [
  "alloy-rpc-types",
  "alloy-rpc-types-eth",
  "alloy-transport",
- "async-trait",
  "blueprint-core",
  "blueprint-evm-extra",
  "blueprint-runner",
@@ -7178,7 +7170,6 @@ dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
- "async-trait",
  "aws-config",
  "aws-sdk-kms",
  "blake3",
@@ -7229,7 +7220,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.8.21",
  "anyhow",
- "async-trait",
  "auto_impl",
  "bincode",
  "blake3",
@@ -7297,7 +7287,6 @@ dependencies = [
 name = "gadget-std"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "colored",
  "num-traits",
  "rand 0.8.5",
@@ -7335,7 +7324,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types 0.8.21",
  "alloy-transport",
- "async-trait",
  "blueprint-core",
  "blueprint-runner",
  "blueprint-tangle-extra",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ rust_2018_idioms = { level = "deny", priority = -1 }
 trivial_casts = "deny"
 trivial_numeric_casts = "deny"
 unused_import_braces = "deny"
+async_fn_in_trait = "allow"
 
 [workspace.lints.clippy]
 pedantic = { level = "deny", priority = -1 }
@@ -122,7 +123,6 @@ sp-io = { version = "38.0.0", default-features = false }
 sp-runtime = { version = "39.0.0", default-features = false }
 
 # Async & Runtime
-async-trait = { version = "0.1.86", default-features = false }
 crossbeam = { version = "0.8", default-features = false }
 crossbeam-channel = { version = "0.5", default-features = false }
 futures = { version = "0.3.30", default-features = false }

--- a/cli/src/tests/run.rs
+++ b/cli/src/tests/run.rs
@@ -132,7 +132,6 @@ alloy-json-abi = {{ version = "0.8" }}
 alloy-dyn-abi = {{ version = "0.8" }}
 alloy-contract = {{ version = "0.9" }}
 alloy-network = {{ version = "0.9" }}
-async-trait = {{ version = "0.1.86" }}
 serde = {{ version = "1.0", features = ["derive"] }}
 serde_json = "1.0"
 "#

--- a/crates/clients/core/Cargo.toml
+++ b/crates/clients/core/Cargo.toml
@@ -13,7 +13,6 @@ workspace = true
 
 [dependencies]
 gadget-std = { workspace = true }
-async-trait = { workspace = true }
 auto_impl = { workspace = true }
 thiserror = { workspace = true }
 

--- a/crates/clients/core/src/lib.rs
+++ b/crates/clients/core/src/lib.rs
@@ -5,7 +5,6 @@ use gadget_std::hash::Hash;
 
 pub type OperatorSet<K, V> = std::collections::BTreeMap<K, V>;
 
-#[async_trait::async_trait]
 #[auto_impl::auto_impl(&, Arc)]
 pub trait GadgetServicesClient: Send + Sync + 'static {
     /// The ID of for operators at the blueprint/application layer. Typically a cryptograpgic key in the form of a point on

--- a/crates/clients/evm/Cargo.toml
+++ b/crates/clients/evm/Cargo.toml
@@ -18,7 +18,6 @@ hex = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }
 thiserror = { workspace = true }
-async-trait = { workspace = true }
 url = { workspace = true }
 
 # Alloy dependencies

--- a/crates/clients/evm/src/client.rs
+++ b/crates/clients/evm/src/client.rs
@@ -2,12 +2,10 @@
 
 use alloy_primitives::BlockNumber;
 use alloy_rpc_types::{Block, BlockNumberOrTag};
-use gadget_std::boxed::Box;
 
 #[derive(Debug)]
 pub struct Client {}
 
-#[async_trait::async_trait]
 pub trait BackendClient {
     type Error;
 

--- a/crates/clients/evm/src/instrumented_client.rs
+++ b/crates/clients/evm/src/instrumented_client.rs
@@ -13,7 +13,6 @@ use alloy_rpc_types_eth::{
 };
 use alloy_transport::{TransportError, TransportResult};
 use gadget_rpc_calls::RpcCallsMetrics as RpcCallsCollector;
-use gadget_std::boxed::Box;
 use gadget_std::string::String;
 use gadget_std::string::ToString;
 use gadget_std::time::Instant;
@@ -47,7 +46,6 @@ pub enum InstrumentedClientError {
     Rpc(#[from] alloy_json_rpc::RpcError<alloy_transport::TransportErrorKind>),
 }
 
-#[async_trait::async_trait]
 impl BackendClient for InstrumentedClient {
     type Error = InstrumentedClientError;
 
@@ -793,14 +791,14 @@ impl InstrumentedClient {
     /// # Returns
     ///
     /// The result of the RPC call.
-    async fn instrument_function<'async_trait, P, R>(
+    async fn instrument_function<P, R>(
         &self,
         rpc_method_name: &str,
         params: P,
     ) -> TransportResult<R>
     where
-        P: RpcSend + 'async_trait,
-        R: RpcRecv + 'async_trait,
+        P: RpcSend,
+        R: RpcRecv,
     {
         let start = Instant::now();
         let method_string = String::from(rpc_method_name);

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -20,7 +20,6 @@ gadget-logging = { workspace = true }
 gadget-keystore = { workspace = true }
 gadget-crypto-sp-core = { workspace = true }
 
-async-trait = { workspace = true }
 auto_impl = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }

--- a/crates/clients/tangle/src/client.rs
+++ b/crates/clients/tangle/src/client.rs
@@ -193,7 +193,6 @@ impl gadget_std::ops::Deref for TangleClient {
     }
 }
 
-#[async_trait::async_trait]
 impl EventsClient<TangleEvent> for TangleClient {
     async fn next_event(&self) -> Option<TangleEvent> {
         let mut lock = self
@@ -221,7 +220,7 @@ impl EventsClient<TangleEvent> for TangleClient {
                 drop(lock);
                 self.initialize().await.ok()?;
                 // Next time, the stream should be initialized.
-                self.next_event().await
+                Box::pin(async { self.next_event().await }).await
             }
         }
     }
@@ -244,7 +243,6 @@ impl EventsClient<TangleEvent> for TangleClient {
 
 pub type BlueprintId = u64;
 
-#[async_trait::async_trait]
 impl GadgetServicesClient for TangleClient {
     type PublicApplicationIdentity = ecdsa::Public;
     type PublicAccountIdentity = AccountId32;

--- a/crates/clients/tangle/src/lib.rs
+++ b/crates/clients/tangle/src/lib.rs
@@ -6,11 +6,8 @@ pub mod services;
 #[cfg(not(any(feature = "std", feature = "web")))]
 compile_error!("`std` or `web` feature required");
 
-use async_trait::async_trait;
 use auto_impl::auto_impl;
-use gadget_std::boxed::Box;
 
-#[async_trait]
 #[auto_impl(Arc)]
 pub trait EventsClient<Event>: Clone + Send + Sync {
     /// Fetch the next event from the client.

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -8,6 +8,9 @@ license.workspace = true
 homepage.workspace = true
 repository.workspace = true
 
+[lints]
+workspace = true
+
 [dependencies]
 blueprint-runner = { workspace = true }
 gadget-std = { workspace = true }
@@ -15,7 +18,6 @@ gadget-clients = { workspace = true }
 gadget-networking = { workspace = true, optional = true }
 gadget-keystore = { workspace = true, optional = true }
 
-async-trait.workspace = true
 proc-macro2 = { workspace = true, optional = true }
 
 tangle-subxt = { workspace = true, optional = true }

--- a/crates/contexts/src/eigenlayer.rs
+++ b/crates/contexts/src/eigenlayer.rs
@@ -3,12 +3,10 @@ use gadget_clients::Error;
 pub use gadget_clients::eigenlayer::client::EigenlayerClient;
 
 /// Provides access to Eigenlayer utilities through its [`EigenlayerClient`].
-#[async_trait::async_trait]
 pub trait EigenlayerContext {
     async fn eigenlayer_client(&self) -> Result<EigenlayerClient, Error>;
 }
 
-#[async_trait::async_trait]
 impl EigenlayerContext for BlueprintEnvironment {
     async fn eigenlayer_client(&self) -> Result<EigenlayerClient, Error> {
         Ok(EigenlayerClient::new(self.clone()))

--- a/crates/contexts/src/instrumented_evm_client.rs
+++ b/crates/contexts/src/instrumented_evm_client.rs
@@ -1,7 +1,6 @@
 pub use gadget_clients::evm::instrumented_client::InstrumentedClient;
 
 /// `EvmInstrumentedClientContext` trait provides access to the EVM provider from the context.
-#[async_trait::async_trait]
 pub trait EvmInstrumentedClientContext {
     async fn evm_client(&self) -> InstrumentedClient;
 }

--- a/crates/contexts/src/services.rs
+++ b/crates/contexts/src/services.rs
@@ -1,7 +1,6 @@
 pub use gadget_clients::tangle::services::TangleServicesClient;
 
 /// `ServicesContext` trait provides access to the Services client from the context.
-#[async_trait::async_trait]
 pub trait ServicesContext {
     /// Returns the Services client instance
     async fn services_client(

--- a/crates/contexts/src/tangle.rs
+++ b/crates/contexts/src/tangle.rs
@@ -3,13 +3,11 @@ pub use gadget_clients::Error;
 pub use gadget_clients::tangle::client::TangleClient;
 
 /// `TangleContext` trait provides access to the Tangle client from the context.
-#[async_trait::async_trait]
 pub trait TangleClientContext {
     /// Returns the Tangle client instance
     async fn tangle_client(&self) -> Result<TangleClient, Error>;
 }
 
-#[async_trait::async_trait]
 impl TangleClientContext for BlueprintEnvironment {
     async fn tangle_client(&self) -> Result<TangleClient, Error> {
         TangleClient::new(self.clone()).await.map_err(Into::into)

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -15,7 +15,6 @@ workspace = true
 # Core dependencies (always included)
 gadget-crypto.workspace = true
 gadget-std.workspace = true
-async-trait.workspace = true
 lock_api.workspace = true
 parking_lot.workspace = true
 thiserror.workspace = true

--- a/crates/keystore/src/keystore/backends/bn254.rs
+++ b/crates/keystore/src/keystore/backends/bn254.rs
@@ -6,7 +6,6 @@ use gadget_crypto::bn254::{
 use gadget_crypto::{BytesEncoding, KeyType, KeyTypeId};
 use gadget_std::boxed::Box;
 
-#[async_trait::async_trait]
 pub trait Bn254Backend: Send + Sync {
     /// Generate a new BN254 key pair from seed
     ///

--- a/crates/keystore/src/keystore/backends/eigenlayer.rs
+++ b/crates/keystore/src/keystore/backends/eigenlayer.rs
@@ -5,7 +5,6 @@ use gadget_crypto::k256::{K256Signature, K256SigningKey, K256VerifyingKey};
 use gadget_crypto::{BytesEncoding, KeyType, KeyTypeId};
 use gadget_std::boxed::Box;
 
-#[async_trait::async_trait]
 pub trait EigenlayerBackend: Bn254Backend {
     /// Generate a new ECDSA key pair from seed
     ///
@@ -40,7 +39,6 @@ pub trait EigenlayerBackend: Bn254Backend {
     fn iter_ecdsa(&self) -> Box<dyn Iterator<Item = K256VerifyingKey> + '_>;
 }
 
-#[async_trait::async_trait]
 impl EigenlayerBackend for Keystore {
     fn ecdsa_generate_new(&self, seed: Option<&[u8]>) -> Result<K256VerifyingKey> {
         let secret =

--- a/crates/keystore/src/keystore/backends/evm.rs
+++ b/crates/keystore/src/keystore/backends/evm.rs
@@ -9,7 +9,6 @@ use gadget_crypto::{BytesEncoding, KeyType};
 use gadget_std::string::ToString;
 use serde::de::DeserializeOwned;
 
-#[async_trait::async_trait]
 pub trait EvmBackend: Send + Sync {
     /// Create an EVM wallet from a private key
     ///

--- a/crates/keystore/src/keystore/backends/remote.rs
+++ b/crates/keystore/src/keystore/backends/remote.rs
@@ -36,7 +36,6 @@ impl RemoteEntry {
     }
 }
 
-#[async_trait::async_trait]
 pub trait RemoteBackend: Backend {
     /// Sign a message using a remote signer
     async fn sign_with_remote<T, R>(
@@ -62,7 +61,6 @@ pub trait RemoteBackend: Backend {
         R::KeyId: Send;
 }
 
-#[async_trait::async_trait]
 impl RemoteBackend for Keystore {
     /// Sign a message using a remote signer
     async fn sign_with_remote<T, R>(

--- a/crates/keystore/src/keystore/backends/tangle.rs
+++ b/crates/keystore/src/keystore/backends/tangle.rs
@@ -9,7 +9,6 @@ use gadget_crypto::{BytesEncoding, KeyTypeId};
 use sp_core::Pair;
 use sp_core::{ecdsa, ed25519, sr25519};
 
-#[async_trait::async_trait]
 pub trait TangleBackend: Send + Sync {
     // String-based Key Generation
     /// Generate an ECDSA key pair from a string seed
@@ -178,7 +177,6 @@ pub mod bls {
     use gadget_crypto::{BytesEncoding, KeyTypeId};
     use sp_core::Pair;
 
-    #[async_trait::async_trait]
     pub trait TangleBlsBackend: TangleBackend {
         // BLS Key Generation Methods
         /// Generate a BLS377 key pair from a string seed

--- a/crates/keystore/src/remote/aws.rs
+++ b/crates/keystore/src/remote/aws.rs
@@ -72,7 +72,6 @@ impl AwsRemoteSigner {
     }
 }
 
-#[async_trait::async_trait]
 impl EcdsaRemoteSigner<K256Ecdsa> for AwsRemoteSigner {
     type Public = K256VerifyingKey;
     type Signature = K256Signature;

--- a/crates/keystore/src/remote/gcp.rs
+++ b/crates/keystore/src/remote/gcp.rs
@@ -86,7 +86,6 @@ impl GcpRemoteSigner {
     }
 }
 
-#[async_trait::async_trait]
 impl EcdsaRemoteSigner<K256Ecdsa> for GcpRemoteSigner {
     type Public = K256VerifyingKey;
     type Signature = K256Signature;

--- a/crates/keystore/src/remote/ledger.rs
+++ b/crates/keystore/src/remote/ledger.rs
@@ -142,7 +142,6 @@ impl From<K256VerifyingKey> for AddressWrapper {
     }
 }
 
-#[async_trait::async_trait]
 impl EcdsaRemoteSigner<K256Ecdsa> for LedgerRemoteSigner {
     type Public = AddressWrapper;
     type Signature = PrimitiveSignature;

--- a/crates/keystore/src/remote/mod.rs
+++ b/crates/keystore/src/remote/mod.rs
@@ -8,7 +8,6 @@ pub mod gcp;
 pub mod ledger;
 
 use crate::error::Result;
-use async_trait::async_trait;
 use gadget_crypto::KeyType;
 use gadget_std::future::Future;
 use serde::{de::DeserializeOwned, Serialize};
@@ -55,7 +54,6 @@ pub trait RemoteSigner<T: KeyType>: RemoteBackend {
 }
 
 // Keep existing EcdsaRemoteSigner for ECDSA-specific remote signing
-#[async_trait::async_trait]
 pub trait EcdsaRemoteSigner<T: KeyType>: Send + Sync {
     type Public: Clone
         + Ord
@@ -91,7 +89,6 @@ pub trait EcdsaRemoteSigner<T: KeyType>: Send + Sync {
 }
 
 // Generic remote operations trait for extensibility
-#[async_trait]
 pub trait RemoteOperations: Send + Sync {
     /// Get the type of remote system
     fn backend_type(&self) -> &'static str;

--- a/crates/macros/context-derive/Cargo.toml
+++ b/crates/macros/context-derive/Cargo.toml
@@ -31,7 +31,6 @@ blueprint-sdk = { workspace = true, features = [
     "local-store",
 ] }
 
-async-trait.workspace = true
 trybuild = { workspace = true }
 
 # EVM Stuff

--- a/crates/macros/context-derive/src/eigenlayer.rs
+++ b/crates/macros/context-derive/src/eigenlayer.rs
@@ -23,7 +23,6 @@ pub fn generate_context_impl(
     let config_ty = quote! { ::blueprint_sdk::contexts::eigenlayer::EigenlayerClient };
 
     quote! {
-        #[::blueprint_sdk::async_trait::async_trait]
         impl #impl_generics ::blueprint_sdk::contexts::eigenlayer::EigenlayerContext for #name #ty_generics #where_clause {
             async fn eigenlayer_client(&self) -> std::result::Result<#config_ty, ::blueprint_sdk::clients::Error> {
                 static CLIENT: std::sync::OnceLock<#config_ty> = std::sync::OnceLock::new();

--- a/crates/macros/context-derive/src/evm.rs
+++ b/crates/macros/context-derive/src/evm.rs
@@ -35,7 +35,6 @@ pub fn generate_context_impl(
         >;
 
         #[automatically_derived]
-        #[::blueprint_sdk::async_trait::async_trait]
         impl #impl_generics ::blueprint_sdk::contexts::instrumented_evm_client::EvmInstrumentedClientContext for #name #ty_generics #where_clause {
             async fn evm_client(&self) -> ::blueprint_sdk::contexts::instrumented_evm_client::InstrumentedClient {
                 ::blueprint_sdk::contexts::instrumented_evm_client::InstrumentedClient::new(

--- a/crates/macros/context-derive/src/tangle/client.rs
+++ b/crates/macros/context-derive/src/tangle/client.rs
@@ -22,7 +22,6 @@ pub fn generate_context_impl(
     let config_ty = quote! { ::blueprint_sdk::contexts::tangle::TangleClient };
 
     quote! {
-        #[::blueprint_sdk::async_trait::async_trait]
         impl #impl_generics ::blueprint_sdk::contexts::tangle::TangleClientContext for #name #ty_generics #where_clause {
             async fn tangle_client(&self) -> std::result::Result<#config_ty, ::blueprint_sdk::clients::Error> {
                 ::blueprint_sdk::contexts::tangle::TangleClientContext::tangle_client(&#field_access_config).await

--- a/crates/macros/context-derive/src/tangle/services.rs
+++ b/crates/macros/context-derive/src/tangle/services.rs
@@ -24,7 +24,6 @@ pub fn generate_context_impl(
     };
 
     quote! {
-        #[::blueprint_sdk::async_trait::async_trait]
         impl #impl_generics ::blueprint_sdk::contexts::services::ServicesContext for #name #ty_generics #where_clause {
             async fn services_client(&self) -> #config_ty {
                 let rpc_client = ::blueprint_sdk::tangle_subxt::subxt::OnlineClient::from_url(

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -41,7 +41,7 @@ tracing-subscriber = { workspace = true, features = ["env-filter", "ansi", "trac
 libp2p = { workspace = true }
 auto_impl = { workspace = true }
 parking_lot = { workspace = true }
-async-trait = { workspace = true }
+dynosaur = { workspace = true }
 sp-core = { workspace = true }
 
 [package.metadata.dist]

--- a/crates/manager/src/executor/event_handler.rs
+++ b/crates/manager/src/executor/event_handler.rs
@@ -6,7 +6,7 @@ use crate::sdk::utils::{
     bounded_string_to_string, generate_running_process_status_handle, make_executable,
 };
 use crate::sources::github::GithubBinaryFetcher;
-use crate::sources::{process_arguments_and_env, BinarySourceFetcher};
+use crate::sources::{process_arguments_and_env, BinarySourceFetcher, DynBinarySourceFetcher};
 use gadget_clients::tangle::client::{TangleConfig, TangleEvent};
 use gadget_clients::tangle::services::{RpcServicesWithBlueprint, TangleServicesClient};
 use blueprint_sdk::runner::config::Protocol;
@@ -25,7 +25,7 @@ use tangle_subxt::tangle_testnet_runtime::api::services::events::{
 const DEFAULT_PROTOCOL: Protocol = Protocol::Tangle;
 
 pub struct VerifiedBlueprint<'a> {
-    pub(crate) fetcher: Box<dyn BinarySourceFetcher + 'a>,
+    pub(crate) fetcher: Box<DynBinarySourceFetcher<'a>>,
     pub(crate) blueprint: FilteredBlueprint,
 }
 
@@ -372,9 +372,9 @@ pub(crate) async fn handle_tangle_event(
 fn get_fetcher_candidates(
     blueprint: &FilteredBlueprint,
     manager_opts: &BlueprintManagerConfig,
-) -> Result<Vec<Box<dyn BinarySourceFetcher>>> {
+) -> Result<Vec<Box<DynBinarySourceFetcher<'static>>>> {
     let mut test_fetcher_idx = None;
-    let mut fetcher_candidates: Vec<Box<dyn BinarySourceFetcher>> = vec![];
+    let mut fetcher_candidates: Vec<Box<DynBinarySourceFetcher<'static>>> = vec![];
 
     let sources;
     match &blueprint.gadget {
@@ -400,7 +400,7 @@ fn get_fetcher_candidates(
                     gadget_name: blueprint.name.clone(),
                 };
 
-                fetcher_candidates.push(Box::new(fetcher));
+                fetcher_candidates.push(DynBinarySourceFetcher::boxed(fetcher));
             }
 
             GadgetSourceFetcher::Testing(test) => {
@@ -417,7 +417,7 @@ fn get_fetcher_candidates(
                 };
 
                 test_fetcher_idx = Some(source_idx);
-                fetcher_candidates.push(Box::new(fetcher));
+                fetcher_candidates.push(DynBinarySourceFetcher::boxed(fetcher));
             }
 
             _ => {

--- a/crates/manager/src/executor/mod.rs
+++ b/crates/manager/src/executor/mod.rs
@@ -276,19 +276,25 @@ pub async fn run_blueprint_manager<F: SendFuture<'static, ()>>(
     };
 
     drop(_span);
-    let handle = tokio::spawn(combined_task);
-
-    let handle = BlueprintManagerHandle {
-        start_tx: Some(start_tx),
-        shutdown_call: Some(tx_stop),
-        running_task: handle,
-        span,
-        sr25519_id: tangle_key,
-        ecdsa_id: ecdsa_key,
-        keystore_uri,
-    };
-
-    Ok(handle)
+    let _ = keystore_uri;
+    let _ = tx_stop;
+    let _ = start_tx;
+    drop(combined_task);
+    let _ = ecdsa_key;
+    todo!("start blueprint manager");
+    // let handle = tokio::spawn(combined_task);
+    //
+    // let handle = BlueprintManagerHandle {
+    //     start_tx: Some(start_tx),
+    //     shutdown_call: Some(tx_stop),
+    //     running_task: handle,
+    //     span,
+    //     sr25519_id: tangle_key,
+    //     ecdsa_id: ecdsa_key,
+    //     keystore_uri,
+    // };
+    //
+    // Ok(handle)
 }
 
 /// * Query to get Vec<RpcServicesWithBlueprint>

--- a/crates/manager/src/sources/github.rs
+++ b/crates/manager/src/sources/github.rs
@@ -3,7 +3,6 @@ use crate::gadget::native::get_gadget_binary;
 use crate::sdk;
 use crate::sdk::utils::{get_download_url, hash_bytes_to_hex, valid_file_exists};
 use crate::sources::BinarySourceFetcher;
-use async_trait::async_trait;
 use gadget_logging::info;
 use std::path::PathBuf;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::gadget::GithubFetcher;
@@ -15,7 +14,6 @@ pub struct GithubBinaryFetcher {
     pub gadget_name: String,
 }
 
-#[async_trait]
 impl BinarySourceFetcher for GithubBinaryFetcher {
     async fn get_binary(&self) -> Result<PathBuf> {
         let relevant_binary =

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -1,20 +1,22 @@
 use crate::config::BlueprintManagerConfig;
 use crate::error::Result;
 use crate::gadget::native::FilteredBlueprint;
-use async_trait::async_trait;
 use blueprint_sdk::runner::config::BlueprintEnvironment;
 use std::path::PathBuf;
 
 pub mod github;
 pub mod testing;
 
-#[async_trait]
 #[auto_impl::auto_impl(Box)]
+#[dynosaur::dynosaur(pub(crate) DynBinarySourceFetcher)]
 pub trait BinarySourceFetcher: Send + Sync {
-    async fn get_binary(&self) -> Result<PathBuf>;
+    fn get_binary(&self) -> impl Future<Output = Result<PathBuf>> + Send;
     fn blueprint_id(&self) -> u64;
     fn name(&self) -> String;
 }
+
+unsafe impl Send for DynBinarySourceFetcher<'_> {}
+unsafe impl Sync for DynBinarySourceFetcher<'_> {}
 
 #[must_use]
 pub fn process_arguments_and_env(

--- a/crates/manager/src/sources/testing.rs
+++ b/crates/manager/src/sources/testing.rs
@@ -1,6 +1,5 @@
 use crate::error::{Error, Result};
 use crate::sources::BinarySourceFetcher;
-use async_trait::async_trait;
 use gadget_logging::trace;
 use std::path::PathBuf;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::gadget::TestFetcher;
@@ -11,7 +10,6 @@ pub struct TestSourceFetcher {
     pub gadget_name: String,
 }
 
-#[async_trait]
 impl BinarySourceFetcher for TestSourceFetcher {
     async fn get_binary(&self) -> Result<PathBuf> {
         // Step 1: Build the binary. It will be stored in the root directory/bin/

--- a/crates/networking/Cargo.toml
+++ b/crates/networking/Cargo.toml
@@ -27,7 +27,6 @@ tokio-stream = { workspace = true, features = ["time"] }
 futures = { workspace = true }
 tracing = { workspace = true }
 bincode = { workspace = true }
-async-trait = { workspace = true }
 lru-mem = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -25,7 +25,6 @@ gadget-std = { workspace = true }
 # The keystore context is the only one that doesn't bring in extra dependencies, so we can always include it
 gadget-contexts = { workspace = true, features = ["keystore"] }
 document-features = { workspace = true }
-async-trait = { workspace = true }
 
 # Macros
 blueprint-macros = { workspace = true, optional = true }

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -22,8 +22,6 @@ pub use gadget_logging as logging;
 pub use gadget_clients as clients;
 pub use gadget_contexts as contexts;
 
-// TODO(serial): remove
-pub use async_trait;
 pub use gadget_keystore as keystore;
 pub use gadget_std as std;
 pub use serde;

--- a/crates/std/Cargo.toml
+++ b/crates/std/Cargo.toml
@@ -12,7 +12,6 @@ repository.workspace = true
 workspace = true
 
 [dependencies]
-async-trait = { workspace = true, optional = true }
 rand = { workspace = true, features = ["std_rng"] }
 rayon = { workspace = true, optional = true }
 num-traits.workspace = true
@@ -27,7 +26,7 @@ tokio = { workspace = true, features = ["sync", "time", "macros", "rt"] }
 [features]
 default = ["std"]
 std = ["thiserror/std", "getrandom"]
-tokio = ["dep:async-trait", "dep:tokio"]
+tokio = ["dep:tokio"]
 parallel = ["dep:rayon", "std"]
 print-trace = ["std"]
 getrandom = ["rand/std"]

--- a/crates/testing-utils/core/Cargo.toml
+++ b/crates/testing-utils/core/Cargo.toml
@@ -24,7 +24,6 @@ thiserror = { workspace = true }
 url = { workspace = true }
 tokio = { workspace = true, features = ["full"] }
 futures = { workspace = true }
-async-trait = { workspace = true }
 tempfile = { workspace = true }
 tracing = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }

--- a/crates/testing-utils/core/src/harness.rs
+++ b/crates/testing-utils/core/src/harness.rs
@@ -2,7 +2,6 @@ use blueprint_runner::config::BlueprintEnvironment;
 use tempfile::TempDir;
 
 /// Generic test harness trait that defines common functionality for all test harnesses
-#[async_trait::async_trait]
 pub trait TestHarness {
     /// The configuration type used by this harness
     type Config;

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -22,7 +22,6 @@ gadget-anvil-testing-utils = { workspace = true }
 gadget-core-testing-utils = { workspace = true }
 gadget-logging = { workspace = true }
 tempfile = { workspace = true }
-async-trait = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }
 alloy-rpc-types = { workspace = true }

--- a/crates/testing-utils/eigenlayer/src/harness.rs
+++ b/crates/testing-utils/eigenlayer/src/harness.rs
@@ -31,7 +31,6 @@ pub struct EigenlayerTestHarness<Ctx> {
     _phantom: core::marker::PhantomData<Ctx>,
 }
 
-#[async_trait::async_trait]
 impl<Ctx> TestHarness for EigenlayerTestHarness<Ctx>
 where
     Ctx: Clone + Send + Sync + 'static,

--- a/crates/testing-utils/tangle/Cargo.toml
+++ b/crates/testing-utils/tangle/Cargo.toml
@@ -37,7 +37,6 @@ alloy-primitives = { workspace = true }
 sp-core = { workspace = true }
 tangle-subxt = { workspace = true }
 
-async-trait = { workspace = true }
 futures = { workspace = true }
 tracing = { workspace = true }
 tempfile = { workspace = true }

--- a/crates/testing-utils/tangle/src/harness.rs
+++ b/crates/testing-utils/tangle/src/harness.rs
@@ -96,7 +96,6 @@ pub(crate) async fn generate_env_from_node_id(
     Ok(env)
 }
 
-#[async_trait::async_trait]
 impl<Ctx> TestHarness for TangleTestHarness<Ctx>
 where
     Ctx: Clone + Send + Sync + 'static,

--- a/examples/incredible-squaring/Cargo.lock
+++ b/examples/incredible-squaring/Cargo.lock
@@ -2480,7 +2480,6 @@ dependencies = [
 name = "blueprint-sdk"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "blueprint-build-utils",
  "blueprint-core",
  "blueprint-evm-extra",
@@ -6197,7 +6196,6 @@ dependencies = [
 name = "gadget-client-core"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "auto_impl",
  "gadget-std",
  "thiserror 2.0.11",
@@ -6241,7 +6239,6 @@ dependencies = [
  "alloy-rpc-types-eth",
  "alloy-transport",
  "alloy-transport-http",
- "async-trait",
  "gadget-client-core",
  "gadget-logging",
  "gadget-rpc-calls",
@@ -6258,7 +6255,6 @@ dependencies = [
 name = "gadget-client-tangle"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "auto_impl",
  "blueprint-runner",
  "gadget-client-core",
@@ -6299,7 +6295,6 @@ dependencies = [
 name = "gadget-contexts"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "blueprint-runner",
  "gadget-clients",
  "gadget-keystore",
@@ -6312,7 +6307,6 @@ dependencies = [
 name = "gadget-core-testing-utils"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "blueprint-core",
  "blueprint-router",
  "blueprint-runner",
@@ -6483,7 +6477,6 @@ dependencies = [
  "ark-ec 0.5.0",
  "ark-ff 0.5.0",
  "ark-serialize 0.5.0",
- "async-trait",
  "blake3",
  "ed25519-zebra",
  "gadget-crypto",
@@ -6522,7 +6515,6 @@ version = "0.1.0"
 dependencies = [
  "alloy-primitives 0.8.21",
  "anyhow",
- "async-trait",
  "auto_impl",
  "bincode",
  "blake3",
@@ -6560,7 +6552,6 @@ dependencies = [
 name = "gadget-std"
 version = "0.1.0"
 dependencies = [
- "async-trait",
  "colored",
  "num-traits",
  "rand 0.8.5",
@@ -6579,7 +6570,6 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types 0.8.21",
  "alloy-transport",
- "async-trait",
  "blueprint-core",
  "blueprint-runner",
  "blueprint-tangle-extra",


### PR DESCRIPTION
# Overview

We now either use native async traits, or in the case we need trait objects, use `dynosaur`.