### PR TITLE
feat: impl IntoTangleFieldTypes for Void

### DIFF
--- a/crates/tangle-extra/src/metadata/job_definition.rs
+++ b/crates/tangle-extra/src/metadata/job_definition.rs
@@ -80,6 +80,15 @@ pub trait IntoTangleFieldTypes {
     fn into_tangle_fields() -> Vec<FieldType>;
 }
 
+/// Implementation for [`Void`] type.
+///
+/// [Void]: blueprint_core::job_result::Void
+impl IntoTangleFieldTypes for blueprint_core::job_result::Void {
+    fn into_tangle_fields() -> Vec<FieldType> {
+        Vec::from([FieldType::Void])
+    }
+}
+
 /// Implementation for functions with no arguments.
 impl<F, Fut, Res> IntoJobDefinition<((),)> for F
 where

--- a/crates/testing-utils/tangle/src/harness.rs
+++ b/crates/testing-utils/tangle/src/harness.rs
@@ -117,7 +117,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use blueprint_tangle_testing_utils::TangleTestHarness;
     /// use tempfile::TempDir;
     ///

--- a/crates/testing-utils/tangle/src/multi_node.rs
+++ b/crates/testing-utils/tangle/src/multi_node.rs
@@ -183,7 +183,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use blueprint_core::extract::Context;
     /// use blueprint_tangle_testing_utils::TangleTestHarness;
     /// use tempfile::TempDir;
@@ -235,7 +235,7 @@ where
     ///
     /// # Examples
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// use blueprint_core::extract::Context;
     /// use blueprint_tangle_testing_utils::TangleTestHarness;
     /// use tempfile::TempDir;


### PR DESCRIPTION
Closes #778
This pull request includes an addition to the `crates/tangle-extra/src/metadata/job_definition.rs` file. The change implements the `IntoTangleFieldTypes` trait for the `Void` type from `blueprint_core::job_result`.

Key change:

* Added an implementation of the `IntoTangleFieldTypes` trait for the `Void` type, which returns a vector containing `FieldType::Void`.