### PR TITLE
feat(blueprint-serde): partial map support

### DIFF
--- a/crates/tangle-extra/src/serde/error.rs
+++ b/crates/tangle-extra/src/serde/error.rs
@@ -45,6 +45,7 @@ pub enum UnsupportedType {
 
 #[derive(Debug)]
 pub enum Error {
+    BadMapKey,
     UnsupportedType(UnsupportedType),
     /// Attempting to deserialize a [`char`] from a [`Field::String`](super::Field::String)
     BadCharLength(usize),
@@ -74,6 +75,7 @@ impl From<alloc::string::FromUtf8Error> for Error {
 impl Display for Error {
     fn fmt(&self, f: &mut Formatter<'_>) -> core::fmt::Result {
         match self {
+            Error::BadMapKey => write!(f, "Map keys must be strings"),
             Error::UnsupportedType(unsupported_type) => {
                 write!(f, "Type `{:?}` unsupported", unsupported_type)
             }

--- a/crates/tangle-extra/src/serde/ser.rs
+++ b/crates/tangle-extra/src/serde/ser.rs
@@ -368,7 +368,11 @@ pub struct SerializeMap<'a> {
 
 impl<'a> SerializeMap<'a> {
     fn new(ser: &'a mut Serializer) -> Self {
-        Self { ser, keys: Vec::new(), values: Vec::new() }
+        Self {
+            ser,
+            keys: Vec::new(),
+            values: Vec::new(),
+        }
     }
 }
 
@@ -382,7 +386,7 @@ impl ser::SerializeMap for SerializeMap<'_> {
     {
         let key = key.serialize(&mut *self.ser)?;
         let Field::String(string) = key else {
-            return Err(super::error::Error::BadMapKey)
+            return Err(super::error::Error::BadMapKey);
         };
 
         self.keys.push(string);
@@ -399,10 +403,15 @@ impl ser::SerializeMap for SerializeMap<'_> {
     }
 
     fn end(self) -> Result<Self::Ok> {
-        let fields = self.keys.into_iter().zip(self.values.into_iter()).collect::<Vec<_>>();
-        Ok(Field::Struct(new_bounded_string(""), Box::new(BoundedVec(
-            fields
-        ))))
+        let fields = self
+            .keys
+            .into_iter()
+            .zip(self.values.into_iter())
+            .collect::<Vec<_>>();
+        Ok(Field::Struct(
+            new_bounded_string(""),
+            Box::new(BoundedVec(fields)),
+        ))
     }
 }
 

--- a/crates/tangle-extra/src/serde/ser.rs
+++ b/crates/tangle-extra/src/serde/ser.rs
@@ -24,7 +24,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     type SerializeTuple = Self::SerializeSeq;
     type SerializeTupleStruct = SerializeTupleStruct<'a>;
     type SerializeTupleVariant = ser::Impossible<Self::Ok, Self::Error>;
-    type SerializeMap = ser::Impossible<Self::Ok, Self::Error>;
+    type SerializeMap = SerializeMap<'a>;
     type SerializeStruct = SerializeStruct<'a>;
     type SerializeStructVariant = ser::Impossible<Self::Ok, Self::Error>;
 
@@ -178,7 +178,7 @@ impl<'a> serde::Serializer for &'a mut Serializer {
     }
 
     fn serialize_map(self, _len: Option<usize>) -> Result<Self::SerializeMap> {
-        Err(Self::Error::UnsupportedType(UnsupportedType::Map))
+        Ok(SerializeMap::new(self))
     }
 
     fn serialize_struct(self, name: &'static str, len: usize) -> Result<Self::SerializeStruct> {
@@ -357,6 +357,52 @@ impl ser::SerializeStruct for SerializeStruct<'_> {
             new_bounded_string(self.name),
             Box::new(BoundedVec(self.fields)),
         ))
+    }
+}
+
+pub struct SerializeMap<'a> {
+    ser: &'a mut Serializer,
+    keys: Vec<BoundedString>,
+    values: Vec<Field<AccountId32>>,
+}
+
+impl<'a> SerializeMap<'a> {
+    fn new(ser: &'a mut Serializer) -> Self {
+        Self { ser, keys: Vec::new(), values: Vec::new() }
+    }
+}
+
+impl ser::SerializeMap for SerializeMap<'_> {
+    type Ok = Field<AccountId32>;
+    type Error = super::error::Error;
+
+    fn serialize_key<T>(&mut self, key: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let key = key.serialize(&mut *self.ser)?;
+        let Field::String(string) = key else {
+            return Err(super::error::Error::BadMapKey)
+        };
+
+        self.keys.push(string);
+        Ok(())
+    }
+
+    fn serialize_value<T>(&mut self, value: &T) -> Result<()>
+    where
+        T: ?Sized + Serialize,
+    {
+        let value = value.serialize(&mut *self.ser)?;
+        self.values.push(value);
+        Ok(())
+    }
+
+    fn end(self) -> Result<Self::Ok> {
+        let fields = self.keys.into_iter().zip(self.values.into_iter()).collect::<Vec<_>>();
+        Ok(Field::Struct(new_bounded_string(""), Box::new(BoundedVec(
+            fields
+        ))))
     }
 }
 

