### PR TITLE
 feat: Blueprint Runner MVP 1

### DIFF
--- a/crates/contexts/src/tangle.rs
+++ b/crates/contexts/src/tangle.rs
@@ -10,6 +10,8 @@ pub trait TangleClientContext {
 
 impl TangleClientContext for BlueprintEnvironment {
     async fn tangle_client(&self) -> Result<TangleClient, Error> {
-        TangleClient::new(self.clone()).await.map_err(Into::into)
+        TangleClient::with_keystore(self.clone(), self.keystore())
+            .await
+            .map_err(Into::into)
     }
 }

--- a/crates/runner/src/tangle/config.rs
+++ b/crates/runner/src/tangle/config.rs
@@ -6,7 +6,6 @@ use blueprint_keystore::backends::Backend;
 use blueprint_keystore::crypto::sp_core::{SpEcdsa, SpSr25519};
 use blueprint_keystore::crypto::tangle_pair_signer::pair_signer::PairSigner;
 use blueprint_keystore::crypto::tangle_pair_signer::sp_core;
-use blueprint_keystore::{Keystore, KeystoreConfig};
 use futures_util::future::select_ok;
 use k256::elliptic_curve::sec1::ToEncodedPoint;
 use serde::{Deserialize, Serialize};
@@ -119,11 +118,7 @@ pub async fn requires_registration_impl(env: &BlueprintEnvironment) -> Result<bo
     let client = get_client(env.ws_rpc_endpoint.as_str(), env.http_rpc_endpoint.as_str()).await?;
 
     // TODO: Improve key fetching logic
-    let keystore_path = env.clone().keystore_uri;
-    let keystore_config = KeystoreConfig::new()
-        .in_memory(false)
-        .fs_root(keystore_path);
-    let keystore = Keystore::new(keystore_config)?;
+    let keystore = env.keystore();
 
     // TODO: Key IDs
     let sr25519_key = keystore
@@ -162,11 +157,7 @@ pub async fn register_impl(
     let client = get_client(env.ws_rpc_endpoint.as_str(), env.http_rpc_endpoint.as_str()).await?;
 
     // TODO: Improve key fetching logic
-    let keystore_path = env.clone().keystore_uri;
-    let keystore_config = KeystoreConfig::new()
-        .in_memory(false)
-        .fs_root(keystore_path);
-    let keystore = Keystore::new(keystore_config)?;
+    let keystore = env.keystore();
 
     // TODO: Key IDs
     let sr25519_key = keystore

--- a/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
@@ -7,7 +7,7 @@ rust-version.workspace = true
 [dependencies]
 incredible-squaring-blueprint-lib.workspace = true
 
-blueprint-sdk = { workspace = true, features = ["std"] }
+blueprint-sdk = { workspace = true, features = ["std", "tangle"] }
 tokio = { workspace = true, features = ["rt-multi-thread"] }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 tracing = { workspace = true }

--- a/examples/incredible-squaring/incredible-squaring-bin/src/main.rs
+++ b/examples/incredible-squaring/incredible-squaring-bin/src/main.rs
@@ -23,8 +23,9 @@ async fn main() -> Result<(), blueprint_sdk::Error> {
     blueprint_sdk::info!("Starting the incredible squaring blueprint!");
 
     let env = BlueprintEnvironment::load()?;
-    let sr25519_signer = env.keystore().first_local::<SpSr25519>()?;
-    let sr25519_pair = env.keystore().get_secret::<SpSr25519>(&sr25519_signer)?;
+    let keystore = env.keystore();
+    let sr25519_signer = keystore.first_local::<SpSr25519>()?;
+    let sr25519_pair = keystore.get_secret::<SpSr25519>(&sr25519_signer)?;
     let st25519_signer = TanglePairSigner::new(sr25519_pair.0);
 
     let tangle_client = env.tangle_client().await?;

--- a/examples/incredible-squaring/run.sh
+++ b/examples/incredible-squaring/run.sh
@@ -93,7 +93,7 @@ check_blueprint() {
 cargo tangle blueprint deploy-mbsm
 
 # Step 6: Build the blueprint if needed
-if [ ! -f "target/debug/espresso-raas-blueprint-cli" ]; then
+if [ ! -f "target/debug/incredible-squaring-blueprint-bin" ]; then
     echo "Building blueprint..."
     cargo build --workspace
 else


### PR DESCRIPTION
This pull request refactors the handling of keystore initialization and updates dependencies and scripts to align with the changes. The most significant updates include replacing custom keystore initialization logic with a unified method, adding a new feature flag to the `blueprint-sdk` dependency, and updating a script to reflect the correct binary name.

### Keystore refactoring:

* [`crates/contexts/src/tangle.rs`](diffhunk://#diff-e28d05ce93035a44a1d269e3f7769f065cb3f88ff5c265b1706ebbe6c29db3a8L13-R15): Updated the `tangle_client` method in the `TangleClientContext` trait to use the `with_keystore` method for initializing the `TangleClient` with a keystore.
* [`crates/runner/src/tangle/config.rs`](diffhunk://#diff-2b50f1205d2b00dcc2b00b9ecaf77d5bba4e08d62d522f4f585eab983550a882L122-R121): Simplified keystore initialization in the `requires_registration_impl` and `register_impl` functions by replacing manual configuration with the `env.keystore()` method. [[1]](diffhunk://#diff-2b50f1205d2b00dcc2b00b9ecaf77d5bba4e08d62d522f4f585eab983550a882L122-R121) [[2]](diffhunk://#diff-2b50f1205d2b00dcc2b00b9ecaf77d5bba4e08d62d522f4f585eab983550a882L165-R160)

### Dependency updates:

* [`examples/incredible-squaring/incredible-squaring-bin/Cargo.toml`](diffhunk://#diff-131c6ad40a86afca737fef1231a7ce5740b7a439e8be942ba36d7e5c63d8993eL10-R10): Added the `tangle` feature to the `blueprint-sdk` dependency to enable tangle-specific functionality.

### Script update:

* [`examples/incredible-squaring/run.sh`](diffhunk://#diff-047b6db61866ae3d1693cb55e260f810889172e8515ef7a468e89bfbf7c2360fL96-R96): Corrected the binary name in the script from `espresso-raas-blueprint-cli` to `incredible-squaring-blueprint-bin`.

### Minor adjustments:

* [`examples/incredible-squaring/incredible-squaring-bin/src/main.rs`](diffhunk://#diff-3801a0f91fb25c908984150bf5965005df0a4e77757106b1c1b405b8db9be1a7L26-R28): Refactored keystore usage in the `main` function to use a local variable for improved readability.