### PR TITLE
fix(ci): redundant protoc install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,9 +47,6 @@ jobs:
       - name: Verify Forge installation
         run: forge --version
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3
-
       - name: install rust
         uses: actions-rs/toolchain@v1
         with:
@@ -140,9 +137,6 @@ jobs:
       - name: Verify Forge installation
         run: forge --version
 
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v3 
-
       - name: install rust
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -151,6 +145,11 @@ jobs:
       - uses: swatinem/rust-cache@v2
         with:
           cache-on-failure: "true"
+      
+      - name: install protobuf and gmp
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y protobuf-compiler libprotobuf-dev libgmp-dev
 
       - uses: taiki-e/install-action@v2
         with:


### PR DESCRIPTION
# Overview

Removes the redundant installation of protoc in CI. Also will solve rate limit issue causing certain checks to fail randomly.