### PR TITLE
feat: support all field types in the job submit subcommand

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16125,6 +16125,7 @@ version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
+ "indexmap 2.8.0",
  "itoa",
  "memchr",
  "ryu",

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -19,7 +19,7 @@ cargo-generate = { workspace = true, features = ["vendored-libgit2"] }
 tracing-subscriber = { workspace = true, features = ["env-filter", "fmt", "ansi"] }
 color-eyre = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
-serde_json = { workspace = true, features = ["alloc"] }
+serde_json = { workspace = true, features = ["alloc", "preserve_order"] }
 tokio = { workspace = true, features = ["full"] }
 hex = { workspace = true }
 tracing = { workspace = true, features = ["log"] }

--- a/cli/src/command/jobs/helpers.rs
+++ b/cli/src/command/jobs/helpers.rs
@@ -5,6 +5,7 @@ use color_eyre::eyre::bail;
 use dialoguer::console::style;
 use serde_json;
 use std::str::FromStr;
+use tangle_subxt::FieldExt;
 use tangle_subxt::subxt::utils::AccountId32;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::FieldType;
 
@@ -158,6 +159,10 @@ pub(crate) fn load_job_args_from_file(
                 bail!("Error parsing argument at position {i} of type {param_type:?}: {e}");
             }
         };
+        let input_ty = input_value.field_type();
+        if &input_ty != param_type {
+            bail!("Argument at position {i} has type {input_ty:?} but expected {param_type:?}");
+        }
         input_values.push(input_value);
     }
 


### PR DESCRIPTION
Using our `blueprint_serde` would make things more easier to work with in the future.

---
This pull request includes significant changes to the `cli/src/command/jobs/helpers.rs` file, primarily to improve the handling of job arguments and simplify the codebase. The most important changes include adding new imports, refactoring the `load_job_args_from_file` function to use a more concise approach for parsing arguments, and improving error handling.

Improvements to argument parsing and error handling:

* [`cli/src/command/jobs/helpers.rs`](diffhunk://#diff-d7f6f99b1e6d83c89dbe474542f982a31d8aa55d2d57009fbd80807af0676695L2-R8): Added new imports `to_field` and `bail` to streamline the parsing process and improve error handling.
* [`cli/src/command/jobs/helpers.rs`](diffhunk://#diff-d7f6f99b1e6d83c89dbe474542f982a31d8aa55d2d57009fbd80807af0676695L154-R165): Refactored the `load_job_args_from_file` function to use `to_field` for parsing arguments, significantly reducing the code complexity and improving maintainability. This change also includes enhanced error messages for better debugging.