### PR TITLE
chore(ci): add `--no-verify` on publish

### DIFF
--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,6 +1,7 @@
 [workspace]
 allow_dirty = true         # allow updating repositories with uncommitted changes
 publish_allow_dirty = true # add `--allow-dirty` to `cargo publish`
+publish_no_verify = true   # add `--no-verify` to `cargo publish`
 publish_timeout = "10m"    # set a timeout for `cargo publish`
 
 [changelog]


### PR DESCRIPTION
Right now the release CI is super slow and usually requires multiple runs since it runs out of disk space.

Verification isn't necessary since CI already verifies that the crates build.