### PR TITLE
fix(blueprint-networking): use blueprint-core log macros

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3360,6 +3360,7 @@ version = "0.1.0-alpha.4"
 dependencies = [
  "alloy-primitives 0.8.25",
  "bincode",
+ "blueprint-core",
  "blueprint-crypto",
  "blueprint-crypto-core",
  "blueprint-networking",
@@ -3377,7 +3378,6 @@ dependencies = [
  "serial_test",
  "thiserror 2.0.12",
  "tokio",
- "tracing",
  "tracing-subscriber 0.3.19",
  "workspace-hack",
 ]

--- a/crates/networking/Cargo.toml
+++ b/crates/networking/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 [dependencies]
 # Internal deps
 blueprint-std = { workspace = true }
+blueprint-core = { workspace = true, features = ["tracing"] }
 
 # Core dependencies
 alloy-primitives = { workspace = true }
@@ -22,7 +23,6 @@ dashmap = { workspace = true }
 libp2p = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 futures = { workspace = true }
-tracing = { workspace = true }
 bincode = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true, features = ["alloc"] }

--- a/crates/networking/extensions/round-based/src/lib.rs
+++ b/crates/networking/extensions/round-based/src/lib.rs
@@ -1,6 +1,6 @@
+use blueprint_core::trace;
 use blueprint_crypto::KeyType;
 use blueprint_networking::{service_handle::NetworkServiceHandle, types::ProtocolMessage};
-use blueprint_core::trace;
 use futures::{Sink, Stream};
 use libp2p::PeerId;
 use round_based::{Delivery, Incoming, MessageDestination, MessageType, Outgoing, PartyIndex};

--- a/crates/networking/extensions/round-based/src/lib.rs
+++ b/crates/networking/extensions/round-based/src/lib.rs
@@ -1,5 +1,6 @@
 use blueprint_crypto::KeyType;
 use blueprint_networking::{service_handle::NetworkServiceHandle, types::ProtocolMessage};
+use blueprint_core::trace;
 use futures::{Sink, Stream};
 use libp2p::PeerId;
 use round_based::{Delivery, Incoming, MessageDestination, MessageType, Outgoing, PartyIndex};
@@ -109,7 +110,7 @@ where
             .get_whitelist_index_from_peer_id(&this.handle.local_peer_id)
             .unwrap_or_default();
 
