### PR TITLE
feat: add support for substrate keystore backend.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3193,16 +3193,21 @@ dependencies = [
  "gcloud-sdk",
  "hex",
  "k256",
+ "parity-scale-codec",
  "parking_lot 0.12.3",
  "paste",
  "ripemd",
  "rust-bls-bn254",
+ "sc-keystore",
+ "scale-info",
  "schnorrkel",
  "serde",
  "serde_bytes",
  "serde_json",
+ "sp-application-crypto",
  "sp-core",
  "sp-io",
+ "sp-keystore",
  "tangle-subxt",
  "tempfile",
  "thiserror 2.0.12",
@@ -15893,6 +15898,21 @@ dependencies = [
  "sp-runtime-interface",
  "sp-wasm-interface",
  "wasmtime",
+]
+
+[[package]]
+name = "sc-keystore"
+version = "33.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ebd4b5b5713006117641c049cb082e8a439dd6ac5e7b171e5cef5ce1c9f8af8"
+dependencies = [
+ "array-bytes",
+ "parking_lot 0.12.3",
+ "serde_json",
+ "sp-application-crypto",
+ "sp-core",
+ "sp-keystore",
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,6 +125,11 @@ round-based = { version = "0.4.1", default-features = false }
 sp-core = { version = "34.0.0", default-features = false }
 sp-io = { version = "38.0.0", default-features = false }
 sp-runtime = { version = "39.0.0", default-features = false }
+sp-keystore = { version = "0.40.0", default-features = false }
+sc-keystore = { version = "33.0.0", default-features = false }
+sp-application-crypto = { version = "38.0.0", default-features = false }
+scale-info = { version = "2.11", default-features = false }
+parity-scale-codec = { version = "3.6", default-features = false }
 
 # Async & Runtime
 crossbeam = { version = "0.8", default-features = false }

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -63,6 +63,13 @@ aws-sdk-kms = { workspace = true, optional = true }
 gcloud-sdk = { workspace = true, features = ["google-cloud-kms-v1"], optional = true }
 ripemd = { workspace = true, optional = true }
 
+# Substrate Keystore backend
+sp-keystore = { workspace = true, optional = true }
+sc-keystore = { workspace = true, optional = true }
+sp-application-crypto = { workspace = true, optional = true }
+scale-info = { workspace = true, optional = true }
+parity-scale-codec = { workspace = true, optional = true }
+
 [dev-dependencies]
 tempfile = { workspace = true }
 
@@ -71,36 +78,37 @@ default = ["std", "tangle-full", "eigenlayer-full", "all-remote-signers"]
 
 # Core features
 std = [
-	# Basic std dependencies
-	"dep:serde_json",
-	"serde/std",
-	"serde_bytes/std",
-	"hex/std",
-	"zeroize/std",
-	"blueprint-crypto/std",
-	"blueprint-std/std",
-	"thiserror/std",
-	"dep:tokio",
-	# Conditional std enables for misc
-	"hex?/std",
-	# Condition std enables for alloy
-	"alloy-primitives?/std",
-	# Conditional std enables for crypto
-	"k256?/std",
-	"schnorrkel?/std",
-	"ed25519-zebra?/std",
-	"tnt-bls?/std",
-	"rust-bls-bn254?/std",
-	# Conditional std enables for protocols
-	"alloy-primitives?/std",
-	"sp-core?/std",
-	"sp-io?/std",
-	"tangle-subxt/std",
-	"ark-serialize?/std",
+    # Basic std dependencies
+    "dep:serde_json",
+    "serde/std",
+    "serde_bytes/std",
+    "hex/std",
+    "zeroize/std",
+    "blueprint-crypto/std",
+    "blueprint-std/std",
+    "thiserror/std",
+    "dep:tokio",
+    # Conditional std enables for misc
+    "hex?/std",
+    # Condition std enables for alloy
+    "alloy-primitives?/std",
+    # Conditional std enables for crypto
+    "k256?/std",
+    "schnorrkel?/std",
+    "ed25519-zebra?/std",
+    "tnt-bls?/std",
+    "rust-bls-bn254?/std",
+    # Conditional std enables for protocols
+    "alloy-primitives?/std",
+    "sp-core?/std",
+    "sp-io?/std",
+    "tangle-subxt/std",
+    "ark-serialize?/std",
+    # Conditional std enables for sp-*
+    "sp-keystore?/std",
+    "sp-application-crypto?/std",
 ]
-web = [
-	"tangle-subxt/web",
-]
+web = ["tangle-subxt/web"]
 
 # Crypto primitive features
 ecdsa = ["dep:k256", "dep:ripemd", "dep:hex", "blueprint-crypto/k256"]
@@ -111,41 +119,25 @@ bn254 = ["dep:ark-bn254", "dep:ark-ec", "dep:ark-ff", "dep:ark-serialize", "blue
 sp-core = ["dep:sp-core", "blueprint-crypto/sp-core"]
 
 # Meant to be used in conjunction with `tangle` feature (for `sp-core`)
-substrate = ["dep:paste", "dep:sp-core", "dep:sp-io", "dep:tangle-subxt", "blueprint-crypto/sp-core"]
+substrate = [
+    "dep:paste",
+    "dep:sp-core",
+    "dep:sp-io",
+    "dep:tangle-subxt",
+    "blueprint-crypto/sp-core",
+    "substrate-keystore",
+]
 
 # Protocol features
-evm = [
-	"ecdsa",
-	"dep:alloy-primitives",
-	"dep:alloy-signer",
-	"dep:alloy-signer-local",
-	"dep:alloy-network",
-]
+evm = ["ecdsa", "dep:alloy-primitives", "dep:alloy-signer", "dep:alloy-signer-local", "dep:alloy-network"]
 
-tangle = [
-	"substrate",
-	"ecdsa",
-	"sr25519-schnorrkel",
-	"zebra",
-	"blueprint-crypto/tangle-pair-signer",
-]
+tangle = ["substrate", "ecdsa", "sr25519-schnorrkel", "zebra", "blueprint-crypto/tangle-pair-signer"]
 
-tangle-bls = [
-	"tangle",
-	"sp-core/bls-experimental",
-	"blueprint-crypto/sp-core-bls",
-]
+tangle-bls = ["tangle", "sp-core/bls-experimental", "blueprint-crypto/sp-core-bls"]
 
-eigenlayer = [
-	"evm",
-	"dep:eigensdk",
-	"dep:rust-bls-bn254",
-	"bn254",
-]
+eigenlayer = ["evm", "dep:eigensdk", "dep:rust-bls-bn254", "bn254"]
 
-symbiotic = [
-	"evm",
-]
+symbiotic = ["evm"]
 
 remote = []
 
@@ -153,6 +145,14 @@ remote = []
 tangle-full = ["tangle", "tangle-bls", "bn254", "evm"]
 eigenlayer-full = ["eigenlayer", "sr25519-schnorrkel", "zebra", "bls"]
 symbiotic-full = ["symbiotic", "sr25519-schnorrkel", "zebra", "bls", "bn254"]
+substrate-keystore = [
+    "dep:sp-keystore",
+    "dep:sc-keystore",
+    "dep:sp-core",
+    "dep:sp-application-crypto",
+    "dep:scale-info",
+    "dep:parity-scale-codec",
+]
 
 # Hardware/Cloud wallet support
 aws-signer = ["remote", "alloy-signer-aws", "aws-config", "aws-sdk-kms", "evm", "std"]

--- a/crates/keystore/src/error.rs
+++ b/crates/keystore/src/error.rs
@@ -26,6 +26,9 @@ pub enum Error {
     /// Key type not supported
     #[error("Key type not supported")]
     KeyTypeNotSupported,
+    /// Keystore operation not supported
+    #[error("Keystore operation not supported")]
+    KeystoreOperationNotSupported,
     /// Key not found
     #[error("Key not found")]
     KeyNotFound,
@@ -106,6 +109,11 @@ pub enum Error {
     #[error(transparent)]
     #[cfg(feature = "evm")]
     LocalSignerError(#[from] alloy_signer_local::LocalSignerError),
+
+    /// An error occurred during the keystore operation
+    #[error("sp-keystore error")]
+    #[cfg(feature = "substrate-keystore")]
+    SpKeystoreError,
 }
 
 #[macro_export]

--- a/crates/keystore/src/storage/mod.rs
+++ b/crates/keystore/src/storage/mod.rs
@@ -11,6 +11,10 @@ mod fs;
 pub use fs::FileStorage;
 mod in_memory;
 pub use in_memory::InMemoryStorage;
+#[cfg(feature = "substrate-keystore")]
+mod substrate;
+#[cfg(feature = "substrate-keystore")]
+pub use substrate::SubstrateStorage;
 
 // Raw storage trait that can be made into a trait object
 #[allow(missing_docs, clippy::missing_errors_doc)] // TODO: determine if this should be doc(hidden)

--- a/crates/keystore/src/storage/substrate.rs
+++ b/crates/keystore/src/storage/substrate.rs
@@ -1,0 +1,248 @@
+use super::RawStorage;
+use crate::error::Result;
+use blueprint_crypto::KeyTypeId;
+use sp_core::Pair;
+use sp_keystore::Keystore;
+/// A substrate-backed local key storage
+pub struct SubstrateStorage {
+    inner: sc_keystore::LocalKeystore,
+}
+
+mod role_ecdsa {
+    use sp_core::crypto::KeyTypeId;
+    use sp_core::ecdsa;
+
+    pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"role");
+
+    sp_application_crypto::app_crypto!(ecdsa, KEY_TYPE);
+}
+
+mod role_ed25519 {
+    use sp_core::crypto::KeyTypeId;
+    use sp_core::ed25519;
+
+    pub const KEY_TYPE: KeyTypeId = KeyTypeId(*b"role");
+
+    sp_application_crypto::app_crypto!(ed25519, KEY_TYPE);
+}
+
+mod acco_sr25519 {
+    use sp_core::crypto::KeyTypeId;
+    use sp_core::sr25519;
+
+    pub const KEY_TYPE: KeyTypeId = sp_core::crypto::key_types::ACCOUNT;
+
+    sp_application_crypto::app_crypto!(sr25519, KEY_TYPE);
+}
+
+impl SubstrateStorage {
+    #[must_use]
+    pub fn new(inner: sc_keystore::LocalKeystore) -> Self {
+        Self { inner }
+    }
+}
+
+impl RawStorage for SubstrateStorage {
+    fn store_raw(
+        &self,
+        type_id: KeyTypeId,
+        public_bytes: Vec<u8>,
+        secret_bytes: Vec<u8>,
+    ) -> Result<()> {
+        let secret = format!("0x{}", hex::encode(secret_bytes));
+        self.inner
+            .insert(sp_keystore_key_type_id_of(type_id)?, &secret, &public_bytes)
+            .map_err(|()| crate::Error::SpKeystoreError)?;
+        Ok(())
+    }
+
+    fn load_secret_raw(
+        &self,
+        type_id: KeyTypeId,
+        public_bytes: Vec<u8>,
+    ) -> Result<Option<Box<[u8]>>> {
+        match type_id {
+            #[cfg(feature = "bn254")]
+            KeyTypeId::Bn254 => Err(crate::Error::KeyTypeNotSupported),
+            #[cfg(any(feature = "ecdsa", feature = "tangle"))]
+            KeyTypeId::Ecdsa => {
+                let public = role_ecdsa::Public::try_from(public_bytes.as_slice())
+                    .map_err(|()| crate::Error::KeyTypeNotSupported)?;
+                let Ok(pair) = self.inner.key_pair::<role_ecdsa::Pair>(&public) else {
+                    return Ok(None);
+                };
+                let secret = pair.map(|pair| pair.into_inner().seed().to_vec());
+                Ok(secret.map(|s| s.into_boxed_slice()))
+            }
+            #[cfg(any(feature = "sr25519-schnorrkel", feature = "tangle"))]
+            KeyTypeId::Sr25519 => {
+                let public = acco_sr25519::Public::try_from(public_bytes.as_slice())
+                    .map_err(|()| crate::Error::KeyTypeNotSupported)?;
+                let Ok(pair) = self.inner.key_pair::<acco_sr25519::Pair>(&public) else {
+                    return Ok(None);
+                };
+                let secret = pair.map(|pair| pair.into_inner().to_raw_vec());
+                Ok(secret.map(|s| s.into_boxed_slice()))
+            }
+            #[cfg(any(feature = "bls", feature = "tangle"))]
+            KeyTypeId::Bls381 => Err(crate::Error::KeyTypeNotSupported),
+            #[cfg(any(feature = "bls", feature = "tangle"))]
+            KeyTypeId::Bls377 => Err(crate::Error::KeyTypeNotSupported),
+            #[cfg(any(feature = "zebra", feature = "tangle"))]
+            KeyTypeId::Ed25519 => {
+                let public = role_ed25519::Public::try_from(public_bytes.as_slice())
+                    .map_err(|()| crate::Error::KeyTypeNotSupported)?;
+                let Ok(pair) = self.inner.key_pair::<role_ed25519::Pair>(&public) else {
+                    return Ok(None);
+                };
+                let secret = pair.map(|pair| pair.into_inner().seed().to_vec());
+                Ok(secret.map(|s| s.into_boxed_slice()))
+            }
+            #[cfg(all(
+                not(feature = "bn254"),
+                not(feature = "ecdsa"),
+                not(feature = "sr25519-schnorrkel"),
+                not(feature = "bls"),
+                not(feature = "zebra"),
+                not(feature = "tangle")
+            ))]
+            _ => unreachable!("All possible variants are feature-gated"),
+        }
+    }
+
+    fn remove_raw(&self, _type_id: KeyTypeId, _public_bytes: Vec<u8>) -> Result<()> {
+        Err(crate::Error::KeystoreOperationNotSupported)
+    }
+
+    fn contains_raw(&self, type_id: KeyTypeId, public_bytes: Vec<u8>) -> bool {
+        let Ok(key_type) = sp_keystore_key_type_id_of(type_id) else {
+            return false;
+        };
+        let keys = [(public_bytes, key_type)];
+        self.inner.has_keys(&keys)
+    }
+
+    fn list_raw(&self, type_id: KeyTypeId) -> Box<dyn Iterator<Item = Box<[u8]>> + '_> {
+        let Ok(key_type) = sp_keystore_key_type_id_of(type_id) else {
+            return Box::new(std::iter::empty());
+        };
+        let Ok(keys) = self.inner.keys(key_type) else {
+            return Box::new(std::iter::empty());
+        };
+
+        Box::new(keys.into_iter().map(Into::into))
+    }
+}
+
+fn sp_keystore_key_type_id_of(key_type: KeyTypeId) -> Result<sp_core::crypto::KeyTypeId> {
+    match key_type {
+        #[cfg(feature = "bn254")]
+        KeyTypeId::Bn254 => Err(crate::Error::KeyTypeNotSupported),
+        #[cfg(any(feature = "ecdsa", feature = "tangle"))]
+        KeyTypeId::Ecdsa => Ok(role_ecdsa::KEY_TYPE),
+        #[cfg(any(feature = "sr25519-schnorrkel", feature = "tangle"))]
+        KeyTypeId::Sr25519 => Ok(acco_sr25519::KEY_TYPE),
+        #[cfg(any(feature = "bls", feature = "tangle"))]
+        KeyTypeId::Bls381 => Err(crate::Error::KeyTypeNotSupported),
+        #[cfg(any(feature = "bls", feature = "tangle"))]
+        KeyTypeId::Bls377 => Err(crate::Error::KeyTypeNotSupported),
+        #[cfg(any(feature = "zebra", feature = "tangle"))]
+        KeyTypeId::Ed25519 => Ok(role_ed25519::KEY_TYPE),
+        #[cfg(all(
+            not(feature = "bn254"),
+            not(feature = "ecdsa"),
+            not(feature = "sr25519-schnorrkel"),
+            not(feature = "bls"),
+            not(feature = "zebra"),
+            not(feature = "tangle")
+        ))]
+        _ => unreachable!("All possible variants are feature-gated"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use blueprint_crypto::sp_core::{SpSr25519, SpSr25519Public};
+    use blueprint_crypto::{IntoCryptoError, KeyType, k256::K256Ecdsa};
+
+    use super::*;
+    use crate::storage::TypedStorage;
+
+    #[test]
+    fn test_basic_operations() -> Result<()> {
+        let tmpdir = tempfile::tempdir()?;
+        let keystore = sc_keystore::LocalKeystore::open(tmpdir.path(), None).unwrap();
+        let raw_storage = SubstrateStorage::new(keystore);
+        let storage = TypedStorage::new(raw_storage);
+
+        // Generate a key pair
+        let secret =
+            K256Ecdsa::generate_with_seed(None).map_err(IntoCryptoError::into_crypto_error)?;
+        let public = K256Ecdsa::public_from_secret(&secret);
+
+        // Test store and load
+        storage.store::<K256Ecdsa>(&public, &secret)?;
+
+        // Test contains
+        assert!(storage.contains::<K256Ecdsa>(&public));
+
+        let loaded = storage.load::<K256Ecdsa>(&public)?;
+        assert_eq!(loaded.as_ref(), Some(&secret));
+
+        // Test list
+        let keys: Vec<_> = storage.list::<K256Ecdsa>().collect();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(&keys[0], &public);
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_key_types() -> Result<()> {
+        let tmpdir = tempfile::tempdir()?;
+        let keystore = sc_keystore::LocalKeystore::open(tmpdir.path(), None).unwrap();
+        let raw_storage = SubstrateStorage::new(keystore);
+        let storage = TypedStorage::new(raw_storage);
+
+        // Create keys of different types
+        let k256_secret =
+            K256Ecdsa::generate_with_seed(None).map_err(IntoCryptoError::into_crypto_error)?;
+        let k256_public = K256Ecdsa::public_from_secret(&k256_secret);
+
+        // Store keys
+        storage.store::<K256Ecdsa>(&k256_public, &k256_secret)?;
+
+        // Verify isolation between types
+        assert!(storage.contains::<K256Ecdsa>(&k256_public));
+
+        // List should only show keys of the requested type
+        assert_eq!(storage.list::<K256Ecdsa>().count(), 1);
+
+        Ok(())
+    }
+
+    #[test]
+    fn native_substrate_keystore_ops() -> Result<()> {
+        let tmpdir = tempfile::tempdir()?;
+        let keystore = sc_keystore::LocalKeystore::open(tmpdir.path(), None).unwrap();
+        let public = keystore
+            .sr25519_generate_new(acco_sr25519::KEY_TYPE, None)
+            .unwrap();
+        let raw_storage = SubstrateStorage::new(keystore);
+        let storage = TypedStorage::new(raw_storage);
+
+        let public = SpSr25519Public(public);
+        // Test contains
+        assert!(storage.contains::<SpSr25519>(&public));
+
+        let loaded = storage.load::<SpSr25519>(&public)?;
+        assert!(loaded.is_some());
+
+        // Test list
+        let keys: Vec<_> = storage.list::<SpSr25519>().collect();
+        assert_eq!(keys.len(), 1);
+        assert_eq!(&keys[0], &public);
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This pull request introduces a new Substrate-backed keystore implementation in the `keystore` crate. The changes include adding new dependencies, updating the error handling, and implementing the Substrate storage module.

### New Dependencies:
* Added `sp-keystore`, `sc-keystore`, `sp-application-crypto`, `scale-info`, and `parity-scale-codec` dependencies to `Cargo.toml` files. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R128-R132) [[2]](diffhunk://#diff-7bff47a0c4db54bd3e8805cca7df05e2806c3ce95877b46fb23dec51b91a9e7aR66-R72)

### Error Handling:
* Added new error variants `KeystoreOperationNotSupported` and `SpKeystoreError` to the `Error` enum in `crates/keystore/src/error.rs`. [[1]](diffhunk://#diff-ccc71ec1242979c3b8ce804075c48d56ed1b8b0891c754bae186b611219fe986R29-R31) [[2]](diffhunk://#diff-ccc71ec1242979c3b8ce804075c48d56ed1b8b0891c754bae186b611219fe986R112-R116)

### Substrate Storage Implementation:
* Introduced the `SubstrateStorage` struct in a new `substrate.rs` file, implementing the `RawStorage` trait for Substrate-backed key storage.
* Added conditional compilation for the `substrate` module in `crates/keystore/src/storage/mod.rs`.

These changes enhance the keystore crate by integrating Substrate's keystore capabilities, allowing for more versatile key management options.

Closes #833