### PR TITLE
feat: add support for request and registration args in the test harness

### DIFF
--- a/crates/chain-setup/tangle/src/transactions.rs
+++ b/crates/chain-setup/tangle/src/transactions.rs
@@ -32,6 +32,7 @@ use tangle_subxt::tangle_testnet_runtime::api::{
             call::{Args, Job},
             create_blueprint::Blueprint,
             register::{Preferences, RegistrationArgs},
+            request::RequestArgs,
         },
         events::{JobCalled, JobResultSubmitted, MasterBlueprintServiceManagerRevised},
     },
@@ -264,6 +265,7 @@ pub async fn request_service<T: Signer<TangleConfig>>(
     user: &T,
     blueprint_id: u64,
     test_nodes: Vec<AccountId32>,
+    request_args: RequestArgs,
     value: u128,
     optional_assets: Option<Vec<AssetSecurityRequirement<AssetId>>>,
 ) -> Result<(), TransactionError> {
@@ -281,7 +283,7 @@ pub async fn request_service<T: Signer<TangleConfig>>(
         blueprint_id,
         Vec::new(),
         test_nodes,
-        Vec::new(),
+        request_args,
         security_requirements,
         1000,
         Asset::Custom(0),
@@ -442,6 +444,8 @@ pub async fn setup_operator_and_service_multiple<T: Signer<TangleConfig>>(
     sr25519_signers: &[T],
     blueprint_id: u64,
     preferences: &[Preferences],
+    registration_args: &[RegistrationArgs],
+    request_args: RequestArgs,
     _exit_after_registration: bool,
 ) -> Result<u64, TransactionError> {
     let alice_signer = sr25519_signers
@@ -452,7 +456,12 @@ pub async fn setup_operator_and_service_multiple<T: Signer<TangleConfig>>(
         .first()
         .ok_or(TransactionError::Other("No client".to_string()))?;
 
-    for ((operator, client), preferences) in sr25519_signers.iter().zip(clients).zip(preferences) {
+    for (((operator, client), preferences), registration_arg) in sr25519_signers
+        .iter()
+        .zip(clients)
+        .zip(preferences)
+        .zip(registration_args)
+    {
         join_operators(client, operator).await?;
         // Register for blueprint
         register_for_blueprint(
@@ -460,7 +469,7 @@ pub async fn setup_operator_and_service_multiple<T: Signer<TangleConfig>>(
             operator,
             blueprint_id,
             preferences.clone(),
-            RegistrationArgs::new(),
+            registration_arg.clone(),
             0,
         )
         .await?;
@@ -473,7 +482,16 @@ pub async fn setup_operator_and_service_multiple<T: Signer<TangleConfig>>(
         .iter()
         .map(Signer::account_id)
         .collect::<Vec<_>>();
-    request_service(alice_client, alice_signer, blueprint_id, accounts, 0, None).await?;
+    request_service(
+        alice_client,
+        alice_signer,
+        blueprint_id,
+        accounts,
+        request_args,
+        0,
+        None,
+    )
+    .await?;
 
     // Approve the service request and wait for completion
     let request_id = get_next_request_id(alice_client).await?.saturating_sub(1);

--- a/crates/testing-utils/tangle/src/harness.rs
+++ b/crates/testing-utils/tangle/src/harness.rs
@@ -217,7 +217,7 @@ impl<const N: usize> Default for SetupServicesOpts<N> {
         Self {
             exit_after_registration: false,
             registration_args: vec![RegistrationArgs::default(); N].try_into().unwrap(),
-            request_args: Vec::default(),
+            request_args: RequestArgs::default(),
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several updates to the `transactions.rs` and `harness.rs` files in the `tangle` crate, adding new parameters and functions to improve service setup and request handling. The most important changes include the addition of `RequestArgs` and `RegistrationArgs` parameters, and the creation of a new `SetupServicesOpts` struct.

### Enhancements to service setup and request handling:

* [`crates/chain-setup/tangle/src/transactions.rs`](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfR35): Added `RequestArgs` parameter to the `request_service` and `setup_operator_and_service_multiple` functions to allow for more detailed service requests. [[1]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfR35) [[2]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfR268) [[3]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfL284-R286) [[4]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfR447-R448) [[5]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfL455-R472) [[6]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfL476-R494)

### Struct and function additions:

* [`crates/testing-utils/tangle/src/harness.rs`](diffhunk://#diff-67b7ad0b91d9e1ce4bee4a3530f12dd507323f9b2e3cc0935097e52204812d18R205-R224): Added `SetupServicesOpts` struct to encapsulate options for service setup, including `exit_after_registration`, `registration_args`, and `request_args`.
* [`crates/testing-utils/tangle/src/harness.rs`](diffhunk://#diff-67b7ad0b91d9e1ce4bee4a3530f12dd507323f9b2e3cc0935097e52204812d18L332-R361): Implemented `setup_services_with_options` function to use `SetupServicesOpts` for more flexible service setup. [[1]](diffhunk://#diff-67b7ad0b91d9e1ce4bee4a3530f12dd507323f9b2e3cc0935097e52204812d18L332-R361) [[2]](diffhunk://#diff-67b7ad0b91d9e1ce4bee4a3530f12dd507323f9b2e3cc0935097e52204812d18R397-R398)
* [`crates/testing-utils/tangle/src/harness.rs`](diffhunk://#diff-67b7ad0b91d9e1ce4bee4a3530f12dd507323f9b2e3cc0935097e52204812d18R411-R435): Added `setup_services` function as a simplified wrapper around `setup_services_with_options`.

These changes enhance the flexibility and configurability of the service setup process in the `tangle` crate.


closes #767 