### PR TITLE
chore: update alloy & eigensdk

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2cc5aeb8dfa1e451a49fac87bc4b86c5de40ebea153ed88e83eb92b8151e74"
+checksum = "89ec9b8795b2083585293bd3d19033e9d67e725917c95c44cb154e3400529ccd"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.22",
@@ -177,16 +177,21 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "k256",
+ "once_cell",
+ "rand 0.8.5",
  "serde",
+ "serde_with",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -198,10 +203,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
+checksum = "7a0fa0584d13dd0c4e79288d411222c4d7c3411c71b7fa637cefda9dcf9bb1f9"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
@@ -257,6 +263,7 @@ dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rlp",
  "crc",
+ "serde",
  "thiserror 2.0.12",
 ]
 
@@ -286,9 +293,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -298,7 +305,8 @@ dependencies = [
  "alloy-serde",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "once_cell",
  "serde",
  "sha2 0.10.8",
@@ -306,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+checksum = "96b11774716152a5204aff0e86a8c841df499ea81464e2b1f82b3f72d6a2ef32"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.22",
@@ -331,9 +339,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
+checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-sol-types 0.8.22",
@@ -345,9 +353,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
+checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -362,6 +370,7 @@ dependencies = [
  "alloy-sol-types 0.8.22",
  "async-trait",
  "auto_impl",
+ "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -370,9 +379,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -430,9 +439,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
+checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -474,9 +483,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a68996f193f542f9e29c88dfa8ed1369d6ee04fa764c1bf23dc11b2f9e4a2"
+checksum = "b1cf194abddb88b034d22ab41449ed8532e5113e58699cd055bf21d98a0991ab"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 0.8.22",
@@ -515,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
+checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 0.8.22",
@@ -541,9 +550,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
+checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-anvil",
@@ -557,9 +566,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d06300df4a87d960add35909240fc72da355dd2ac926fa6999f9efafbdc5a7"
+checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-eth",
@@ -569,9 +578,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
+checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -580,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834b7012054cb2f90ee9893b7cc97702edca340ec1ef386c30c42e55e6cd691"
+checksum = "8fa8f6e27d47b4c56c627cb03dc91624c26bd814f6609bb1d1a836148b76fc9b"
 dependencies = [
  "alloy-primitives 0.8.22",
  "serde",
@@ -590,25 +599,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83dde9fcf1ccb9b815cc0c89bba26bbbbaae5150a53ae624ed0fc63cb3676c1"
+checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives 0.8.22",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "rand 0.8.5",
  "serde",
- "strum 0.26.3",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -626,9 +636,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd951155515fa452a2ca4b5434d4b3ab742bcd3d1d1b9a91704bcef5b8d2604"
+checksum = "5ef4bba67ec601730ceb23e542980d73ae9f718819604dfdd8289b13a506e762"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-eth",
@@ -640,9 +650,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8dd5bd94993eda3d56a8c4c0d693548183a35462523ffc4385c0b020d3b0c"
+checksum = "8edc8512f919feb79dd30864ef7574d2877e71b73e30b5de4925ba9bc6bd4f96"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-eth",
@@ -652,9 +662,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
 dependencies = [
  "alloy-primitives 0.8.22",
  "serde",
@@ -663,9 +673,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
+checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
 dependencies = [
  "alloy-dyn-abi",
  "alloy-primitives 0.8.22",
@@ -680,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f7fae8dec636317c89e08498675c9421a214f1791a59dcaea2094c1a2dbf07"
+checksum = "3c4861024ab627a150e07d2658ae29bb90d27cd1caddc2f6deff5b940167508b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -698,9 +708,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-gcp"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7fcc881fb827d16c1379d375e7f5f26159039fb6956b9f1408989be6bf91444"
+checksum = "4265500541723b09b625e37d19b718bf13c0535830692c5cf176619e2df678f4"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -716,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-ledger"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "327a0cfa3d68a60862aeaa42fbdfb5cc7d66275a79e01a3f9cfe38d293b6215a"
+checksum = "3cb71c0a180015f377b74aed8bafa60c8967529a0b09f55212913ad012e57bd1"
 dependencies = [
  "alloy-consensus",
  "alloy-dyn-abi",
@@ -736,9 +746,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -856,9 +866,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
+checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -875,9 +885,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
+checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -890,9 +900,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e88304aa8b796204e5e2500dfe235933ed692745e3effd94c3733643db6d218"
+checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -910,9 +920,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9653ea9aa06d0e02fcbe2f04f1c47f35a85c378ccefa98e54ae85210bc8bbfa"
+checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -4902,7 +4912,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "unicode-xid",
 ]
 
 [[package]]
@@ -5240,7 +5249,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-avsregistry"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -5259,7 +5268,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-elcontracts"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "eigen-common",
@@ -5274,7 +5283,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-eth"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -5288,7 +5297,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-fireblocks"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "chrono",
@@ -5308,7 +5317,7 @@ dependencies = [
 [[package]]
 name = "eigen-common"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "url",
@@ -5317,7 +5326,7 @@ dependencies = [
 [[package]]
 name = "eigen-crypto-bls"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -5334,7 +5343,7 @@ dependencies = [
 [[package]]
 name = "eigen-crypto-bn254"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "ark-bn254",
  "ark-ec 0.5.0",
@@ -5345,7 +5354,7 @@ dependencies = [
 [[package]]
 name = "eigen-logging"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "ctor",
  "once_cell",
@@ -5356,7 +5365,7 @@ dependencies = [
 [[package]]
 name = "eigen-metrics"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "eigen-logging",
  "metrics",
@@ -5367,7 +5376,7 @@ dependencies = [
 [[package]]
 name = "eigen-metrics-collectors-economic"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "eigen-client-avsregistry",
@@ -5382,7 +5391,7 @@ dependencies = [
 [[package]]
 name = "eigen-metrics-collectors-rpc-calls"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "eigen-logging",
  "metrics",
@@ -5391,7 +5400,7 @@ dependencies = [
 [[package]]
 name = "eigen-nodeapi"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "ntex",
  "serde",
@@ -5403,7 +5412,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-avsregistry"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -5419,7 +5428,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-blsaggregation"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -5441,7 +5450,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-operatorsinfo"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -5462,7 +5471,7 @@ dependencies = [
 [[package]]
 name = "eigen-signer"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -5476,7 +5485,7 @@ dependencies = [
 [[package]]
 name = "eigen-testing-utils"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "eigen-common",
@@ -5490,7 +5499,7 @@ dependencies = [
 [[package]]
 name = "eigen-types"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -5510,7 +5519,7 @@ dependencies = [
 [[package]]
 name = "eigen-utils"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "regex",
@@ -5520,7 +5529,7 @@ dependencies = [
 [[package]]
 name = "eigensdk"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
@@ -5548,6 +5557,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"
@@ -9222,7 +9234,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-targets 0.48.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -212,33 +212,33 @@ document-features = "0.2.11"
 rustversion = "1.0.20"
 
 # Alloy (EVM)
-alloy = { version = "0.11", default-features = false }
+alloy = { version = "0.12", default-features = false }
 alloy-primitives = { version = "0.8", default-features = false }
 alloy-json-abi = { version = "0.8", default-features = false }
-alloy-json-rpc = { version = "0.11", default-features = false }
+alloy-json-rpc = { version = "0.12", default-features = false }
 alloy-dyn-abi = { version = "0.8", default-features = false }
 alloy-sol-types = { version = "0.8", default-features = false }
 alloy-rlp = { version = "0.3", default-features = false }
-alloy-rpc-client = { version = "0.11", default-features = false }
-alloy-rpc-types = { version = "0.11", default-features = false }
-alloy-rpc-types-eth = { version = "0.11", default-features = false }
-alloy-provider = { version = "0.11", default-features = false, features = ["reqwest", "ws"] }
-alloy-pubsub = { version = "0.11", default-features = false }
-alloy-signer = { version = "0.11", default-features = false }
-alloy-signer-local = { version = "0.11", default-features = false }
-alloy-network = { version = "0.11", default-features = false }
-alloy-node-bindings = { version = "0.11", default-features = false }
-alloy-contract = { version = "0.11", default-features = false }
-alloy-consensus = { version = "0.11", default-features = false }
-alloy-transport = { version = "0.11", default-features = false }
-alloy-transport-http = { version = "0.11", default-features = false }
+alloy-rpc-client = { version = "0.12", default-features = false }
+alloy-rpc-types = { version = "0.12", default-features = false }
+alloy-rpc-types-eth = { version = "0.12", default-features = false }
+alloy-provider = { version = "0.12", default-features = false, features = ["reqwest", "ws"] }
+alloy-pubsub = { version = "0.12", default-features = false }
+alloy-signer = { version = "0.12", default-features = false }
+alloy-signer-local = { version = "0.12", default-features = false }
+alloy-network = { version = "0.12", default-features = false }
+alloy-node-bindings = { version = "0.12", default-features = false }
+alloy-contract = { version = "0.12", default-features = false }
+alloy-consensus = { version = "0.12", default-features = false }
+alloy-transport = { version = "0.12", default-features = false }
+alloy-transport-http = { version = "0.12", default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 
 # Remote signing
-alloy-signer-aws = { version = "0.11", default-features = false }
-alloy-signer-gcp = { version = "0.11", default-features = false }
-alloy-signer-ledger = { version = "0.11", default-features = false, features = ["eip712"] }
+alloy-signer-aws = { version = "0.12", default-features = false }
+alloy-signer-gcp = { version = "0.12", default-features = false }
+alloy-signer-ledger = { version = "0.12", default-features = false, features = ["eip712"] }
 aws-config = { version = "1", default-features = false }
 aws-sdk-kms = { version = "1", default-features = false }
 gcloud-sdk = { version = "0.26", default-features = false }
@@ -254,7 +254,7 @@ rayon = { version = "1", default-features = false }
 zeroize = { version = "1.8.1", default-features = false }
 
 # Eigenlayer
-eigensdk = { git = "https://github.com/Serial-ATA/eigensdk-rs.git", branch = "serial/alloy-0.11", default-features = false }
+eigensdk = { git = "https://github.com/Serial-ATA/eigensdk-rs.git", branch = "alloy-update", default-features = false }
 rust-bls-bn254 = { version = "0.2.1", default-features = false }
 testcontainers = { version = "0.23.1", default-features = false }
 

--- a/crates/clients/evm/src/instrumented_client.rs
+++ b/crates/clients/evm/src/instrumented_client.rs
@@ -829,9 +829,7 @@ mod tests {
     use alloy_network::TxSignerSync;
     use alloy_primitives::address;
     use alloy_primitives::{TxKind::Call, U256, bytes};
-    use alloy_rpc_types::eth::{
-        BlockId, BlockNumberOrTag, BlockTransactionsKind, pubsub::SubscriptionResult,
-    };
+    use alloy_rpc_types::eth::{BlockId, BlockNumberOrTag, pubsub::SubscriptionResult};
     use alloy_signer_local::PrivateKeySigner;
     use blueprint_evm_extra::util::get_provider_http;
     use gadget_anvil_testing_utils::{start_default_anvil_testnet, wait_transaction};
@@ -936,17 +934,14 @@ mod tests {
 
         // get the hash from the last block
         let hash = provider
-            .get_block(BlockId::latest(), BlockTransactionsKind::Hashes)
+            .get_block(BlockId::latest())
             .await
             .unwrap()
             .unwrap()
             .header
             .hash;
 
-        let expected_block = provider
-            .get_block_by_hash(hash, BlockTransactionsKind::Full)
-            .await
-            .unwrap();
+        let expected_block = provider.get_block_by_hash(hash).full().await.unwrap();
         let block = instrumented_client.block_by_hash(hash).await.unwrap();
 
         assert_eq!(expected_block, block);
@@ -961,7 +956,8 @@ mod tests {
         let block_number = 1;
 
         let expected_block = provider
-            .get_block_by_number(block_number.into(), BlockTransactionsKind::Full)
+            .get_block_by_number(block_number.into())
+            .full()
             .await
             .unwrap();
         let block = instrumented_client
@@ -980,7 +976,7 @@ mod tests {
         let instrumented_client = InstrumentedClient::new(&http_endpoint).await.unwrap();
 
         let block = provider
-            .get_block(BlockId::latest(), BlockTransactionsKind::Hashes)
+            .get_block(BlockId::latest())
             .await
             .unwrap()
             .unwrap();
@@ -1074,7 +1070,11 @@ mod tests {
         let tx_request: TransactionRequest = tx.clone().into();
         let tx_request = tx_request.from(*from);
 
-        let expected_estimated_gas = provider.clone().estimate_gas(&tx_request).await.unwrap();
+        let expected_estimated_gas = provider
+            .clone()
+            .estimate_gas(tx_request.clone())
+            .await
+            .unwrap();
         let estimated_gas = instrumented_client.estimate_gas(tx_request).await.unwrap();
         assert_eq!(expected_estimated_gas, estimated_gas);
     }
@@ -1110,7 +1110,7 @@ mod tests {
         let tx_request = tx_request.from(*from);
 
         // test call_contract
-        let expected_bytes = anvil.call(&tx_request).await.unwrap();
+        let expected_bytes = anvil.call(tx_request.clone()).await.unwrap();
         let bytes = instrumented_client
             .call_contract(tx_request.clone(), BlockNumberOrTag::Earliest)
             .await
@@ -1243,14 +1243,14 @@ mod tests {
 
         let instrumented_client = InstrumentedClient::new(&http_endpoint).await.unwrap();
         let hash = provider
-            .get_block(BlockId::latest(), BlockTransactionsKind::Hashes)
+            .get_block(BlockId::latest())
             .await
             .unwrap()
             .unwrap()
             .header
             .hash;
         let expected_header = provider
-            .get_block_by_hash(hash, BlockTransactionsKind::Hashes)
+            .get_block_by_hash(hash)
             .await
             .unwrap()
             .unwrap()
@@ -1274,7 +1274,7 @@ mod tests {
             .unwrap();
 
         let expected_header = provider
-            .get_block_by_number(block_number, BlockTransactionsKind::Hashes)
+            .get_block_by_number(block_number)
             .await
             .unwrap()
             .unwrap()
@@ -1376,7 +1376,7 @@ mod tests {
         let instrumented_client = InstrumentedClient::new(&http_endpoint).await.unwrap();
 
         let expected_transaction_count: u64 = provider
-            .get_block_by_number(BlockNumberOrTag::Pending, BlockTransactionsKind::Hashes)
+            .get_block_by_number(BlockNumberOrTag::Pending)
             .await
             .unwrap()
             .unwrap()

--- a/crates/sdk/src/error.rs
+++ b/crates/sdk/src/error.rs
@@ -32,6 +32,10 @@ pub enum Error {
     #[error("Networking error: {0}")]
     Networking(#[from] gadget_networking::error::Error),
 
+    #[expect(
+        clippy::non_minimal_cfg,
+        reason = "More store types may be added in the future"
+    )]
     #[cfg(any(feature = "local-store"))]
     #[error("Database error: {0}")]
     Stores(#[from] gadget_stores::Error),

--- a/examples/incredible-squaring/Cargo.lock
+++ b/examples/incredible-squaring/Cargo.lock
@@ -128,9 +128,9 @@ checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
 name = "alloy"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d2cc5aeb8dfa1e451a49fac87bc4b86c5de40ebea153ed88e83eb92b8151e74"
+checksum = "89ec9b8795b2083585293bd3d19033e9d67e725917c95c44cb154e3400529ccd"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -166,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e32ef5c74bbeb1733c37f4ac7f866f8c8af208b7b4265e21af609dcac5bd5e"
+checksum = "a84efb7b8ddb9223346bfad9d8094e1a100c254037a3b5913243bfa8e04be266"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.22",
@@ -177,16 +177,21 @@ dependencies = [
  "alloy-trie",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "k256",
+ "once_cell",
+ "rand 0.8.5",
  "serde",
+ "serde_with",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
 name = "alloy-consensus-any"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fa13b7b1e1e3fedc42f0728103bfa3b4d566d3d42b606db449504d88dbdbdcf"
+checksum = "fafded0c1ff8f0275c4a484239058e1c01c0c2589f8a16e03669ef7094a06f9b"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -198,10 +203,11 @@ dependencies = [
 
 [[package]]
 name = "alloy-contract"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee6180fb232becdea70fad57c63b6967f01f74ab9595671b870f504116dd29de"
+checksum = "7a0fa0584d13dd0c4e79288d411222c4d7c3411c71b7fa637cefda9dcf9bb1f9"
 dependencies = [
+ "alloy-consensus",
  "alloy-dyn-abi",
  "alloy-json-abi",
  "alloy-network",
@@ -256,6 +262,7 @@ dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rlp",
  "crc",
+ "serde",
  "thiserror 2.0.12",
 ]
 
@@ -285,9 +292,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5591581ca2ab0b3e7226a4047f9a1bfcf431da1d0cce3752fda609fea3c27e37"
+checksum = "5f4bffedaddc627520eabdcbfe27a2d2c2f716e15295e2ed1010df3feae67040"
 dependencies = [
  "alloy-eip2124",
  "alloy-eip2930",
@@ -297,7 +304,8 @@ dependencies = [
  "alloy-serde",
  "auto_impl",
  "c-kzg",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "either",
  "once_cell",
  "serde",
  "sha2 0.10.8",
@@ -305,9 +313,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cded3a2d4bd7173f696458c5d4c98c18a628dfcc9f194385e80a486e412e2e0"
+checksum = "96b11774716152a5204aff0e86a8c841df499ea81464e2b1f82b3f72d6a2ef32"
 dependencies = [
  "alloy-eips",
  "alloy-primitives 0.8.22",
@@ -330,9 +338,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "762414662d793d7aaa36ee3af6928b6be23227df1681ce9c039f6f11daadef64"
+checksum = "6929e607b0a56803c69c68adc6e8aae1644c94e37ea458aa2d0713fc77490e70"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-sol-types 0.8.22",
@@ -344,9 +352,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be03f2ebc00cf88bd06d3c6caf387dceaa9c7e6b268216779fa68a9bf8ab4e6"
+checksum = "c2b14524c3605ed5ee173b966333089474415416a8cfd80ceb003c18fd6d1736"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -361,6 +369,7 @@ dependencies = [
  "alloy-sol-types 0.8.22",
  "async-trait",
  "auto_impl",
+ "derive_more 2.0.1",
  "futures-utils-wasm",
  "serde",
  "serde_json",
@@ -369,9 +378,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a00ce618ae2f78369918be0c20f620336381502c83b6ed62c2f7b2db27698b0"
+checksum = "4c06932646544ea341f0fda48d2c0fe4fda75bc132379cb84019cdfb6ddcb0fb"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -429,9 +438,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbe0a2acff0c4bd1669c71251ce10fc455cbffa1b4d0a817d5ea4ba7e5bb3db7"
+checksum = "ff1ec2eabd9b3acc46e59247c35f75545960372431c68f7fdbfcfb970a486c30"
 dependencies = [
  "alloy-chains",
  "alloy-consensus",
@@ -473,9 +482,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "de3a68996f193f542f9e29c88dfa8ed1369d6ee04fa764c1bf23dc11b2f9e4a2"
+checksum = "b1cf194abddb88b034d22ab41449ed8532e5113e58699cd055bf21d98a0991ab"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 0.8.22",
@@ -514,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b37cc3c7883dc41be1b01460127ad7930466d0a4bb6ba15a02ee34d2745e2d7c"
+checksum = "6213829d8eabc239c2f9572452a5993ebdf78b04c020abc450ae48c54261d4ce"
 dependencies = [
  "alloy-json-rpc",
  "alloy-primitives 0.8.22",
@@ -540,9 +549,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f18e68a3882f372e045ddc89eb455469347767d17878ca492cfbac81e71a111"
+checksum = "a153db94cf231b03238fe4da48f59dc6f36e01b5e4d5a2e30de33b95395380fa"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-anvil",
@@ -556,9 +565,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-anvil"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10d06300df4a87d960add35909240fc72da355dd2ac926fa6999f9efafbdc5a7"
+checksum = "5462937f088889c337c236c2509226e87a26301d2b01f9fafee246bd84cb0407"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-eth",
@@ -568,9 +577,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-any"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "318ae46dd12456df42527c3b94c1ae9001e1ceb707f7afe2c7807ac4e49ebad9"
+checksum = "2cd4ceea38ea27eeb26f021df34ed5b7b793704ad7a2a009f16137a19461e7ca"
 dependencies = [
  "alloy-consensus-any",
  "alloy-rpc-types-eth",
@@ -579,9 +588,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-debug"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834b7012054cb2f90ee9893b7cc97702edca340ec1ef386c30c42e55e6cd691"
+checksum = "8fa8f6e27d47b4c56c627cb03dc91624c26bd814f6609bb1d1a836148b76fc9b"
 dependencies = [
  "alloy-primitives 0.8.22",
  "serde",
@@ -589,25 +598,26 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83dde9fcf1ccb9b815cc0c89bba26bbbbaae5150a53ae624ed0fc63cb3676c1"
+checksum = "b1a1a0710dbfbab2b33200ef45c650963d63edf6a81b2c7399ede762b3586dfd"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
  "alloy-primitives 0.8.22",
  "alloy-rlp",
  "alloy-serde",
- "derive_more 1.0.0",
+ "derive_more 2.0.1",
+ "rand 0.8.5",
  "serde",
- "strum 0.26.3",
+ "strum 0.27.1",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b4dbee4d82f8a22dde18c28257bed759afeae7ba73da4a1479a039fd1445d04"
+checksum = "8e18d94b1036302720b987564560e4a5b85035a17553c53a50afa2bd8762b487"
 dependencies = [
  "alloy-consensus",
  "alloy-consensus-any",
@@ -617,7 +627,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde",
  "alloy-sol-types 0.8.22",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "thiserror 2.0.12",
@@ -625,9 +635,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7bd951155515fa452a2ca4b5434d4b3ab742bcd3d1d1b9a91704bcef5b8d2604"
+checksum = "5ef4bba67ec601730ceb23e542980d73ae9f718819604dfdd8289b13a506e762"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-eth",
@@ -639,9 +649,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-txpool"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21d8dd5bd94993eda3d56a8c4c0d693548183a35462523ffc4385c0b020d3b0c"
+checksum = "8edc8512f919feb79dd30864ef7574d2877e71b73e30b5de4925ba9bc6bd4f96"
 dependencies = [
  "alloy-primitives 0.8.22",
  "alloy-rpc-types-eth",
@@ -651,9 +661,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8732058f5ca28c1d53d241e8504620b997ef670315d7c8afab856b3e3b80d945"
+checksum = "9824e1bf92cd7848ca6fabb01c9aca15c9c5fb0ab96da5514ef0543f021c69f6"
 dependencies = [
  "alloy-primitives 0.8.22",
  "serde",
@@ -662,9 +672,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f96b3526fdd779a4bd0f37319cfb4172db52a7ac24cdbb8804b72091c18e1701"
+checksum = "81755ed6a6a33061302ac95e9bb7b40ebf7078e4568397168024242bc31a3e58"
 dependencies = [
  "alloy-primitives 0.8.22",
  "async-trait",
@@ -677,9 +687,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-aws"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6f7fae8dec636317c89e08498675c9421a214f1791a59dcaea2094c1a2dbf07"
+checksum = "3c4861024ab627a150e07d2658ae29bb90d27cd1caddc2f6deff5b940167508b"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -695,9 +705,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe8f78cd6b7501c7e813a1eb4a087b72d23af51f5bb66d4e948dc840bdd207d8"
+checksum = "aa857621a5c95c13e640e18bb9c4720f4338a666d6276f55446477a6bc3912ff"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -815,9 +825,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a8d762eadce3e9b65eac09879430c6f4fce3736cac3cac123f9b1bf435ddd13"
+checksum = "6c74598eb65cefa886be6ba624c14a6856d9d84339ec720520f3efcc03311716"
 dependencies = [
  "alloy-json-rpc",
  "base64 0.22.1",
@@ -834,9 +844,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20819c4cb978fb39ce6ac31991ba90f386d595f922f42ef888b4a18be190713e"
+checksum = "cfcd2f8ab2f053cd848ead5d625cb1b63716562951101588c1fa49300e3c6418"
 dependencies = [
  "alloy-json-rpc",
  "alloy-transport",
@@ -849,9 +859,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e88304aa8b796204e5e2500dfe235933ed692745e3effd94c3733643db6d218"
+checksum = "e61e2b5cbf16f7588e4420848b61824f6514944773732534f4129ba6a251e059"
 dependencies = [
  "alloy-json-rpc",
  "alloy-pubsub",
@@ -869,9 +879,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.11.1"
+version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9653ea9aa06d0e02fcbe2f04f1c47f35a85c378ccefa98e54ae85210bc8bbfa"
+checksum = "67ddcf4b98b3448eb998e057dc5a27345997863d6544ee7f0f79957616768dd3"
 dependencies = [
  "alloy-pubsub",
  "alloy-transport",
@@ -4466,7 +4476,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.100",
- "unicode-xid",
 ]
 
 [[package]]
@@ -4792,7 +4801,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-avsregistry"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -4811,7 +4820,7 @@ dependencies = [
 [[package]]
 name = "eigen-client-elcontracts"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "eigen-common",
@@ -4826,7 +4835,7 @@ dependencies = [
 [[package]]
 name = "eigen-common"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "url",
@@ -4835,7 +4844,7 @@ dependencies = [
 [[package]]
 name = "eigen-crypto-bls"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -4852,7 +4861,7 @@ dependencies = [
 [[package]]
 name = "eigen-crypto-bn254"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "ark-bn254",
  "ark-ec 0.5.0",
@@ -4863,7 +4872,7 @@ dependencies = [
 [[package]]
 name = "eigen-logging"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "ctor",
  "once_cell",
@@ -4874,7 +4883,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-avsregistry"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -4890,7 +4899,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-blsaggregation"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-bn254",
@@ -4912,7 +4921,7 @@ dependencies = [
 [[package]]
 name = "eigen-services-operatorsinfo"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "async-trait",
@@ -4933,7 +4942,7 @@ dependencies = [
 [[package]]
 name = "eigen-types"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "ark-ff 0.5.0",
@@ -4953,7 +4962,7 @@ dependencies = [
 [[package]]
 name = "eigen-utils"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "alloy",
  "regex",
@@ -4963,7 +4972,7 @@ dependencies = [
 [[package]]
 name = "eigensdk"
 version = "0.4.0"
-source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=serial%2Falloy-0.11#267df08b4d150f4279818d0041be4e55f0826aea"
+source = "git+https://github.com/Serial-ATA/eigensdk-rs.git?branch=alloy-update#47b5051ce55d65474f6072a1db35eaa82df23dbd"
 dependencies = [
  "eigen-client-avsregistry",
  "eigen-client-elcontracts",
@@ -4981,6 +4990,9 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "elliptic-curve"


### PR DESCRIPTION
# Overview

* bump `alloy` to 0.12
* bump `eigensdk` to the latest state of ***my branch***. Continuing to use my branch as a safety net until a new `eigensdk` release is out.

closes #740