### PR TITLE
fix: job call rejections should be errors

### DIFF
--- a/crates/core/src/macros.rs
+++ b/crates/core/src/macros.rs
@@ -9,7 +9,7 @@ macro_rules! __log_rejection {
     ) => {
         {
             $crate::__private::tracing::event!(
-                target: "gadget::rejection",
+                target: "blueprint-rejection",
                 $crate::__private::tracing::Level::TRACE,
                 body = $body_text,
                 rejection_type = ::core::any::type_name::<$ty>(),
@@ -234,7 +234,7 @@ macro_rules! __define_rejection {
                     rejection_type = $name,
                     body_text = $body
                 );
-                $body.into_job_result()
+                Some($crate::JobResult::Err($crate::error::Error::new(self)))
             }
         }
 
@@ -285,7 +285,7 @@ macro_rules! __define_rejection {
                     rejection_type = $name,
                     body_text = body_text
                 );
-                body_text.into_job_result()
+                Some($crate::JobResult::Err($crate::error::Error::new(self)))
             }
         }
 


### PR DESCRIPTION
This pull request includes changes to the `crates/core/src/macros.rs` file to update the logging target and modify the handling of job results in rejection macros. The most important changes are as follows:

Updates to logging target:

* Changed the logging target from `"gadget::rejection"` to `"blueprint-rejection"` in the `__log_rejection` macro.

Modifications to job result handling:

* Updated the `__define_rejection` macro to return a `JobResult::Err` with a new error instance instead of calling `into_job_result` on the body text. This change was applied in two places within the macro. [[1]](diffhunk://#diff-9f9d78b0be0c65a06b06bd5419f768554061d5af427860a9baa1d7b4be19dcb8L237-R237) [[2]](diffhunk://#diff-9f9d78b0be0c65a06b06bd5419f768554061d5af427860a9baa1d7b4be19dcb8L288-R288)
----

Closes #806