### PR TITLE
feat: log build output

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3436,7 +3436,6 @@ dependencies = [
  "dialoguer",
  "dotenv",
  "eigensdk",
- "escargot",
  "gadget-clients",
  "gadget-crypto",
  "gadget-crypto-core",
@@ -5761,18 +5760,6 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "escargot"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a3ac187a16b5382fef8c69fd1bad123c67b7cf3932240a2d43dcdd32cded88"
-dependencies = [
- "log",
- "once_cell",
- "serde",
- "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -200,7 +200,6 @@ chrono = { version = "0.4.40", default-features = false }
 # Development & Testing
 auto_impl = { version = "1.2.1", default-features = false }
 cargo_toml = { version = "0.21.0", default-features = false }
-escargot = { version = "0.5.12", default-features = false }
 itertools = { version = "0.14.0", default-features = false }
 paste = { version = "1.0.15", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -18,7 +18,6 @@ clap = { workspace = true, features = ["derive", "wrap_help"] }
 clap-cargo = { workspace = true, features = ["clap"] }
 cargo-generate = { workspace = true, features = ["vendored-libgit2"] }
 cargo_metadata = { workspace = true }
-escargot = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "ansi"] }
 color-eyre = { workspace = true }
 serde = { workspace = true, features = ["derive"] }

--- a/cli/src/deploy/tangle.rs
+++ b/cli/src/deploy/tangle.rs
@@ -1,9 +1,12 @@
-use std::env;
+use std::{env, thread};
+use std::io::{BufRead, BufReader};
+use std::path::Path;
+use std::process::{Command, Stdio};
 use alloy_provider::network::TransactionBuilder;
 use alloy_provider::{Provider, WsConnect};
 use alloy_rpc_types_eth::TransactionRequest;
 use alloy_signer_local::PrivateKeySigner;
-use color_eyre::eyre::{self, Context, ContextCompat, Result};
+use color_eyre::eyre::{self, eyre, Context, ContextCompat, Result};
 use blueprint_tangle_extra::metadata::types::blueprint::BlueprintServiceManager;
 use gadget_crypto::tangle_pair_signer::TanglePairSigner;
 use gadget_std::fmt::Debug;
@@ -168,6 +171,51 @@ fn workspace_or_package_manifest_path(package: &cargo_metadata::Package) -> Path
     )
 }
 
+fn do_cargo_build(manifest_path: &Path) -> Result<()> {
+    let mut cmd = Command::new("cargo");
+    cmd.arg("build")
+        .arg("--manifest-path")
+        .arg(&manifest_path)
+        .arg("--all")
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+
+    let mut child = cmd.spawn().expect("Failed to start cargo build");
+    let stdout = child.stdout.take().expect("Failed to capture stdout");
+    let stderr = child.stderr.take().expect("Failed to capture stderr");
+
+    let stdout_thread = thread::spawn(move || {
+        let reader = BufReader::new(stdout);
+        for line in reader.lines() {
+            if let Ok(line) = line {
+                tracing::debug!(target: "build-output", "{}", line);
+            }
+        }
+    });
+
+    let stderr_thread = thread::spawn(move || {
+        let reader = BufReader::new(stderr);
+        for line in reader.lines() {
+            if let Ok(line) = line {
+                tracing::debug!(target: "build-output", "{}", line);
+            }
+        }
+    });
+
+    let status = child.wait().expect("Failed to wait on cargo build");
+
+    stdout_thread.join().expect("Stdout thread panicked");
+    stderr_thread.join().expect("Stderr thread panicked");
+
+    if !status.success() {
+        tracing::error!("Cargo build failed");
+        tracing::error!("NOTE: Use `RUST_LOG=build-output=debug` to see more details");
+        return Err(eyre!("Cargo build failed"));
+    }
+
+    Ok(())
+}
+
 fn load_blueprint_metadata(
     package: &cargo_metadata::Package,
 ) -> Result<blueprint_tangle_extra::metadata::types::blueprint::ServiceBlueprint<'static>> {