--- a/crates/tangle-extra/src/serde/tests.rs
+++ b/crates/tangle-extra/src/serde/tests.rs
@@ -457,6 +457,23 @@ mod maps {
         let err = to_field(&map).unwrap_err();
         assert!(matches!(err, Error::BadMapKey));
     }
+
+    #[test]
+    fn test_ser_nested_map() {
+        let mut map = HashMap::new();
+        map.insert("key", HashMap::<String, String>::new());
+        let field = to_field(&map).unwrap();
+        assert_eq!(
+            field,
+            Field::Struct(
+                new_bounded_string(""),
+                Box::new(BoundedVec(vec![(
+                    new_bounded_string("key"),
+                    Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![])))
+                )]))
+            )
+        );
+    }
 }
 
 mod primitives {

--- a/crates/tangle-extra/src/serde/tests.rs
+++ b/crates/tangle-extra/src/serde/tests.rs
@@ -400,20 +400,23 @@ mod enums {
 }
 
 mod maps {
-    use std::collections::HashMap;
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn test_ser_map_empty() {
         let map: HashMap<String, String> = HashMap::new();
         let field = to_field(&map).unwrap();
-        assert_eq!(field, Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![]))));
+        assert_eq!(
+            field,
+            Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![])))
+        );
     }
 
     #[test]
     fn test_de_map_empty() {
         let field = Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![])));
-        let res  = from_field::<HashMap<String, String>>(field);
+        let res = from_field::<HashMap<String, String>>(field);
         assert!(res.is_err(), "direct map deserialization should fail");
     }
 
@@ -422,16 +425,27 @@ mod maps {
         let mut map = HashMap::new();
         map.insert("key".to_string(), "value".to_string());
         let field = to_field(&map).unwrap();
-        assert_eq!(field, Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![
-            (new_bounded_string("key"), Field::String(new_bounded_string("value"))),
-        ]))));
+        assert_eq!(
+            field,
+            Field::Struct(
+                new_bounded_string(""),
+                Box::new(BoundedVec(vec![(
+                    new_bounded_string("key"),
+                    Field::String(new_bounded_string("value"))
+                ),]))
+            )
+        );
     }
 
     #[test]
     fn test_de_map() {
-        let field = Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![
-            (new_bounded_string("key"), Field::String(new_bounded_string("value"))),
-        ])));
+        let field = Field::Struct(
+            new_bounded_string(""),
+            Box::new(BoundedVec(vec![(
+                new_bounded_string("key"),
+                Field::String(new_bounded_string("value")),
+            )])),
+        );
         let res = from_field::<HashMap<String, String>>(field);
         assert!(res.is_err(), "direct map deserialization should fail");
     }

--- a/crates/tangle-extra/src/serde/tests.rs
+++ b/crates/tangle-extra/src/serde/tests.rs
@@ -399,6 +399,52 @@ mod enums {
     }
 }
 
+mod maps {
+    use std::collections::HashMap;
+    use super::*;
+
+    #[test]
+    fn test_ser_map_empty() {
+        let map: HashMap<String, String> = HashMap::new();
+        let field = to_field(&map).unwrap();
+        assert_eq!(field, Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![]))));
+    }
+
+    #[test]
+    fn test_de_map_empty() {
+        let field = Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![])));
+        let res  = from_field::<HashMap<String, String>>(field);
+        assert!(res.is_err(), "direct map deserialization should fail");
+    }
+
+    #[test]
+    fn test_ser_map() {
+        let mut map = HashMap::new();
+        map.insert("key".to_string(), "value".to_string());
+        let field = to_field(&map).unwrap();
+        assert_eq!(field, Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![
+            (new_bounded_string("key"), Field::String(new_bounded_string("value"))),
+        ]))));
+    }
+
+    #[test]
+    fn test_de_map() {
+        let field = Field::Struct(new_bounded_string(""), Box::new(BoundedVec(vec![
+            (new_bounded_string("key"), Field::String(new_bounded_string("value"))),
+        ])));
+        let res = from_field::<HashMap<String, String>>(field);
+        assert!(res.is_err(), "direct map deserialization should fail");
+    }
+
+    #[test]
+    fn test_ser_non_string_key() {
+        let mut map = HashMap::new();
+        map.insert(1, "value".to_string());
+        let err = to_field(&map).unwrap_err();
+        assert!(matches!(err, Error::BadMapKey));
+    }
+}
+
 mod primitives {
     use super::*;
 


### PR DESCRIPTION
This just converts maps into unnamed `Field::Struct`s. That means that map keys must be strings.

So we don't *really* support maps, this is really just a hack for supporting JSON object conversions.