### PR TITLE
chore: enable `networking` for the blueprint-runner from the SDK.

### DIFF
--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -108,7 +108,7 @@ networking = [
     "gadget-contexts/networking",
     "gadget-keystore/std",
     "gadget-context-derive?/networking",
-    "blueprint-runner?/networking"
+    "blueprint-runner/networking"
 ]
 
 ## Enable local KV stores

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -108,6 +108,7 @@ networking = [
     "gadget-contexts/networking",
     "gadget-keystore/std",
     "gadget-context-derive?/networking",
+    "blueprint-runner?/networking"
 ]
 
 ## Enable local KV stores


### PR DESCRIPTION
This pull request includes a small change to the `crates/sdk/Cargo.toml` file. The change adds the `blueprint-runner?/networking` feature to the list of networking dependencies.

* [`crates/sdk/Cargo.toml`](diffhunk://#diff-f43d2be11323bdce102d0733ead2bfde8104dd6f2fc3b4329c8a7eccda26c73bR111): Added `blueprint-runner?/networking` to the `networking` list.