### PR TITLE
chore(ci): use nightly rustfmt

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Install Rust
         uses: actions-rs/toolchain@v1
         with:
-          toolchain: stable
+          toolchain: nightly
           components: rustfmt
 
       - name: Check Formatting
-        run: cargo fmt -- --check
+        run: cargo +nightly fmt -- --check
 
   linting:
     timeout-minutes: 120

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -158,7 +158,7 @@ pub fn load_abi(input: TokenStream) -> TokenStream {
 //  xx |     pub async fn my_job(TangleArg(_): TangleArg<u64>)  {}
 //     |                                   ^^^^ not found in this scope
 /// ```
-///
+/// 
 /// # Performance
 ///
 /// This macro has no effect when compiled with the release profile. (eg. `cargo build --release`)


### PR DESCRIPTION
Since we use on some nightly options. They get ignored in CI currently.