-        tracing::trace!(
+        trace!(
             i = %party_index,
             recipient = ?outgoing.recipient,
             %round,
@@ -144,7 +145,7 @@ where
             payload: serde_json::to_vec(&outgoing.msg).map_err(NetworkError::Serialization)?,
         };
 
-        tracing::trace!(
+        trace!(
             %round,
             %msg_id,
             protocol_id = %this.protocol_id,
@@ -214,7 +215,7 @@ where
                 match sender_index {
                     Some(sender_index) => match serde_json::from_slice(&protocol_message.payload) {
                         Ok(msg) => {
-                            tracing::trace!(
+                            trace!(
                                 i = %party_index,
                                 sender = ?sender_index,
                                 %id,
@@ -233,7 +234,7 @@ where
                         Err(e) => Poll::Ready(Some(Err(NetworkError::Serialization(e)))),
                     },
                     None => {
-                        tracing::warn!(
+                        trace!(
                             i = %party_index,
                             sender = ?sender,
                             %id,
@@ -246,7 +247,7 @@ where
                 }
             }
             None => {
-                //tracing::trace!(i = %this.party_index, "No message received; the waker will wake us up when there is a new message");
+                //trace!(i = %this.party_index, "No message received; the waker will wake us up when there is a new message");
                 // In this case, tell the waker to wake us up when there is a new message
                 cx.waker().wake_by_ref();
                 Poll::Pending

--- a/crates/networking/extensions/round-based/tests/rand_protocol.rs
+++ b/crates/networking/extensions/round-based/tests/rand_protocol.rs
@@ -2,6 +2,7 @@
 
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256, digest::Output};
+use blueprint_core::{debug, error, info};
 
 use round_based::rounds_router::{
     CompleteRoundError, RoundsRouter,
@@ -59,11 +60,11 @@ where
     let mut local_randomness = [0u8; 32];
     rng.fill_bytes(&mut local_randomness);
 
-    tracing::debug!(local_randomness = %hex::encode(local_randomness), "Generated local randomness");
+    debug!(local_randomness = %hex::encode(local_randomness), "Generated local randomness");
 
     // 2. Commit local randomness (broadcast m=sha256(randomness))
     let commitment = Sha256::digest(local_randomness);
-    tracing::debug!(commitment = %hex::encode(commitment), "Committed local randomness");
+    debug!(commitment = %hex::encode(commitment), "Committed local randomness");
     outgoing
         .send(Outgoing::broadcast(Msg::CommitMsg(CommitMsg {
             commitment,
@@ -71,7 +72,7 @@ where
         .await
         .map_err(Error::Round1Send)?;
 
-    tracing::debug!("Sent commitment and waiting for others to send theirs");
+    debug!("Sent commitment and waiting for others to send theirs");
 
     // 3. Receive committed randomness from other parties
     let commitments = rounds
@@ -79,10 +80,10 @@ where
         .await
         .map_err(Error::Round1Receive)?;
 
-    tracing::debug!("Received commitments from all parties");
+    debug!("Received commitments from all parties");
 
     // 4. Open local randomness
-    tracing::debug!("Opening local randomness");
+    debug!("Opening local randomness");
     outgoing
         .send(Outgoing::broadcast(Msg::DecommitMsg(DecommitMsg {
             randomness: local_randomness,
@@ -90,7 +91,7 @@ where
         .await
         .map_err(Error::Round2Send)?;
 
-    tracing::debug!("Sent decommitment and waiting for others to send theirs");
+    debug!("Sent decommitment and waiting for others to send theirs");
 
     // 5. Receive opened local randomness from other parties, verify them, and output protocol randomness
     let randomness = rounds
@@ -98,7 +99,7 @@ where
         .await
         .map_err(Error::Round2Receive)?;
 
-    tracing::debug!("Received decommitments from all parties");
+    debug!("Received decommitments from all parties");
 
     let mut guilty_parties = vec![];
     let mut output = local_randomness;
@@ -123,11 +124,11 @@ where
     }
 
     if guilty_parties.is_empty() {
-        tracing::debug!(output = %hex::encode(output), "Generated randomness");
-        tracing::info!("Randomness generation protocol completed successfully.");
+        debug!(output = %hex::encode(output), "Generated randomness");
+        info!("Randomness generation protocol completed successfully.");
         Ok(output)
     } else {
-        tracing::error!(guilty_parties = ?guilty_parties, "Some parties cheated");
+        error!(guilty_parties = ?guilty_parties, "Some parties cheated");
         Err(Error::PartiesOpenedRandomnessDoesntMatchCommitment { guilty_parties })
     }
 }
@@ -177,7 +178,7 @@ mod tests {
     use blueprint_networking::test_utils::{create_whitelisted_nodes, wait_for_all_handshakes};
     use blueprint_networking_round_based_extension::RoundBasedNetworkAdapter;
     use round_based::MpcParty;
-    use tracing::{debug, info};
+    use blueprint_core::{debug, info};
     use tracing_subscriber::EnvFilter;
 
     use super::protocol_of_random_generation;

--- a/crates/networking/extensions/round-based/tests/rand_protocol.rs
+++ b/crates/networking/extensions/round-based/tests/rand_protocol.rs
@@ -1,8 +1,8 @@
 //! Simple protocol in which parties cooperate to generate randomness
 
+use blueprint_core::{debug, error, info};
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256, digest::Output};
-use blueprint_core::{debug, error, info};
 
 use round_based::rounds_router::{
     CompleteRoundError, RoundsRouter,
@@ -173,12 +173,12 @@ mod tests {
     use std::collections::HashMap;
     use std::time::Duration;
 
+    use blueprint_core::{debug, info};
     use blueprint_crypto::sp_core::SpEcdsa;
     use blueprint_networking::service_handle::NetworkServiceHandle;
     use blueprint_networking::test_utils::{create_whitelisted_nodes, wait_for_all_handshakes};
     use blueprint_networking_round_based_extension::RoundBasedNetworkAdapter;
     use round_based::MpcParty;
-    use blueprint_core::{debug, info};
     use tracing_subscriber::EnvFilter;
 
     use super::protocol_of_random_generation;

--- a/crates/networking/src/behaviours.rs
+++ b/crates/networking/src/behaviours.rs
@@ -8,6 +8,7 @@ use crate::{
         config::DiscoveryConfig,
     },
 };
+use blueprint_core::{debug, info};
 use blueprint_crypto::KeyType;
 use crossbeam_channel::Sender;
 use libp2p::{
@@ -23,7 +24,6 @@ use std::{
     sync::Arc,
     time::Duration,
 };
-use tracing::{debug, info};
 
 /// Events that can be emitted by the `GadgetBehavior`
 #[derive(Debug)]

--- a/crates/networking/src/blueprint_protocol/behaviour.rs
+++ b/crates/networking/src/blueprint_protocol/behaviour.rs
@@ -5,6 +5,7 @@ use crate::discovery::peers::VerificationIdentifierKey;
 use crate::discovery::utils::get_address_from_compressed_pubkey;
 use crate::types::ProtocolMessage;
 use bincode;
+use blueprint_core::{debug, error, info, warn};
 use blueprint_crypto::BytesEncoding;
 use blueprint_crypto::KeyType;
 use crossbeam_channel::Sender;
@@ -25,7 +26,6 @@ use std::{
     task::Poll,
     time::{Duration, Instant},
 };
-use tracing::{debug, error, info, warn};
 
 #[derive(NetworkBehaviour)]
 pub struct DerivedBlueprintProtocolBehaviour<K: KeyType> {

--- a/crates/networking/src/blueprint_protocol/handler.rs
+++ b/crates/networking/src/blueprint_protocol/handler.rs
@@ -1,9 +1,9 @@
 use std::time::{Duration, Instant};
 
 use alloy_primitives::Address;
+use blueprint_core::{debug, warn};
 use blueprint_crypto::{BytesEncoding, KeyType, hashing::keccak_256};
 use libp2p::{PeerId, request_response};
-use tracing::{debug, warn};
 
 use crate::blueprint_protocol::HandshakeMessage;
 use crate::discovery::peers::VerificationIdentifierKey;

--- a/crates/networking/src/discovery/behaviour.rs
+++ b/crates/networking/src/discovery/behaviour.rs
@@ -6,6 +6,7 @@ use std::{
 };
 
 use crate::error::Error;
+use blueprint_core::{debug, info, trace};
 use blueprint_crypto::KeyType;
 use libp2p::{
     autonat,
@@ -22,8 +23,6 @@ use libp2p::{
     upnp,
 };
 use tokio::time::Interval;
-use tracing::trace;
-use tracing::{debug, info};
 
 use super::PeerInfo;
 

--- a/crates/networking/src/discovery/config.rs
+++ b/crates/networking/src/discovery/config.rs
@@ -3,6 +3,7 @@ use super::{
     new_kademlia,
 };
 use crate::error::Error;
+use blueprint_core::warn;
 use blueprint_crypto::KeyType;
 use libp2p::{
     Multiaddr, PeerId, StreamProtocol, autonat, identify, identity::PublicKey, mdns, relay, upnp,
@@ -11,7 +12,6 @@ use std::{
     collections::{HashMap, HashSet, VecDeque},
     time::Duration,
 };
-use tracing::warn;
 
 pub struct DiscoveryConfig<K: KeyType> {
     /// The local peer ID.

--- a/crates/networking/src/discovery/peers.rs
+++ b/crates/networking/src/discovery/peers.rs
@@ -1,5 +1,6 @@
 use crate::service::AllowedKeys;
 use alloy_primitives::Address;
+use blueprint_core::debug;
 use blueprint_crypto::BytesEncoding;
 use blueprint_crypto::KeyType;
 use blueprint_crypto::hashing::keccak_256;
@@ -14,7 +15,6 @@ use std::{
     time::{Duration, Instant, SystemTime},
 };
 use tokio::sync::broadcast;
-use tracing::debug;
 
 use super::utils::{get_address_from_pubkey, secp256k1_ecdsa_recover};
 

--- a/crates/networking/src/service.rs
+++ b/crates/networking/src/service.rs
@@ -10,6 +10,7 @@ use crate::{
     types::ProtocolMessage,
 };
 use alloy_primitives::Address;
+use blueprint_core::{debug, info, trace, warn};
 use blueprint_crypto::KeyType;
 use crossbeam_channel::{self, Receiver, SendError, Sender};
 use futures::StreamExt;
@@ -20,8 +21,6 @@ use libp2p::{
     swarm::{SwarmEvent, dial_opts::DialOpts},
 };
 use std::{collections::HashSet, fmt::Display, sync::Arc, time::Duration};
-use tracing::trace;
-use tracing::{debug, info, warn};
 
 pub enum AllowedKeys<K: KeyType> {
     EvmAddresses(blueprint_std::collections::HashSet<Address>),

--- a/crates/networking/src/service_handle.rs
+++ b/crates/networking/src/service_handle.rs
@@ -5,12 +5,12 @@ use crate::{
     service::NetworkCommandMessage,
     types::ProtocolMessage,
 };
+use blueprint_core::debug;
 use blueprint_crypto::KeyType;
 use crossbeam_channel::{self, Receiver, Sender};
 use libp2p::{Multiaddr, PeerId};
 use std::sync::Arc;
 use tokio::task::JoinHandle;
-use tracing::debug;
 
 /// Handle for sending outgoing messages to the network
 #[derive(Clone)]

--- a/crates/networking/src/test_utils/mod.rs
+++ b/crates/networking/src/test_utils/mod.rs
@@ -1,6 +1,7 @@
 use crate::{
     NetworkConfig, NetworkService, service::AllowedKeys, service_handle::NetworkServiceHandle,
 };
+use blueprint_core::info;
 use blueprint_crypto::KeyType;
 use libp2p::{
     Multiaddr, PeerId,
@@ -8,7 +9,6 @@ use libp2p::{
 };
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
-use tracing::info;
 
 pub fn setup_log() {
     let _ = tracing_subscriber::fmt()

--- a/crates/networking/src/tests/blueprint_protocol.rs
+++ b/crates/networking/src/tests/blueprint_protocol.rs
@@ -7,12 +7,12 @@ use crate::{
     },
     types::{MessageRouting, ProtocolMessage},
 };
+use blueprint_core::info;
 use blueprint_crypto::{KeyType, sp_core::SpEcdsa};
 use libp2p::PeerId;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
-use tracing::info;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(20);
 

--- a/crates/networking/src/tests/discovery.rs
+++ b/crates/networking/src/tests/discovery.rs
@@ -2,10 +2,10 @@ use crate::test_utils::{
     create_whitelisted_nodes, setup_log, wait_for_peer_discovery, wait_for_peer_info,
 };
 use crate::{service::AllowedKeys, test_utils::TestNode};
+use blueprint_core::info;
 use blueprint_crypto::sp_core::SpEcdsa;
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
-use tracing::info;
 
 #[tokio::test]
 #[serial_test::serial]
@@ -105,7 +105,7 @@ async fn test_peer_discovery_kademlia() {
     })
     .await
     {
-        Ok(()) => println!("All peers discovered each other through Kademlia"),
+        Ok(()) => info!("All peers discovered each other through Kademlia"),
         Err(e) => panic!("Kademlia peer discovery timed out: {e}"),
     }
 }

--- a/crates/networking/src/tests/gossip.rs
+++ b/crates/networking/src/tests/gossip.rs
@@ -7,10 +7,10 @@ use crate::{
     },
     types::MessageRouting,
 };
+use blueprint_core::info;
 use blueprint_crypto::sp_core::SpEcdsa;
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
-use tracing::info;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(10);
 const NETWORK_NAME: &str = "gossip";

--- a/crates/networking/src/tests/handshake.rs
+++ b/crates/networking/src/tests/handshake.rs
@@ -2,10 +2,10 @@ use crate::service::AllowedKeys;
 use crate::test_utils::TestNode;
 use crate::test_utils::create_whitelisted_nodes;
 use crate::test_utils::setup_log;
+use blueprint_core::info;
 use blueprint_crypto::sp_core::SpEcdsa;
 use std::{collections::HashSet, time::Duration};
 use tokio::time::timeout;
-use tracing::info;
 
 const TEST_TIMEOUT: Duration = Duration::from_secs(5);
 


### PR DESCRIPTION
# Overview

Replaces tracing log macros with those in `blueprint-core`