### PR TITLE
chore: pin workspace to 1.85

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 homepage = "https://tangle.tools"
 repository = "https://github.com/tangle-network/blueprint"
+rust-version = "1.85" # Update the rust-toolchain.toml as well
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/benchmarking/Cargo.toml
+++ b/crates/benchmarking/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/chain-setup/Cargo.toml
+++ b/crates/chain-setup/Cargo.toml
@@ -7,7 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-publish = false
+rust-version.workspace = true
 
 [dependencies]
 blueprint-chain-setup-tangle = { workspace = true, optional = true }

--- a/crates/chain-setup/anvil/Cargo.toml
+++ b/crates/chain-setup/anvil/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/chain-setup/common/Cargo.toml
+++ b/crates/chain-setup/common/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/chain-setup/tangle/Cargo.toml
+++ b/crates/chain-setup/tangle/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/clients/Cargo.toml
+++ b/crates/clients/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/clients/core/Cargo.toml
+++ b/crates/clients/core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/clients/eigenlayer/Cargo.toml
+++ b/crates/clients/eigenlayer/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/clients/evm/Cargo.toml
+++ b/crates/clients/evm/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,8 +1,13 @@
 [package]
 name = "blueprint-core"
 version = "0.1.0"
-edition.workspace = true
 description = "Blueprint SDK Core functionality"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 bytes.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-crypto-core = { path = "core" }

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-crypto-core = { workspace = true, features = ["bls"] }

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-crypto-core = { workspace = true, features = ["bn254"] }

--- a/crates/crypto/core/Cargo.toml
+++ b/crates/crypto/core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/crypto/ed25519/Cargo.toml
+++ b/crates/crypto/ed25519/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-crypto-core = { workspace = true, features = ["zebra"] }

--- a/crates/crypto/hashing/Cargo.toml
+++ b/crates/crypto/hashing/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/crypto/k256/Cargo.toml
+++ b/crates/crypto/k256/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-crypto-core = { workspace = true, features = ["k256"] }

--- a/crates/crypto/sp-core/Cargo.toml
+++ b/crates/crypto/sp-core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/crypto/sr25519/Cargo.toml
+++ b/crates/crypto/sr25519/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-crypto-core = { workspace = true, features = ["sr25519-schnorrkel"] }

--- a/crates/crypto/tangle-pair-signer/Cargo.toml
+++ b/crates/crypto/tangle-pair-signer/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-std = { workspace = true }

--- a/crates/eigenlayer-extra/Cargo.toml
+++ b/crates/eigenlayer-extra/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/evm-extra/Cargo.toml
+++ b/crates/evm-extra/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -2,9 +2,12 @@
 name = "blueprint-macros"
 version = "0.1.0"
 description = "Macros for the Tangle Blueprint SDK"
+authors.workspace = true
 edition.workspace = true
-homepage.workspace = true
 license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/macros/context-derive/Cargo.toml
+++ b/crates/macros/context-derive/Cargo.toml
@@ -1,12 +1,13 @@
 [package]
 name = "blueprint-context-derive"
 version = "0.3.1"
+description = "Procedural macros for deriving Context Extension traits from blueprint-sdk"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
-description = "Procedural macros for deriving Context Extension traits from blueprint-sdk"
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -158,7 +158,7 @@ pub fn load_abi(input: TokenStream) -> TokenStream {
 //  xx |     pub async fn my_job(TangleArg(_): TangleArg<u64>)  {}
 //     |                                   ^^^^ not found in this scope
 /// ```
-/// 
+///
 /// # Performance
 ///
 /// This macro has no effect when compiled with the release profile. (eg. `cargo build --release`)

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/metrics/rpc-calls/Cargo.toml
+++ b/crates/metrics/rpc-calls/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/networking/Cargo.toml
+++ b/crates/networking/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/networking/extensions/round-based/Cargo.toml
+++ b/crates/networking/extensions/round-based/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/producers-extra/Cargo.toml
+++ b/crates/producers-extra/Cargo.toml
@@ -1,10 +1,12 @@
 [package]
 name = "blueprint-producers-extra"
 version = "0.1.0"
+authors.workspace = true
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true
-authors.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "blueprint-router"
 version = "0.1.0"
+authors.workspace = true
 edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "blueprint-runner"
 version = "0.1.0"
+authors.workspace = true
 edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/std/Cargo.toml
+++ b/crates/std/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/stores/Cargo.toml
+++ b/crates/stores/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/stores/local-database/Cargo.toml
+++ b/crates/stores/local-database/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "blueprint-store-local-database"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/stores/local-database/src/lib.rs
+++ b/crates/stores/local-database/src/lib.rs
@@ -7,7 +7,7 @@ use blueprint_std::collections::HashMap;
 use blueprint_std::fs;
 use blueprint_std::path::{Path, PathBuf};
 use blueprint_std::sync::Mutex;
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{Serialize, de::DeserializeOwned};
 
 /// A local database for storing key-value pairs.
 ///

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -6,6 +6,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/testing-utils/anvil/Cargo.toml
+++ b/crates/testing-utils/anvil/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/testing-utils/core/Cargo.toml
+++ b/crates/testing-utils/core/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -7,6 +7,7 @@ edition.workspace = true
 license.workspace = true
 homepage.workspace = true
 repository.workspace = true
+rust-version.workspace = true
 
 [lints]
 workspace = true

--- a/examples/incredible-squaring/Cargo.lock
+++ b/examples/incredible-squaring/Cargo.lock
@@ -7486,7 +7486,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-bin"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blueprint-sdk",
  "incredible-squaring-blueprint-lib",
@@ -7498,7 +7498,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-lib"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "blueprint-sdk",
  "color-eyre",

--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -6,6 +6,7 @@ members = ["incredible-squaring-lib", "incredible-squaring-bin"]
 version = "0.1.1"
 description = "An experimental blueprint"
 edition = "2024"
+rust-version = "1.85"
 
 [workspace.dependencies]
 incredible-squaring-blueprint-lib = { path = "incredible-squaring-lib" }

--- a/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "incredible-squaring-blueprint-bin"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 incredible-squaring-blueprint-lib.workspace = true

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
-version = "0.1.0"
-edition = "2024"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
 
 [dependencies]
 blueprint-sdk = { workspace = true, features = ["std", "tangle", "macros"] }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "nightly"
+channel = "1.85" # Update the workspace rust-version as well
 components = ["rustfmt", "clippy", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
Since we don't rely on `rustdoc-types` for metadata anymore, we can pin to the latest stable. All crates have an explicit minimum `rust-version` of 1.85, and the toolchain was downgraded to 1.85.