### PR TITLE
feat: impl MBSM deploy subcommand

### DIFF
--- a/cli/src/command/deploy/mbsm.rs
+++ b/cli/src/command/deploy/mbsm.rs
@@ -1,0 +1,115 @@
+use blueprint_chain_setup::tangle::transactions;
+use blueprint_contexts::tangle::TangleClientContext;
+use blueprint_crypto::sp_core::{SpEcdsa, SpSr25519};
+use blueprint_crypto::tangle_pair_signer::TanglePairSigner;
+use blueprint_keystore::backends::Backend;
+use blueprint_testing_utils::tangle::harness::{ENDOWED_TEST_NAMES, generate_env_from_node_id};
+use dialoguer::console::style;
+use tempfile::TempDir;
+use url::Url;
+
+/// Deploy the MBSM contract to the chain
+///
+/// # Arguments
+/// * `http_rpc_url` - The URL of the HTTP RPC server
+/// * `force` - Whether to force the deployment
+///
+/// # Errors
+///
+/// Returns an error if the deployment fails
+pub async fn deploy_mbsm(http_rpc_url: String, force: bool) -> Result<(), color_eyre::Report> {
+    let temp_dir = TempDir::new()?;
+    let http_rpc_url = Url::parse(&http_rpc_url)?;
+    let mut ws_endpoint = http_rpc_url.clone();
+    ws_endpoint.set_scheme("ws").map_err(|()| {
+        color_eyre::Report::msg(format!(
+            "Failed to set the scheme of the URL to 'ws': {}",
+            ws_endpoint
+        ))
+    })?;
+
+    let temp_path = temp_dir.path().to_path_buf();
+    println!(
+        "{}",
+        style("Checking if the deployment can proceed...")
+            .cyan()
+            .bold()
+    );
+
+    // Set up Alice's environment for MBSM deployment
+    let alice_env = generate_env_from_node_id(
+        ENDOWED_TEST_NAMES[0],
+        http_rpc_url.clone(),
+        ws_endpoint.clone(),
+        temp_path.as_path(),
+    )
+    .await?;
+
+    let alice_keystore = alice_env.keystore();
+    let alice_client = alice_env.tangle_client().await?;
+
+    let alice_sr25519_public = alice_keystore.first_local::<SpSr25519>()?;
+    let alice_sr25519_pair = alice_keystore.get_secret::<SpSr25519>(&alice_sr25519_public)?;
+    let alice_sr25519_signer = TanglePairSigner::new(alice_sr25519_pair.0);
+
+    let alice_ecdsa_public = alice_keystore.first_local::<SpEcdsa>()?;
+    let alice_ecdsa_pair = alice_keystore.get_secret::<SpEcdsa>(&alice_ecdsa_public)?;
+    let alice_ecdsa_signer = TanglePairSigner::new(alice_ecdsa_pair.0);
+    let alice_alloy_key = alice_ecdsa_signer
+        .alloy_key()
+        .map_err(|e| color_eyre::Report::msg(format!("Failed to get Alice's Alloy key: {}", e)))?;
+
+    // Check if MBSM is already deployed
+    let latest_revision = transactions::get_latest_mbsm_revision(&alice_client)
+        .await
+        .map_err(|e| {
+            color_eyre::Report::msg(format!("Failed to get latest MBSM revision: {}", e))
+        })?;
+
+    match latest_revision {
+        Some((rev, addr)) if !force => {
+            println!(
+                "{}",
+                style(format!(
+                    "MBSM is already deployed at revision #{} at address {}",
+                    rev, addr
+                ))
+                .green()
+            );
+            return Ok(());
+        }
+        Some((rev, addr)) => {
+            println!(
+                "{}",
+                style(format!(
+                    "MBSM is already deployed at revision #{} at address {}",
+                    rev, addr
+                ))
+                .yellow()
+            );
+        }
+        None => {
+            println!("{}", style("MBSM is not deployed").yellow());
+        }
+    }
+
+    println!(
+        "{}",
+        style("MBSM is not deployed, deploying now with Alice's account...").cyan()
+    );
+
+    let bytecode = tnt_core_bytecode::bytecode::MASTER_BLUEPRINT_SERVICE_MANAGER;
+    transactions::deploy_new_mbsm_revision(
+        ws_endpoint.as_str(),
+        &alice_client,
+        &alice_sr25519_signer,
+        alice_alloy_key.clone(),
+        bytecode,
+        alloy_primitives::address!("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+    )
+    .await
+    .map_err(|e| color_eyre::Report::msg(format!("Failed to deploy MBSM: {}", e)))?;
+
+    println!("{}", style("MBSM deployed successfully").green());
+    Ok(())
+}

--- a/cli/src/command/deploy/mod.rs
+++ b/cli/src/command/deploy/mod.rs
@@ -1,2 +1,3 @@
 pub mod eigenlayer;
+pub mod mbsm;
 pub mod tangle;

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -1,5 +1,5 @@
 use std::path::PathBuf;
-use cargo_tangle::command::create;
+use cargo_tangle::command::{create, deploy};
 use blueprint_runner::config::{BlueprintEnvironment, Protocol, ProtocolSettings, SupportedChains};
 use blueprint_runner::eigenlayer::config::EigenlayerProtocolSettings;
 use blueprint_runner::error::ConfigError;
@@ -305,6 +305,18 @@ pub enum BlueprintCommands {
         /// Whether to wait for the job to complete
         #[arg(long)]
         watcher: bool,
+    },
+
+    /// Deploy a Master Blueprint Service Manager (MBSM) contract to the Tangle Network
+    #[command(visible_alias = "mbsm")]
+    DeployMBSM {
+        /// The HTTP RPC URL to use
+        #[arg(long, value_name = "URL", default_value = "http://127.0.0.1:9944", env)]
+        http_rpc_url: String,
+
+        /// Force deployment even if the contract is already deployed
+        #[arg(short, long, value_name = "VALUE", default_value_t = false)]
+        force: bool,
     },
 }
 
@@ -619,6 +631,12 @@ async fn main() -> color_eyre::Result<()> {
                     watcher,
                 )
                 .await?;
+            }
+            BlueprintCommands::DeployMBSM {
+                http_rpc_url,
+                force,
+            } => {
+                deploy::mbsm::deploy_mbsm(http_rpc_url, force).await?;
             }
         },
         Commands::Key { command } => match command {


### PR DESCRIPTION
This pull request introduces a new feature to deploy the Master Blueprint Service Manager (MBSM) contract to the Tangle Network. The changes include the addition of a new command, necessary imports, and the implementation of the deployment logic.

Key changes include:

### New feature: Deploy MBSM contract

* [`cli/src/command/deploy/mbsm.rs`](diffhunk://#diff-d64280036730815ccaef4af414494a85303d623322f24a92f87e6b3ad49f373cR1-R115): Implemented the `deploy_mbsm` function to handle the deployment of the MBSM contract, including setting up the environment, checking for existing deployments, and deploying the contract if necessary.

### Command additions and modifications

* [`cli/src/command/deploy/mod.rs`](diffhunk://#diff-49d413c8ed499ee753b49cf25612f3d38f9a9c6cfe0dd47817e7cb7969dfb67fR2): Added the `mbsm` module to the list of deploy commands.
* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL2-R2): Updated imports to include the new `deploy` command and added the `DeployMBSM` variant to the `BlueprintCommands` enum. [[1]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bL2-R2) [[2]](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR309-R320)

### Main function update

* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR635-R640): Modified the `async fn main()` function to handle the new `DeployMBSM` command, invoking the `deploy_mbsm` function when this command is called.

Closes #796 