### PR TITLE
refactor(core)!: remove `IntoJobId` trait

### DIFF
--- a/crates/core/src/extract/job_id.rs
+++ b/crates/core/src/extract/job_id.rs
@@ -34,9 +34,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
-    use crate::IntoJobId;
-
     use super::*;
 
     macro_rules! test_extract_job_id{
@@ -82,8 +79,8 @@ mod tests {
         }
     }
 
-    impl IntoJobId for MyCustomJobId {
-        fn into_job_id(self) -> crate::JobId {
+    impl From<MyCustomJobId> for crate::job_call::job_id::JobId {
+        fn from(_: MyCustomJobId) -> crate::JobId {
             42u64.into()
         }
     }

--- a/crates/core/src/job_call/job_id.rs
+++ b/crates/core/src/job_call/job_id.rs
@@ -3,32 +3,9 @@
 //! A Job Identifier is a unique identifier for each job registered with the system.
 //! It is used to identify a job and to route job calls to the appropriate job handler.
 //!
-//! A Job Id can be anything that implements `Into<JobId>`, and it is implemented for various primitive types.
+//! A job ID can be anything that implements `Into<JobId>`, and it is implemented for various primitive types.
 
 use alloc::string::ToString;
-
-/// Helper trait to convert types into `JobId`.
-///
-/// This trait can be implemented by types that can be converted into a `JobId`.
-/// Any type that implements `Into<JobId>` automatically implements this trait.
-///
-/// # Example
-/// ```
-/// use blueprint_core::IntoJobId;
-/// use blueprint_core::JobId;
-///
-/// let num: u64 = 42;
-/// let job_id = num.into_job_id(); // Convert u64 into JobId
-/// ```
-pub trait IntoJobId {
-    fn into_job_id(self) -> JobId;
-}
-
-impl<T: Into<JobId>> IntoJobId for T {
-    fn into_job_id(self) -> JobId {
-        self.into()
-    }
-}
 
 /// Job Identifier.
 #[derive(Clone, PartialEq, Eq, Hash, Copy)]
@@ -89,19 +66,19 @@ macro_rules! impl_from_numbers {
     ) => {
         $(
             impl From<$ty> for JobId {
-            #[inline]
-            fn from(value: $ty) -> Self {
-                let mut id = [0; 4];
-                id[3] = value as u64;
-                Self(id)
-            }
+                #[inline]
+                fn from(value: $ty) -> Self {
+                    let mut id = [0; 4];
+                    id[3] = value as u64;
+                    Self(id)
+                }
             }
 
             impl From<&$ty> for JobId {
-            #[inline]
-            fn from(value: &$ty) -> Self {
-                Self::from(*value)
-            }
+                #[inline]
+                fn from(value: &$ty) -> Self {
+                    Self::from(*value)
+                }
             }
 
             impl From<JobId> for $ty {

--- a/crates/core/src/job_call/mod.rs
+++ b/crates/core/src/job_call/mod.rs
@@ -1,4 +1,4 @@
-use job_id::{IntoJobId, JobId};
+use job_id::JobId;
 
 use crate::extensions::Extensions;
 use crate::metadata::{MetadataMap, MetadataValue};
@@ -60,9 +60,9 @@ pub struct Parts {
 
 impl Parts {
     /// Create a new `Parts` with the given `job_id`
-    pub fn new<J: IntoJobId>(job_id: J) -> Self {
+    pub fn new<J: Into<JobId>>(job_id: J) -> Self {
         Self {
-            job_id: job_id.into_job_id(),
+            job_id: job_id.into(),
             metadata: MetadataMap::new(),
             extensions: Extensions::new(),
         }
@@ -113,14 +113,14 @@ impl<T> JobCall<T> {
     /// # Examples
     ///
     /// ```rust
-    /// use blueprint_sdk::{IntoJobId, JobCall};
+    /// use blueprint_sdk::JobCall;
     ///
     /// const MY_JOB_ID: u8 = 0;
     ///
     /// let call = JobCall::new(MY_JOB_ID, ());
-    /// assert_eq!(call.job_id(), MY_JOB_ID.into_job_id());
+    /// assert_eq!(call.job_id(), MY_JOB_ID.into());
     /// ```
-    pub fn new<J: IntoJobId>(job_id: J, body: T) -> Self {
+    pub fn new<J: Into<JobId>>(job_id: J, body: T) -> Self {
         Self {
             head: Parts::new(job_id),
             body,
@@ -132,14 +132,14 @@ impl<T> JobCall<T> {
     /// # Examples
     ///
     /// ```rust
+    /// use blueprint_sdk::JobCall;
     /// use blueprint_sdk::job_call::Parts;
-    /// use blueprint_sdk::{IntoJobId, JobCall};
     ///
     /// const MY_JOB_ID: u8 = 0;
     /// let parts = Parts::new(MY_JOB_ID);
     ///
     /// let call = JobCall::from_parts(parts, ());
-    /// assert_eq!(call.job_id(), MY_JOB_ID.into_job_id());
+    /// assert_eq!(call.job_id(), MY_JOB_ID.into());
     /// ```
     pub fn from_parts(parts: Parts, body: T) -> Self {
         Self { head: parts, body }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -25,7 +25,7 @@ pub mod metadata;
 pub use self::error::Error;
 pub use self::ext_traits::{job_call::JobCallExt, job_call_parts::JobCallPartsExt};
 pub use self::extract::{FromJobCall, FromJobCallParts};
-pub use self::job_call::job_id::{IntoJobId, JobId};
+pub use self::job_call::job_id::JobId;
 pub use self::job_result::{IntoJobResult, IntoJobResultParts};
 pub use bytes::Bytes;
 pub use job::Job;

--- a/crates/producers-extra/src/cron.rs
+++ b/crates/producers-extra/src/cron.rs
@@ -1,5 +1,5 @@
 use blueprint_core::error::BoxError;
-use blueprint_core::{Bytes, IntoJobId, JobCall, JobId};
+use blueprint_core::{Bytes, JobCall, JobId};
 use chrono::{TimeZone, Utc};
 use core::pin::Pin;
 use core::task::Poll;
@@ -54,7 +54,7 @@ impl CronJob {
     /// Create a new [`CronJob`], using the [`Utc`] timezone
     pub async fn new<I, S>(job_id: I, schedule: S) -> Result<Self, JobSchedulerError>
     where
-        I: IntoJobId,
+        I: Into<JobId>,
         S: AsRef<str>,
     {
         Self::new_tz(job_id, schedule, Utc).await
@@ -67,7 +67,7 @@ impl CronJob {
         timezone: Tz,
     ) -> Result<Self, JobSchedulerError>
     where
-        I: IntoJobId,
+        I: Into<JobId>,
         S: AsRef<str>,
         Tz: TimeZone,
     {
@@ -85,7 +85,7 @@ impl CronJob {
         scheduler.start().await?;
 
         Ok(Self {
-            job_id: job_id.into_job_id(),
+            job_id: job_id.into(),
             _scheduler: scheduler,
             rx,
         })

--- a/crates/router/src/lib.rs
+++ b/crates/router/src/lib.rs
@@ -15,7 +15,7 @@
 //! }
 //!
 //! // Give the job some kind of ID. Many types can be converted
-//! // into a [`JobId`]. See [`IntoJobId`] for more details
+//! // into a [`JobId`]. See [`JobId`] for more details
 //! const MY_JOB_ID: u32 = 0;
 //!
 //! let router = Router::new().route(MY_JOB_ID, my_job);
@@ -27,7 +27,6 @@
 //!
 //! - [`Job`](https://docs.rs/blueprint_sdk/latest/blueprint_sdk/trait.Job.html)
 //! - [`JobId`]
-//! - [`IntoJobId`](https://docs.rs/blueprint_sdk/latest/blueprint_sdk/trait.IntoJobId.html)
 //!
 //! [`JobId`]: https://docs.rs/blueprint_sdk/latest/blueprint_sdk/struct.JobId.html
 //!

--- a/crates/router/src/routing.rs
+++ b/crates/router/src/routing.rs
@@ -5,7 +5,7 @@ use alloc::boxed::Box;
 
 use crate::job_id_router::JobIdRouter;
 use crate::util::try_downcast;
-use blueprint_core::{IntoJobId, IntoJobResult, Job, JobCall, JobResult};
+use blueprint_core::{IntoJobResult, Job, JobCall, JobId, JobResult};
 
 use alloc::sync::Arc;
 use alloc::vec::Vec;
@@ -83,7 +83,7 @@ where
     #[track_caller]
     pub fn route<I, J, T>(self, job_id: I, job: J) -> Self
     where
-        I: IntoJobId,
+        I: Into<JobId>,
         J: Job<T, Ctx>,
         T: 'static,
     {


### PR DESCRIPTION
The trait was unnecessary, just use `Into<JobId>`.