### PR TITLE
chore: add docs for the new substrate based keystore backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 homepage = "https://tangle.tools"
 repository = "https://github.com/tangle-network/blueprint"
-rust-version = "1.85"
+rust-version = "1.86"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }

--- a/crates/keystore/src/keystore/config.rs
+++ b/crates/keystore/src/keystore/config.rs
@@ -30,7 +30,7 @@
 /// [`InMemoryStorage`]: crate::storage::InMemoryStorage
 /// [`Keystore`]: crate::Keystore
 /// [`Keystore::new()`]: crate::Keystore::new
-#[derive(Default, Debug)]
+#[derive(Default)]
 pub struct KeystoreConfig {
     pub(crate) in_memory: bool,
     #[cfg(feature = "std")]
@@ -42,6 +42,29 @@ pub struct KeystoreConfig {
         feature = "ledger-node"
     ))]
     pub(crate) remote_configs: Vec<crate::remote::RemoteConfig>,
+
+    #[cfg(feature = "substrate-keystore")]
+    pub(crate) substrate: Option<blueprint_std::sync::Arc<sc_keystore::LocalKeystore>>,
+}
+
+impl core::fmt::Debug for KeystoreConfig {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        let mut binding = f.debug_struct("KeystoreConfig");
+        let c = binding.field("in_memory", &self.in_memory);
+        #[cfg(feature = "std")]
+        let c = c.field("fs_root", &self.fs_root);
+
+        #[cfg(any(
+            feature = "aws-signer",
+            feature = "gcp-signer",
+            feature = "ledger-browser",
+            feature = "ledger-node"
+        ))]
+        let c = c.field("remote_configs", &self.remote_configs);
+        #[cfg(feature = "substrate-keystore")]
+        c.field("substrate", &"substrate");
+        c.finish()
+    }
 }
 
 impl KeystoreConfig {
@@ -107,6 +130,34 @@ impl KeystoreConfig {
     #[must_use]
     pub fn fs_root<P: AsRef<std::path::Path>>(mut self, path: P) -> Self {
         self.fs_root = Some(path.as_ref().to_path_buf());
+        self
+    }
+
+    /// Register a [`SubstrateStorage`] backend
+    /// See [`SubstrateStorage::new()`] for notes on how `keystore` is used.
+    ///
+    /// # Examples
+    ///
+    /// ```rust,no_run
+    /// use blueprint_keystore::{Keystore, KeystoreConfig};
+    /// use sc_keystore::LocalKeystore;
+    ///
+    /// # fn main() -> blueprint_keystore::Result<()> {
+    /// let keystore = LocalKeystore::in_memory();
+    /// let config = KeystoreConfig::new().substrate(keystore);
+    /// let keystore = Keystore::new(config)?;
+    /// # Ok(()) }
+    /// ```
+    ///
+    /// [`SubstrateStorage`]: crate::storage::SubstrateStorage
+    /// [`SubstrateStorage::new()`]: crate::storage::SubstrateStorage::new
+    #[cfg(feature = "substrate-keystore")]
+    #[must_use]
+    pub fn substrate(
+        mut self,
+        keystore: blueprint_std::sync::Arc<sc_keystore::LocalKeystore>,
+    ) -> Self {
+        self.substrate = Some(keystore);
         self
     }
 

--- a/crates/keystore/src/keystore/mod.rs
+++ b/crates/keystore/src/keystore/mod.rs
@@ -97,6 +97,14 @@ impl Keystore {
             }
         }
 
+        #[cfg(feature = "substrate-keystore")]
+        if let Some(inner) = config.substrate {
+            for key_type in KeyTypeId::ENABLED {
+                let backend = crate::storage::SubstrateStorage::new(inner.clone());
+                keystore.register_storage(*key_type, BackendConfig::Local(Box::new(backend)), 0)?;
+            }
+        }
+
         #[cfg(any(
             feature = "aws-signer",
             feature = "gcp-signer",

--- a/crates/keystore/src/storage/mod.rs
+++ b/crates/keystore/src/storage/mod.rs
@@ -11,6 +11,7 @@ mod fs;
 pub use fs::FileStorage;
 mod in_memory;
 pub use in_memory::InMemoryStorage;
+#[cfg(feature = "substrate-keystore")]
 mod substrate;
 /// Substrate keystore storage
 #[cfg(feature = "substrate-keystore")]

--- a/crates/keystore/src/storage/mod.rs
+++ b/crates/keystore/src/storage/mod.rs
@@ -13,6 +13,7 @@ mod in_memory;
 pub use in_memory::InMemoryStorage;
 #[cfg(feature = "substrate-keystore")]
 mod substrate;
+/// Substrate keystore storage
 #[cfg(feature = "substrate-keystore")]
 pub use substrate::SubstrateStorage;
 

--- a/crates/keystore/src/storage/mod.rs
+++ b/crates/keystore/src/storage/mod.rs
@@ -11,8 +11,6 @@ mod fs;
 pub use fs::FileStorage;
 mod in_memory;
 pub use in_memory::InMemoryStorage;
-#[cfg(feature = "substrate-keystore")]
-mod substrate;
 /// Substrate keystore storage
 #[cfg(feature = "substrate-keystore")]
 pub use substrate::SubstrateStorage;

--- a/crates/keystore/src/storage/mod.rs
+++ b/crates/keystore/src/storage/mod.rs
@@ -11,6 +11,7 @@ mod fs;
 pub use fs::FileStorage;
 mod in_memory;
 pub use in_memory::InMemoryStorage;
+mod substrate;
 /// Substrate keystore storage
 #[cfg(feature = "substrate-keystore")]
 pub use substrate::SubstrateStorage;

--- a/crates/keystore/src/storage/substrate.rs
+++ b/crates/keystore/src/storage/substrate.rs
@@ -8,7 +8,7 @@ use sp_keystore::Keystore;
 /// A substrate-backed local key storage
 ///
 /// This wrapper is used to provide a substrate-backed local key storage.
-/// It implements the `RawStorage` trait, which allows for storing and retrieving keys in a
+/// It implements the [`RawStorage`] trait, which allows for storing and retrieving keys in a
 /// substrate-compatible format.
 pub struct SubstrateStorage {
     inner: Arc<sc_keystore::LocalKeystore>,

--- a/crates/keystore/src/storage/substrate.rs
+++ b/crates/keystore/src/storage/substrate.rs
@@ -1,11 +1,33 @@
+use blueprint_std::sync::Arc;
+
 use super::RawStorage;
 use crate::error::Result;
 use blueprint_crypto::KeyTypeId;
 use sp_core::Pair;
 use sp_keystore::Keystore;
 /// A substrate-backed local key storage
+///
+/// This wrapper is used to provide a substrate-backed local key storage.
+/// It implements the `RawStorage` trait, which allows for storing and retrieving keys in a
+/// substrate-compatible format.
 pub struct SubstrateStorage {
-    inner: sc_keystore::LocalKeystore,
+    inner: Arc<sc_keystore::LocalKeystore>,
+}
+
+impl core::fmt::Debug for SubstrateStorage {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("SubstrateStorage")
+            .field("inner", &"sc_keystore::LocalKeystore")
+            .finish()
+    }
+}
+
+impl Clone for SubstrateStorage {
+    fn clone(&self) -> Self {
+        Self {
+            inner: Arc::clone(&self.inner),
+        }
+    }
 }
 
 mod role_ecdsa {
@@ -35,9 +57,21 @@ mod acco_sr25519 {
     sp_application_crypto::app_crypto!(sr25519, KEY_TYPE);
 }
 
+impl Default for SubstrateStorage {
+    fn default() -> Self {
+        let keystore = sc_keystore::LocalKeystore::in_memory();
+        Self {
+            inner: Arc::new(keystore),
+        }
+    }
+}
+
 impl SubstrateStorage {
+    /// Creates a new `SubstrateStorage` instance.
+    ///
+    /// This wrapper is used to provide a substrate-backed local key storage.
     #[must_use]
-    pub fn new(inner: sc_keystore::LocalKeystore) -> Self {
+    pub fn new(inner: Arc<sc_keystore::LocalKeystore>) -> Self {
         Self { inner }
     }
 }
@@ -162,6 +196,8 @@ fn sp_keystore_key_type_id_of(key_type: KeyTypeId) -> Result<sp_core::crypto::Ke
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use blueprint_crypto::sp_core::{SpSr25519, SpSr25519Public};
     use blueprint_crypto::{IntoCryptoError, KeyType, k256::K256Ecdsa};
 
@@ -172,7 +208,7 @@ mod tests {
     fn test_basic_operations() -> Result<()> {
         let tmpdir = tempfile::tempdir()?;
         let keystore = sc_keystore::LocalKeystore::open(tmpdir.path(), None).unwrap();
-        let raw_storage = SubstrateStorage::new(keystore);
+        let raw_storage = SubstrateStorage::new(Arc::new(keystore));
         let storage = TypedStorage::new(raw_storage);
 
         // Generate a key pair
@@ -201,7 +237,7 @@ mod tests {
     fn test_multiple_key_types() -> Result<()> {
         let tmpdir = tempfile::tempdir()?;
         let keystore = sc_keystore::LocalKeystore::open(tmpdir.path(), None).unwrap();
-        let raw_storage = SubstrateStorage::new(keystore);
+        let raw_storage = SubstrateStorage::new(Arc::new(keystore));
         let storage = TypedStorage::new(raw_storage);
 
         // Create keys of different types
@@ -228,7 +264,7 @@ mod tests {
         let public = keystore
             .sr25519_generate_new(acco_sr25519::KEY_TYPE, None)
             .unwrap();
-        let raw_storage = SubstrateStorage::new(keystore);
+        let raw_storage = SubstrateStorage::new(Arc::new(keystore));
         let storage = TypedStorage::new(raw_storage);
 
         let public = SpSr25519Public(public);

--- a/crates/networking/extensions/agg-sig-gossip/src/aggregator_selection.rs
+++ b/crates/networking/extensions/agg-sig-gossip/src/aggregator_selection.rs
@@ -272,7 +272,7 @@ impl<S: AggregatableSignature, W: SignatureWeight> SignatureAggregationProtocol<
             Ok(Some(_)) => {}
             Ok(None) => return Err(AggregationError::MissingData),
             Err(e) => return Err(e),
-        };
+        }
 
         // Check the threshold
         self.check_threshold(&result.message)?;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.85" # Update the workspace rust-version as well
+channel = "1.86"                               # Update the workspace rust-version as well
 components = ["rustfmt", "clippy", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
These are missed commits from #838 
---
This pull request includes several updates to the `keystore` module, as well as a version bump for the Rust toolchain. The most important changes involve adding support for Substrate keystore storage and updating the Rust version.

### Keystore Module Enhancements:

* Added support for Substrate keystore storage by introducing the `SubstrateStorage` struct and implementing necessary traits such as `Debug` and `Clone`. [[1]](diffhunk://#diff-31de59bda2bc18a1f2975b0c8e438830a1fe829bca0dc0d8aa961f809e58625dR45-R67) [[2]](diffhunk://#diff-315637bc7f6857287803b2efba5b300bfb22156c0767d483c1ad8aed90bad68fR1-R30) [[3]](diffhunk://#diff-315637bc7f6857287803b2efba5b300bfb22156c0767d483c1ad8aed90bad68fR60-R74)
* Implemented a new method `substrate` in `KeystoreConfig` to register a Substrate storage backend.
* Updated `Keystore` to register Substrate storage if the `substrate-keystore` feature is enabled.

### Rust Version Update:

* Updated the Rust version from `1.85` to `1.86` in both `Cargo.toml` and `rust-toolchain.toml` to ensure compatibility with the latest features and improvements. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L11-R11) [[2]](diffhunk://#diff-2b1bde2cf3a858b7bf7424cb8bcbf01f35b94dc80b925d9432cbab3319ca9b4eL2-R2)

### Code Cleanup:

* Removed the `Debug` derive macro from `KeystoreConfig` and implemented a custom `Debug` trait instead.
* Fixed a minor formatting issue in `aggregator_selection.rs`.