@@ -178,11 +226,9 @@ fn load_blueprint_metadata(
         tracing::warn!("Could not find blueprint.json; running `cargo build`...");
         // Need to run cargo build. We don't know the package name, so unfortunately this will
         // build the entire workspace.
-        escargot::CargoBuild::new()
-            .manifest_path(manifest_dir.join("Cargo.toml"))
-            .run()
-            .context("Failed to build the package")?;
+        do_cargo_build(&manifest_dir.join("Cargo.toml"))?;
     }
+
     // should have the blueprint.json
     let blueprint_json =
         std::fs::read_to_string(blueprint_json_path).context("Reading blueprint.json file")?;

--- a/cli/src/deploy/tangle.rs
+++ b/cli/src/deploy/tangle.rs
@@ -175,7 +175,7 @@ fn do_cargo_build(manifest_path: &Path) -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.arg("build")
         .arg("--manifest-path")
-        .arg(&manifest_path)
+        .arg(manifest_path)
         .arg("--all")
         .stdout(Stdio::piped())
         .stderr(Stdio::piped());
@@ -186,19 +186,15 @@ fn do_cargo_build(manifest_path: &Path) -> Result<()> {
 
     let stdout_thread = thread::spawn(move || {
         let reader = BufReader::new(stdout);
-        for line in reader.lines() {
-            if let Ok(line) = line {
-                tracing::debug!(target: "build-output", "{}", line);
-            }
+        for line in reader.lines().flatten() {
+            tracing::debug!(target: "build-output", "{}", line);
         }
     });
 
     let stderr_thread = thread::spawn(move || {
         let reader = BufReader::new(stderr);
-        for line in reader.lines() {
-            if let Ok(line) = line {
-                tracing::debug!(target: "build-output", "{}", line);
-            }
+        for line in reader.lines().flatten() {
+            tracing::debug!(target: "build-output", "{}", line);
         }
     });
 

--- a/examples/incredible-squaring/Cargo.lock
+++ b/examples/incredible-squaring/Cargo.lock
@@ -3096,7 +3096,6 @@ dependencies = [
  "color-eyre",
  "dialoguer",
  "dotenv",
- "escargot",
  "gadget-clients",
  "gadget-crypto",
  "gadget-crypto-core",
@@ -5175,18 +5174,6 @@ checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "escargot"
-version = "0.5.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05a3ac187a16b5382fef8c69fd1bad123c67b7cf3932240a2d43dcdd32cded88"
-dependencies = [
- "log",
- "once_cell",
- "serde",
- "serde_json",
 ]
 
 [[package]]


### PR DESCRIPTION
# Overview

This actually fixes 2 issues:

1. We were calling `escargot::CargoBuild::run()`, which isn't correct for the new workspace layout of Tangle blueprints. That causes CI to fail.
2. When a build failed, you had no idea why. Just a generic "Failed to build the package" message.

I guess this just wasn't encountered since I always have a `blueprint.json` from building the binary myself.

The new output is:

```
ERROR cargo_tangle::deploy::tangle: Cargo build failed
ERROR cargo_tangle::deploy::tangle: NOTE: Use `RUST_LOG=build-output=debug` to see more details
Error: 
   0: Runner setup failed: Cargo build failed
```

Then with the suggestion:

```
DEBUG build-output:    Compiling hyperlane-validator-blueprint-bin v0.1.0 (hyperlane-validator-blueprint/hyperlane-validator-bin)
DEBUG build-output: error: expected `;`, found keyword `let`
DEBUG build-output:   --> hyperlane-validator-bin/src/main.rs:17:21
DEBUG build-output:    |
DEBUG build-output: 17 |     setup_log();junk
DEBUG build-output:    |                     ^ help: add `;` here
DEBUG build-output: 18 |
DEBUG build-output: 19 |     let env = BlueprintEnvironment::load()?;
DEBUG build-output:    |     --- unexpected token
DEBUG build-output: 
DEBUG build-output: error: could not compile `hyperlane-validator-blueprint-bin` (bin "hyperlane-validator-blueprint-bin") due to 1 previous error
Error: 
   0: Runner setup failed: Cargo build failed
```

also got rid of `escargot`. Not really useful here, can easily implement what we need ourselves.