### PR TITLE
fix(tangle-client): allow insecure URLs

### DIFF
--- a/crates/clients/tangle/src/client.rs
+++ b/crates/clients/tangle/src/client.rs
@@ -57,7 +57,8 @@ impl TangleClient {
         let keystore = Arc::new(Keystore::new(keystore_config)?);
 
         let rpc_url = config.ws_rpc_endpoint.as_str();
-        let client = TangleServicesClient::new(subxt::OnlineClient::from_url(rpc_url).await?);
+        let client =
+            TangleServicesClient::new(subxt::OnlineClient::from_insecure_url(rpc_url).await?);
 
         // TODO: Update once keystore is updated
         let account_id = keystore

--- a/crates/macros/context-derive/src/tangle/services.rs
+++ b/crates/macros/context-derive/src/tangle/services.rs
@@ -26,7 +26,7 @@ pub fn generate_context_impl(
     quote! {
         impl #impl_generics ::blueprint_sdk::contexts::services::ServicesContext for #name #ty_generics #where_clause {
             async fn services_client(&self) -> #config_ty {
-                let rpc_client = ::blueprint_sdk::tangle_subxt::subxt::OnlineClient::from_url(
+                let rpc_client = ::blueprint_sdk::tangle_subxt::subxt::OnlineClient::from_insecure_url(
                     &#field_access_config.http_rpc_endpoint
                 )
                 .await


### PR DESCRIPTION
Necessary for containerized blueprints using local Tangle nodes, which have their RPC URLs rewritten (upcoming PR) to something that doesn't resolve to localhost.