### PR TITLE
feat: allow for blueprint manage to take a keystore.

### DIFF
--- a/cli/src/command/run/tangle.rs
+++ b/cli/src/command/run/tangle.rs
@@ -106,7 +106,7 @@ pub async fn run_blueprint(opts: RunOpts) -> Result<()> {
     pb.enable_steady_tick(Duration::from_millis(100));
 
     let mut handle =
-        run_blueprint_manager(blueprint_manager_config, gadget_config, shutdown_signal).await?;
+        run_blueprint_manager(blueprint_manager_config, gadget_config, shutdown_signal)?;
 
     pb.finish_with_message("Blueprint initialized successfully!");
 

--- a/crates/manager/src/executor/mod.rs
+++ b/crates/manager/src/executor/mod.rs
@@ -153,7 +153,7 @@ impl Future for BlueprintManagerHandle {
 #[allow(clippy::used_underscore_binding)]
 pub fn run_blueprint_manager_with_keystore<F: SendFuture<'static, ()>>(
     blueprint_manager_config: BlueprintManagerConfig,
-    keystore: &Keystore,
+    keystore: Keystore,
     env: BlueprintEnvironment,
     shutdown_cmd: F,
 ) -> color_eyre::Result<BlueprintManagerHandle> {
@@ -197,7 +197,7 @@ pub fn run_blueprint_manager_with_keystore<F: SendFuture<'static, ()>>(
     let keystore_uri = env.keystore_uri.clone();
 
     let manager_task = async move {
-        let tangle_client = TangleClient::new(env.clone()).await?;
+        let tangle_client = TangleClient::with_keystore(env.clone(), keystore).await?;
         let services_client = tangle_client.services_client();
 
         // With the basics setup, we must now implement the main logic of the Blueprint Manager
@@ -319,7 +319,7 @@ pub fn run_blueprint_manager<F: SendFuture<'static, ()>>(
 ) -> color_eyre::Result<BlueprintManagerHandle> {
     run_blueprint_manager_with_keystore(
         blueprint_manager_config,
-        &Keystore::new(KeystoreConfig::new().fs_root(&env.keystore_uri))?,
+        Keystore::new(KeystoreConfig::new().fs_root(&env.keystore_uri))?,
         env,
         shutdown_cmd,
     )


### PR DESCRIPTION
These are cherrypicked commits from https://github.com/tangle-network/blueprint/compare/main...polkadot-stable2407 that I want to upstream them.

---

This pull request introduces improvements to the `TangleClient` and `BlueprintManager` components, focusing on better modularity, enhanced error handling, and code clarity. The most significant changes include refactoring the `TangleClient` initialization process, introducing a new function for running the `BlueprintManager` with a keystore, and improving error handling in the `handle_init` function.

### Improvements to `TangleClient` Initialization:
* Refactored the `TangleClient::new` method to delegate initialization to a new `TangleClient::with_keystore` method, allowing the client to be created with an existing `Keystore`. This improves flexibility and modularity.
* Updated the `TangleClient` struct to store the `Keystore` in an `Arc`, ensuring thread-safe sharing of the keystore instance.

### Enhancements to `BlueprintManager`:
* Introduced a new `run_blueprint_manager_with_keystore` function, which allows the `BlueprintManager` to be initialized with an existing `Keystore`. This separates concerns and avoids duplicating keystore initialization logic.
* Added a wrapper function `run_blueprint_manager` that internally calls `run_blueprint_manager_with_keystore`, retaining backward compatibility while simplifying the interface for most use cases.

### Improved Error Handling:
* Enhanced the `handle_init` function to handle errors when querying operator blueprints. If the query fails, a warning is logged, and an empty vector is returned instead of propagating the error. This ensures the system can proceed gracefully in the event of a failure.

### Additional Changes:
* Updated imports in `crates/manager/src/executor/mod.rs` to include the `warn` macro for logging warnings.
* Added documentation for new and modified functions to improve code clarity and maintainability. [[1]](diffhunk://#diff-cfb6f837fafc0566c9451004344ec96889b4c7d0ea80c799e1609e1ed16bb299R138) [[2]](diffhunk://#diff-cfb6f837fafc0566c9451004344ec96889b4c7d0ea80c799e1609e1ed16bb299R295-R327)