### PR TITLE
feat: add support for `request_params` and `registration_params`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,6 +2656,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "blueprint-benchmarking"
+version = "0.1.0"
+dependencies = [
+ "blueprint-std",
+ "sysinfo",
+ "tokio",
+]
+
+[[package]]
 name = "blueprint-build-utils"
 version = "0.1.0"
 dependencies = [
@@ -7403,15 +7412,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
 dependencies = [
  "byteorder",
-]
-
-[[package]]
-name = "blueprint-benchmarking"
-version = "0.1.0"
-dependencies = [
- "blueprint-std",
- "sysinfo",
- "tokio",
 ]
 
 [[package]]

--- a/crates/tangle-extra/src/metadata/macros.rs
+++ b/crates/tangle-extra/src/metadata/macros.rs
@@ -354,12 +354,20 @@ macro_rules! blueprint_inner {
         }
         $crate::blueprint_inner!(@__CONSTRUCT $object $($rest)*);
     }};
-    (@__CONSTRUCT $object:ident registration_params: [$($registration_params:expr),* $(,)?] , $($rest:tt)*) => {
-        // TODO(serial): Generate registration params
+    (@__CONSTRUCT $object:ident registration_params: $registration_params:ty , $($rest:tt)*) => {
+        let registration_params = <$registration_params as $crate::metadata::job_definition::IntoTangleFieldTypes>::into_tangle_fields();
+        $object.insert(
+            String::from("registration_params"),
+            $crate::metadata::macros::ext::serde_json::to_value(registration_params).expect("should serialize"),
+        );
         $crate::blueprint_inner!(@__CONSTRUCT $object $($rest)*)
     };
-    (@__CONSTRUCT $object:ident request_params: [$($request_params:expr),* $(,)?] , $($rest:tt)*) => {
-        // TODO(serial): Generate request params
+    (@__CONSTRUCT $object:ident request_params: $request_params:ty , $($rest:tt)*) => {
+        let request_params = <$request_params as $crate::metadata::job_definition::IntoTangleFieldTypes>::into_tangle_fields();
+        $object.insert(
+            String::from("request_params"),
+            $crate::metadata::macros::ext::serde_json::to_value(request_params).expect("should serialize"),
+        );
         $crate::blueprint_inner!(@__CONSTRUCT $object $($rest)*)
     };
     (@__CONSTRUCT $object:ident manager: { $variant:ident = $value:literal } , $($rest:tt)*) => {{
@@ -396,9 +404,21 @@ macro_rules! blueprint_inner {
 #[cfg(test)]
 mod tests {
     use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::FieldType;
+    use tangle_subxt::tangle_testnet_runtime::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
     use super::*;
-    use crate::extract::{TangleArg, TangleResult};
+    use crate::extract::{List, TangleArg, TangleArgs2, TangleResult, Optional};
     use crate::metadata::types::job::JobMetadata;
+
+    #[derive(Default, serde::Deserialize, serde::Serialize)]
+    struct MyCustomType {
+        value: u8,
+        optional: Optional<u64>,
+        list: List<u64>,
+        bytes: List<u8>,
+        x: u64,
+        y: u64,
+        z: u64,
+    }
 
     #[test]
     fn info_test() {
@@ -485,6 +505,86 @@ mod tests {
                     result: vec![FieldType::Uint64],
                 }
             ]
+        );
+    }
+
+    #[test]
+    fn with_request_params() {
+        type MyRequestParams = TangleArgs2<u64, u32>;
+        let blueprint = blueprint! {
+            name: "test",
+            master_manager_revision: "Latest",
+            manager: { Evm = "TestBlueprint" },
+            request_params: MyRequestParams,
+        }
+        .unwrap();
+
+        assert_eq!(
+            blueprint.request_params,
+            vec![FieldType::Uint64, FieldType::Uint32]
+        );
+
+        type MyRequestParams2 = TangleArg<MyCustomType>;
+
+        let blueprint = blueprint! {
+            name: "test",
+            master_manager_revision: "Latest",
+            manager: { Evm = "TestBlueprint" },
+            request_params: MyRequestParams2,
+        }
+        .unwrap();
+
+        assert_eq!(
+            blueprint.request_params,
+            vec![FieldType::Struct(Box::new(BoundedVec(vec![
+                FieldType::Uint8,
+                FieldType::Optional(Box::new(FieldType::Uint64)),
+                FieldType::List(Box::new(FieldType::Uint64)),
+                FieldType::List(Box::new(FieldType::Uint8)),
+                FieldType::Uint64,
+                FieldType::Uint64,
+                FieldType::Uint64,
+            ])))]
+        );
+    }
+
+    #[test]
+    fn with_registration_params() {
+        type MyRegistrationParams = TangleArgs2<u64, u32>;
+        let blueprint = blueprint! {
+            name: "test",
+            master_manager_revision: "Latest",
+            manager: { Evm = "TestBlueprint" },
+            registration_params: MyRegistrationParams,
+        }
+        .unwrap();
+
+        assert_eq!(
+            blueprint.registration_params,
+            vec![FieldType::Uint64, FieldType::Uint32]
+        );
+
+        type MyRegistrationParams2 = TangleArg<MyCustomType>;
+
+        let blueprint = blueprint! {
+            name: "test",
+            master_manager_revision: "Latest",
+            manager: { Evm = "TestBlueprint" },
+            registration_params: MyRegistrationParams2,
+        }
+        .unwrap();
+
+        assert_eq!(
+            blueprint.registration_params,
+            vec![FieldType::Struct(Box::new(BoundedVec(vec![
+                FieldType::Uint8,
+                FieldType::Optional(Box::new(FieldType::Uint64)),
+                FieldType::List(Box::new(FieldType::Uint64)),
+                FieldType::List(Box::new(FieldType::Uint8)),
+                FieldType::Uint64,
+                FieldType::Uint64,
+                FieldType::Uint64,
+            ])))]
         );
     }
 

--- a/flake.lock
+++ b/flake.lock
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1741037377,
-        "narHash": "sha256-SvtvVKHaUX4Owb+PasySwZsoc5VUeTf1px34BByiOxw=",
+        "lastModified": 1742272065,
+        "narHash": "sha256-ud8vcSzJsZ/CK+r8/v0lyf4yUntVmDq6Z0A41ODfWbE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "02032da4af073d0f6110540c8677f16d4be0117f",
+        "rev": "3549532663732bfd89993204d40543e9edaec4f2",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1741314698,
-        "narHash": "sha256-6Yp0CTwAY/jq/F81Sa8NM0Zi1EwxAdASO6y4A5neGuc=",
+        "lastModified": 1742351546,
+        "narHash": "sha256-GPubFcOXyi8TVm1xpltHYPcfGr+iO+if2u/EtzFVnHQ=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "4e9af61c1a631886cdc7e13032af4fc9e75bb76b",
+        "rev": "b0a7450168c62a46f87d204280e6d9d1c0292671",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
closes #766

This pull request includes significant updates to the `blueprint_inner` macro in the `crates/tangle-extra/src/metadata/macros.rs` file to improve the handling and serialization of parameters. Additionally, it introduces new test cases to ensure the correctness of these updates.

Improvements to parameter handling and serialization:

* [`crates/tangle-extra/src/metadata/macros.rs`](diffhunk://#diff-70c90534f01433ac1ee4898f4411de0aed5bba57682b425eb116748d298ccb54L357-R370): Updated the `blueprint_inner` macro to generate and serialize `registration_params` and `request_params` using the `IntoTangleFieldTypes` trait.

Enhancements to testing:

* [`crates/tangle-extra/src/metadata/macros.rs`](diffhunk://#diff-70c90534f01433ac1ee4898f4411de0aed5bba57682b425eb116748d298ccb54R407-R422): Added a new custom type `MyCustomType` for testing purposes.
* [`crates/tangle-extra/src/metadata/macros.rs`](diffhunk://#diff-70c90534f01433ac1ee4898f4411de0aed5bba57682b425eb116748d298ccb54R511-R590): Introduced new test cases `with_request_params` and `with_registration_params` to verify the correct generation and serialization of `request_params` and `registration_params`.