### PR TITLE
feat: impl `IntoTangleFieldTypes` for `TangleResult` in `Result` and `Option`

### DIFF
--- a/crates/macros/tests/debug_job/fail/argument_not_extractor.stderr
+++ b/crates/macros/tests/debug_job/fail/argument_not_extractor.stderr
@@ -1,4 +1,4 @@
-error[E0277]: the trait bound `bool: FromJobCall<(), blueprint_core::extract::private::ViaParts>` is not satisfied
+error[E0277]: the trait bound `bool: FromJobCall<(), blueprint_sdk::blueprint_core::extract::private::ViaParts>` is not satisfied
  --> tests/debug_job/fail/argument_not_extractor.rs:4:20
   |
 4 | async fn job(_foo: bool) {}
@@ -16,7 +16,7 @@ error[E0277]: the trait bound `bool: FromJobCall<(), blueprint_core::extract::pr
             `(T1, T2, T3, T4, T5, T6, T7)` implements `FromJobCallParts<Ctx>`
             `(T1, T2, T3, T4, T5, T6, T7, T8)` implements `FromJobCallParts<Ctx>`
           and $N others
-  = note: required for `bool` to implement `FromJobCall<(), blueprint_core::extract::private::ViaParts>`
+  = note: required for `bool` to implement `FromJobCall<(), blueprint_sdk::blueprint_core::extract::private::ViaParts>`
 note: required by a bound in `__blueprint_macros_check_job_0_from_job_check`
  --> tests/debug_job/fail/argument_not_extractor.rs:4:20
   |

--- a/crates/tangle-extra/src/extract/result.rs
+++ b/crates/tangle-extra/src/extract/result.rs
@@ -88,6 +88,32 @@ macro_rules! impl_tangle_field_types {
                 ]
             }
         }
+
+       impl<$($ty,)* E> crate::metadata::IntoTangleFieldTypes for Result<$name<$($ty,)*>, E>
+        where
+            $($ty: Default + serde::Serialize,)*
+        {
+            fn into_tangle_fields() -> Vec<FieldType> {
+                vec![
+                    $(
+                        gadget_blueprint_serde::to_field(<$ty as core::default::Default>::default()).expect("type should serialize").field_type()
+                    ),*
+                ]
+            }
+        }
+
+       impl<$($ty,)*> crate::metadata::IntoTangleFieldTypes for Option<$name<$($ty,)*>>
+        where
+            $($ty: Default + serde::Serialize,)*
+        {
+            fn into_tangle_fields() -> Vec<FieldType> {
+                vec![
+                    $(
+                        gadget_blueprint_serde::to_field(<$ty as core::default::Default>::default()).expect("type should serialize").field_type()
+                    ),*
+                ]
+            }
+        }
     }
 }
 

--- a/crates/tangle-extra/src/metadata/job_definition.rs
+++ b/crates/tangle-extra/src/metadata/job_definition.rs
@@ -205,6 +205,14 @@ mod tests {
                         todo!()
                     }
 
+
+                    #[allow(unused_variables)]
+                    #[allow(clippy::type_complexity)]
+                    async fn [<$func _with_context_ret_opt>](Context(ctx): Context<MyContext>, $args_ty($($args),*): $ty) -> Option<TangleResult<u64>> {
+                        eprintln!("ctx: {:?}", ctx.foo);
+                        todo!()
+                    }
+
                     #[test]
                     fn [<$func _test>]() {
                         let def = $func.into_job_definition();
@@ -237,6 +245,17 @@ mod tests {
                         assert_eq!(def3.result.0.len(), 1);
                         assert!(def3.params.0.iter().all(|ty| ty.clone() == FieldType::Uint64));
                         assert_eq!(def3.result.0[0], FieldType::Uint64);
+
+                        let def4 = [<$func _with_context_ret_opt>].into_job_definition();
+                        assert_eq!(
+                            def4.metadata.name.0.0,
+                            format!("blueprint_tangle_extra::metadata::job_definition::tests::{}", stringify!([<$func _with_context_ret_opt>])).as_bytes(),
+                        );
+                        assert_eq!(def4.params.0.len(), count!($($args),*));
+                        assert_eq!(def4.result.0.len(), 1);
+                        assert!(def4.params.0.iter().all(|ty| ty.clone() == FieldType::Uint64));
+                        assert_eq!(def4.result.0[0], FieldType::Uint64);
+
                     }
                 }
             )*

--- a/crates/tangle-extra/src/metadata/job_definition.rs
+++ b/crates/tangle-extra/src/metadata/job_definition.rs
@@ -171,6 +171,17 @@ mod tests {
         foo: u64,
     }
 
+    #[derive(Debug)]
+    struct MyError;
+
+    impl std::fmt::Display for MyError {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "MyError")
+        }
+    }
+
+    impl std::error::Error for MyError {}
+
     macro_rules! definition_tests {
         ($($func:ident($args_ty:ident($($args:ident),*): $ty:ty));* $(;)?) => {
             $(
@@ -183,6 +194,13 @@ mod tests {
                     #[allow(unused_variables)]
                     #[allow(clippy::type_complexity)]
                     async fn [<$func _with_context>](Context(ctx): Context<MyContext>, $args_ty($($args),*): $ty) -> TangleResult<u64> {
+                        eprintln!("ctx: {:?}", ctx.foo);
+                        todo!()
+                    }
+
+                    #[allow(unused_variables)]
+                    #[allow(clippy::type_complexity)]
+                    async fn [<$func _with_context_ret_res>](Context(ctx): Context<MyContext>, $args_ty($($args),*): $ty) -> Result<TangleResult<u64>, MyError> {
                         eprintln!("ctx: {:?}", ctx.foo);
                         todo!()
                     }
@@ -208,6 +226,17 @@ mod tests {
                         assert_eq!(def2.result.0.len(), 1);
                         assert!(def2.params.0.iter().all(|ty| ty.clone() == FieldType::Uint64));
                         assert_eq!(def2.result.0[0], FieldType::Uint64);
+
+
+                        let def3 = [<$func _with_context_ret_res>].into_job_definition();
+                        assert_eq!(
+                            def3.metadata.name.0.0,
+                            format!("blueprint_tangle_extra::metadata::job_definition::tests::{}", stringify!([<$func _with_context_ret_res>])).as_bytes(),
+                        );
+                        assert_eq!(def3.params.0.len(), count!($($args),*));
+                        assert_eq!(def3.result.0.len(), 1);
+                        assert!(def3.params.0.iter().all(|ty| ty.clone() == FieldType::Uint64));
+                        assert_eq!(def3.result.0[0], FieldType::Uint64);
                     }
                 }
             )*


### PR DESCRIPTION
This pull request includes several changes to the `tangle-extra` crate, focusing on adding new implementations for `IntoTangleFieldTypes` and expanding test coverage. The most important changes include adding implementations for `Result` and `Option` types, and adding new test cases for context-aware functions.

### New Implementations:

* Added implementations for `IntoTangleFieldTypes` for `Result` and `Option` types in `macro_rules! impl_tangle_field_types` in `crates/tangle-extra/src/extract/result.rs`.

### Test Enhancements:

* Added new context-aware test functions `[<$func _with_context_ret_res>]` and `[<$func _with_context_ret_opt>]` to `mod tests` in `crates/tangle-extra/src/metadata/job_definition.rs`.
* Included additional assertions for the new context-aware test functions in `mod tests` in `crates/tangle-extra/src/metadata/job_definition.rs`.

Closes #728 