### PR TITLE
feat(testing-utils): support per-node contexts

### DIFF
--- a/cli/src/deploy/tangle.rs
+++ b/cli/src/deploy/tangle.rs
@@ -186,14 +186,14 @@ fn do_cargo_build(manifest_path: &Path) -> Result<()> {
 
     let stdout_thread = thread::spawn(move || {
         let reader = BufReader::new(stdout);
-        for line in reader.lines().flatten() {
+        for line in reader.lines().map_while(Result::ok) {
             tracing::debug!(target: "build-output", "{}", line);
         }
     });
 
     let stderr_thread = thread::spawn(move || {
         let reader = BufReader::new(stderr);
-        for line in reader.lines().flatten() {
+        for line in reader.lines().map_while(Result::ok) {
             tracing::debug!(target: "build-output", "{}", line);
         }
     });

--- a/crates/tangle-extra/src/util/tests.rs
+++ b/crates/tangle-extra/src/util/tests.rs
@@ -7,7 +7,7 @@ use tangle_subxt::subxt::tx::Signer;
 async fn test_transaction_submission() -> color_eyre::Result<()> {
     // Setup test harness
     let test_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(test_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(test_dir).await?;
 
     // Test basic transaction submission
     let tx = tangle_subxt::tangle_testnet_runtime::api::tx()
@@ -33,7 +33,7 @@ async fn test_transaction_submission() -> color_eyre::Result<()> {
 async fn test_transaction_progress_tracking() -> color_eyre::Result<()> {
     // Setup test harness
     let test_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(test_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(test_dir).await?;
 
     // Submit transaction and track progress
     let tx = tangle_subxt::tangle_testnet_runtime::api::tx()

--- a/crates/testing-utils/eigenlayer/src/runner.rs
+++ b/crates/testing-utils/eigenlayer/src/runner.rs
@@ -23,12 +23,8 @@ where
     type Config = EigenlayerBLSConfig;
     type Context = Ctx;
 
-    fn new(
-        config: Self::Config,
-        env: BlueprintEnvironment,
-        context: Self::Context,
-    ) -> Result<Self, Error> {
-        let runner = TestRunner::new(config, env.clone(), context);
+    fn new(config: Self::Config, env: BlueprintEnvironment) -> Result<Self, Error> {
+        let runner = TestRunner::new(config, env.clone());
 
         Ok(Self {
             runner: Some(runner),
@@ -63,10 +59,10 @@ where
         self.env.clone()
     }
 
-    async fn run_runner(&mut self) -> Result<(), Error> {
+    async fn run_runner(&mut self, context: Self::Context) -> Result<(), Error> {
         // Spawn the runner in a background task
         let runner = self.runner.take().expect("Runner already running");
-        let handle = tokio::spawn(async move { runner.run().await });
+        let handle = tokio::spawn(async move { runner.run(context).await });
 
         let mut guard = self.runner_handle.lock().await;
         *guard = Some(handle);

--- a/crates/testing-utils/tangle/src/harness.rs
+++ b/crates/testing-utils/tangle/src/harness.rs
@@ -18,6 +18,7 @@ use gadget_crypto_tangle_pair_signer::TanglePairSigner;
 use gadget_keystore::backends::Backend;
 use gadget_keystore::crypto::sp_core::{SpEcdsa, SpSr25519};
 use std::io;
+use std::marker::PhantomData;
 use std::path::{Path, PathBuf};
 use tangle_subxt::tangle_testnet_runtime::api::services::events::JobCalled;
 use tangle_subxt::tangle_testnet_runtime::api::services::{
@@ -57,9 +58,9 @@ pub struct TangleTestHarness<Ctx = ()> {
     pub ecdsa_signer: TanglePairSigner<sp_core::ecdsa::Pair>,
     pub alloy_key: alloy_signer_local::PrivateKeySigner,
     config: TangleTestConfig,
-    context: Ctx,
     temp_dir: tempfile::TempDir,
     _node: crate::node::testnet::SubstrateNode,
+    _phantom: PhantomData<Ctx>,
 }
 
 pub(crate) async fn generate_env_from_node_id(
@@ -95,7 +96,10 @@ pub(crate) async fn generate_env_from_node_id(
     Ok(env)
 }
 
-impl TangleTestHarness<()> {
+impl<Ctx> TangleTestHarness<Ctx>
+where
+    Ctx: Clone + Send + Sync + 'static,
+{
     /// Create a new `TangleTestHarness`
     ///
     /// NOTE: The resulting harness will have a context of `()`. This is not valid for jobs that require
@@ -120,51 +124,9 @@ impl TangleTestHarness<()> {
     /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let tmp_dir = TempDir::new()?;
     /// let harness = TangleTestHarness::setup(tmp_dir).await?;
-    ///
-    /// assert_eq!(harness.context(), &());
     /// # Ok(()) }
     /// ```
     pub async fn setup(test_dir: TempDir) -> Result<Self, Error> {
-        Self::setup_with_context(test_dir, ()).await
-    }
-}
-
-impl<Ctx> TangleTestHarness<Ctx>
-where
-    Ctx: Clone + Send + Sync + 'static,
-{
-    /// Create a new `TangleTestHarness` with a predefined context
-    ///
-    /// NOTE: If your context type depends on [`Self::env()`], see [`Self::setup()`]
-    ///
-    /// # Errors
-    ///
-    /// * TODO
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use gadget_tangle_testing_utils::TangleTestHarness;
-    /// use tempfile::TempDir;
-    ///
-    /// #[derive(Clone)]
-    /// struct MyContext {
-    ///     foo: u64,
-    /// }
-    ///
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// // `MyContext` can be constructed beforehand, as it has no reliance on the environment
-    /// let context = MyContext { foo: 0 };
-    ///
-    /// let tmp_dir = TempDir::new()?;
-    /// let harness = TangleTestHarness::setup_with_context(tmp_dir, context).await?;
-    /// # Ok(()) }
-    /// ```
-    pub async fn setup_with_context(test_dir: TempDir, context: Ctx) -> Result<Self, Error>
-    where
-        Self: Sized,
-    {
         // Start Local Tangle Node
         let node = run(NodeConfig::new(false))
             .await
@@ -212,7 +174,7 @@ where
             temp_dir: test_dir,
             config,
             _node: node,
-            context,
+            _phantom: PhantomData,
         };
 
         // Deploy MBSM if needed
@@ -224,12 +186,9 @@ where
         Ok(harness)
     }
 
+    #[must_use]
     pub fn env(&self) -> &BlueprintEnvironment {
         &self.client.config
-    }
-
-    pub fn context(&self) -> &Ctx {
-        &self.context
     }
 }
 
@@ -281,65 +240,8 @@ where
         Ok(nodes)
     }
 
-    /// Add a context to the harness
-    ///
-    /// This **must** be called before [`Self::setup_services()`]
-    ///
-    /// See also: [`Self::setup_with_context()`]
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use blueprint_core::extract::Context;
-    /// use gadget_tangle_testing_utils::TangleTestHarness;
-    /// use tempfile::TempDir;
-    ///
-    /// #[derive(Clone)]
-    /// struct MyContext {
-    ///     foo: u64,
-    /// }
-    ///
-    /// // `some_job` relies on our `MyContext` type
-    /// async fn some_job(Context(_context): Context<MyContext>) {}
-    ///
-    /// # #[tokio::main]
-    /// # async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    /// let temp_dir = TempDir::new()?;
-    ///
-    /// // Harness currently has a context of `()`. This is not valid for `some_job()`.
-    /// let harness = TangleTestHarness::setup(temp_dir).await?;
-    ///
-    /// let context = MyContext { foo: 0 };
-    ///
-    /// // The harness now has a context of `MyContext`
-    /// let harness_with_context = harness.set_context(context);
-    ///
-    /// // Now add the job as normal
-    /// let (test_env, _service_id, _blueprint_id) =
-    ///     harness_with_context.setup_services::<1>(false).await?;
-    /// test_env.add_job(some_job).await;
-    /// # Ok(()) }
-    /// ```
-    #[allow(clippy::used_underscore_binding)]
-    pub fn set_context<Ctx2: Clone + Send + Sync + 'static>(
-        self,
-        context: Ctx2,
-    ) -> TangleTestHarness<Ctx2> {
-        TangleTestHarness {
-            http_endpoint: self.http_endpoint,
-            ws_endpoint: self.ws_endpoint,
-            client: self.client,
-            sr25519_signer: self.sr25519_signer,
-            ecdsa_signer: self.ecdsa_signer,
-            alloy_key: self.alloy_key,
-            config: self.config,
-            context,
-            temp_dir: self.temp_dir,
-            _node: self._node,
-        }
-    }
-
     /// Gets a reference to the Tangle client
+    #[must_use]
     pub fn client(&self) -> &TangleClient {
         &self.client
     }
@@ -471,7 +373,7 @@ where
         };
 
         // Create and initialize the new multi-node environment
-        let executor = MultiNodeTestEnv::new::<N>(self.config.clone(), self.context.clone());
+        let executor = MultiNodeTestEnv::new::<N>(self.config.clone());
 
         Ok((executor, service_id, blueprint_id))
     }
@@ -570,7 +472,7 @@ mod tests {
     #[tokio::test]
     async fn test_harness_setup() {
         let test_dir = TempDir::new().unwrap();
-        let harness = TangleTestHarness::setup(test_dir).await;
+        let harness = TangleTestHarness::<()>::setup(test_dir).await;
         assert!(harness.is_ok(), "Harness setup should succeed");
 
         let harness = harness.unwrap();
@@ -583,7 +485,7 @@ mod tests {
     #[tokio::test]
     async fn test_deploy_mbsm() {
         let test_dir = TempDir::new().unwrap();
-        let harness = TangleTestHarness::setup(test_dir).await.unwrap();
+        let harness = TangleTestHarness::<()>::setup(test_dir).await.unwrap();
 
         // MBSM should be deployed during setup
         let latest_revision = transactions::get_latest_mbsm_revision(harness.client())

--- a/crates/testing-utils/tangle/src/runner.rs
+++ b/crates/testing-utils/tangle/src/runner.rs
@@ -79,12 +79,8 @@ where
     type Config = TangleConfig;
     type Context = Ctx;
 
-    fn new(
-        config: Self::Config,
-        env: BlueprintEnvironment,
-        context: Self::Context,
-    ) -> Result<Self, Error> {
-        let runner = TestRunner::new::<Self::Config>(config.clone(), env.clone(), context);
+    fn new(config: Self::Config, env: BlueprintEnvironment) -> Result<Self, Error> {
+        let runner = TestRunner::<Ctx>::new::<Self::Config>(config.clone(), env.clone());
 
         Ok(Self {
             runner: Some(runner),
@@ -119,10 +115,10 @@ where
         self.env.clone()
     }
 
-    async fn run_runner(&mut self) -> Result<(), Error> {
+    async fn run_runner(&mut self, context: Self::Context) -> Result<(), Error> {
         // Spawn the runner in a background task
         let runner = self.runner.take().expect("Runner already running");
-        let handle = tokio::spawn(async move { runner.run().await });
+        let handle = tokio::spawn(async move { runner.run(context).await });
 
         let mut guard = self.runner_handle.lock().await;
         *guard = Some(handle);

--- a/crates/testing-utils/tangle/src/tests.rs
+++ b/crates/testing-utils/tangle/src/tests.rs
@@ -9,7 +9,7 @@ async fn test_client_initialization() -> Result<(), Error> {
     setup_log();
 
     let temp_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(temp_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(temp_dir).await?;
 
     assert!(
         harness
@@ -30,7 +30,7 @@ async fn test_operator_metadata() -> Result<(), Error> {
     setup_log();
 
     let temp_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(temp_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(temp_dir).await?;
 
     // Get operator metadata for the test account
     let metadata = harness
@@ -51,7 +51,7 @@ async fn test_services_client() -> Result<(), Error> {
     setup_log();
 
     let temp_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(temp_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(temp_dir).await?;
     let services = harness.client().services_client();
 
     // Test blueprint queries
@@ -89,7 +89,7 @@ async fn test_events_client() -> Result<(), Error> {
     setup_log();
 
     let temp_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(temp_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(temp_dir).await?;
 
     // Test event subscription
     let latest = harness.client().latest_event().await;
@@ -112,7 +112,7 @@ async fn test_service_operators() -> Result<(), Error> {
     setup_log();
 
     let temp_dir = tempfile::TempDir::new()?;
-    let harness = TangleTestHarness::setup(temp_dir).await?;
+    let harness = TangleTestHarness::<()>::setup(temp_dir).await?;
     let services = harness.client().services_client();
 
     // Get current block hash

--- a/examples/incredible-squaring/incredible-squaring-lib/tests/e2e.rs
+++ b/examples/incredible-squaring/incredible-squaring-lib/tests/e2e.rs
@@ -21,7 +21,7 @@ async fn test_incredible_squaring() -> Result<()> {
 
     // Add the job to the node, and start it
     test_env.add_job(square.layer(TangleLayer)).await;
-    test_env.start().await?;
+    test_env.start(()).await?;
 
     // Submit job and wait for execution
     let job = harness


### PR DESCRIPTION
# Overview

The BLS blueprint, since it has networking in the context, needs to be able to set a context per-node, rather than once when the harness is created.

This changes `MultiNodeTestEnv::start()` to take a context, which will be cloned to each node, and adds `MultiNodeTestEnv::start_with_contexts()`, which takes a `Vec<Ctx>` to apply to the nodes in order.

## Example

```rust
use blueprint_core::extract::Context;
use gadget_tangle_testing_utils::TangleTestHarness;
use tempfile::TempDir;

// This context is node specific. Each node needs its own copy.
#[derive(Clone)]
struct MyContext {
    foo: u64,
}

async fn some_job(Context(_context): Context<MyContext>) {}

// Start up a test with 2 nodes
const N: usize = 2;

#[tokio::main]
async fn main() -> Result<(), Box<dyn std::error::Error>> {
    let tmp_dir = TempDir::new()?;

    // Initialize the harness with the type, this is an indication that it will need the
    // context later.
    let harness = TangleTestHarness::<MyContext>::setup(tmp_dir).await?;

    let (mut test_env, _service_id, _blueprint_id) = harness.setup_services::<N>(false).await?;

    // Setup the test environment
    test_env.initialize().await?;
    test_env.add_job(some_job).await;

    // Ready to start now, provide the contexts
    let mut contexts = Vec::new();
    let handles = test_env.node_handles().await;
    for (index, handle) in handles.iter().enumerate() {
        let context = MyContext { foo: index as u64 };
        contexts.push(context);
    }

    test_env.start_with_contexts(contexts).await?;
    Ok(())
}
```