### PR TITLE
feat: add auth proxy to blueprint manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3344,6 +3344,8 @@ name = "blueprint-manager"
 version = "0.3.0-alpha.13"
 dependencies = [
  "auto_impl",
+ "axum 0.8.4",
+ "blueprint-auth",
  "blueprint-clients",
  "blueprint-core",
  "blueprint-crypto",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,7 @@ incredible-squaring-blueprint-eigenlayer = { version = "0.1.1", path = "./exampl
 # Blueprint utils
 blueprint-manager = { version = "0.3.0-alpha.13", path = "./crates/manager", default-features = false }
 blueprint-build-utils = { version = "0.1.0-alpha.3", path = "./crates/build-utils", default-features = false }
+blueprint-auth = { version = "0.1.0-alpha.2", path = "./crates/auth", default-features = false }
 
 # Chain Setup
 blueprint-chain-setup = { version = "0.1.0-alpha.12", path = "./crates/chain-setup", default-features = false }

--- a/crates/auth/src/proxy.rs
+++ b/crates/auth/src/proxy.rs
@@ -50,10 +50,16 @@ impl AuthenticatedProxy {
             client: self.client,
         };
         Router::new()
-            .route("/auth/challenge", post(auth_challenge))
-            .route("/auth/verify", post(auth_verify))
+            .nest("/v1", Self::internal_api_router_v1())
             .fallback(any(reverse_proxy))
             .with_state(state)
+    }
+
+    /// Internal API router for version 1
+    pub fn internal_api_router_v1() -> Router<AuthenticatedProxyState> {
+        Router::new()
+            .route("/auth/challenge", post(auth_challenge))
+            .route("/auth/verify", post(auth_verify))
     }
 }
 
@@ -247,7 +253,7 @@ mod tests {
         };
 
         let res = client
-            .post("/auth/challenge")
+            .post("/v1/auth/challenge")
             .header(headers::X_SERVICE_ID, service_id.to_string())
             .json(&req)
             .await;
@@ -278,7 +284,7 @@ mod tests {
         };
 
         let res = client
-            .post("/auth/verify")
+            .post("/v1/auth/verify")
             .header(headers::X_SERVICE_ID, ServiceId::new(0).to_string())
             .json(&req)
             .await;

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -24,7 +24,9 @@ blueprint-crypto = { workspace = true, features = ["std", "tangle-pair-signer"] 
 blueprint-keystore = { workspace = true, features = ["std", "tangle"] }
 blueprint-networking = { workspace = true, features = ["std"] }
 blueprint-std = { workspace = true, features = ["std"] }
+blueprint-auth = { workspace = true, features = ["std"] }
 
+axum = { workspace = true, default-features = false, features = ["json"] }
 docktopus = { workspace = true, features = ["deploy"] }
 clap = { workspace = true, features = ["derive", "wrap_help"] }
 color-eyre = { workspace = true, features = ["tracing-error", "color-spantrace", "issue-url"] }

--- a/crates/manager/src/config.rs
+++ b/crates/manager/src/config.rs
@@ -20,7 +20,7 @@ pub static DEFAULT_DOCKER_HOST: LazyLock<Url> =
 #[derive(Debug, Parser)]
 #[command(
     name = "Blueprint Manager",
-    about = "An program executor that connects to the Tangle network and runs blueprints dynamically on the fly"
+    about = "A program executor that connects to the Tangle network and runs blueprints dynamically on the fly"
 )]
 pub struct BlueprintManagerConfig {
     /// The path to the blueprint configuration file

--- a/crates/manager/src/error.rs
+++ b/crates/manager/src/error.rs
@@ -44,4 +44,6 @@ pub enum Error {
     Request(#[from] reqwest::Error),
     #[error(transparent)]
     TangleClient(#[from] blueprint_clients::tangle::error::Error),
+    #[error(transparent)]
+    Auth(#[from] blueprint_auth::Error),
 }

--- a/crates/manager/src/executor/mod.rs
+++ b/crates/manager/src/executor/mod.rs
@@ -1,12 +1,12 @@
 use crate::blueprint::ActiveBlueprints;
-use crate::config::{BlueprintManagerConfig, SourceCandidates};
+use crate::config::{AuthProxyOpts, BlueprintManagerConfig, SourceCandidates};
 use crate::error::Error;
 use crate::error::Result;
 use crate::sdk::entry::SendFuture;
 use blueprint_clients::tangle::EventsClient;
 use blueprint_clients::tangle::client::{TangleClient, TangleConfig};
 use blueprint_clients::tangle::services::{RpcServicesWithBlueprint, TangleServicesClient};
-use blueprint_core::{info, warn};
+use blueprint_core::{error, info, warn};
 use blueprint_crypto::sp_core::{SpEcdsa, SpSr25519};
 use blueprint_crypto::tangle_pair_signer::TanglePairSigner;
 use blueprint_keystore::backends::Backend;
@@ -17,6 +17,7 @@ use color_eyre::eyre::OptionExt;
 use sp_core::{ecdsa, sr25519};
 use std::collections::HashMap;
 use std::future::Future;
+use std::path::PathBuf;
 use std::pin::Pin;
 use std::task::{Context, Poll};
 use tangle_subxt::subxt::tx::Signer;
@@ -191,6 +192,11 @@ pub async fn run_blueprint_manager_with_keystore<F: SendFuture<'static, ()>>(
     )
     .await?;
 
+    // Create the auth proxy task
+    let auth_proxy_task = run_auth_proxy(
+        data_dir.clone(),
+        blueprint_manager_config.auth_proxy_opts.clone(),
+    );
     // TODO: Actual error handling
     let (tangle_key, ecdsa_key) = {
         let sr_key_pub = keystore.first_local::<SpSr25519>()?;
@@ -284,6 +290,9 @@ pub async fn run_blueprint_manager_with_keystore<F: SendFuture<'static, ()>>(
         tokio::select! {
             res0 = manager_task => {
                 Err(Report::msg(format!("Blueprint Manager Closed Unexpectedly: {res0:?}")))
+            },
+            res1 = auth_proxy_task => {
+                Err(Report::msg(format!("Auth Proxy Closed Unexpectedly: {res1:?}")))
             },
 
             () = shutdown_task => {
@@ -398,4 +407,43 @@ async fn handle_init(
     .await?;
 
     Ok(operator_subscribed_blueprints)
+}
+
+/// Runs the authentication proxy server.
+///
+/// This function sets up and runs an authenticated proxy server that listens on the configured host and port.
+/// It creates necessary directories for the proxy's database and then starts the server.
+///
+/// # Arguments
+///
+/// * `data_dir` - The path to the data directory where the proxy's database will be stored.
+/// * `auth_proxy_opts` - Configuration options for the authentication proxy, including host and port.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - It fails to create the necessary directories for the database.
+/// - It fails to bind to the specified host and port.
+/// - The Axum server encounters an error during operation.
+async fn run_auth_proxy(data_dir: PathBuf, auth_proxy_opts: AuthProxyOpts) -> Result<()> {
+    let db_path = data_dir.join("private").join("auth-proxy").join("db");
+    tokio::fs::create_dir_all(&db_path).await?;
+
+    let proxy = blueprint_auth::proxy::AuthenticatedProxy::new(&db_path)?;
+    let router = proxy.router();
+    let listener = tokio::net::TcpListener::bind((
+        auth_proxy_opts.auth_proxy_host,
+        auth_proxy_opts.auth_proxy_port,
+    ))
+    .await?;
+    info!(
+        "Auth proxy listening on {}:{}",
+        auth_proxy_opts.auth_proxy_host, auth_proxy_opts.auth_proxy_port
+    );
+    let result = axum::serve(listener, router).await;
+    if let Err(err) = result {
+        error!("Auth proxy error: {err}");
+    }
+
+    Ok(())
 }


### PR DESCRIPTION
This pull request introduces a new authentication proxy feature to the Blueprint Manager, along with associated configuration, routing, and error handling changes. The most significant updates include adding the `blueprint-auth` crate, implementing the authentication proxy server, and updating the routing structure for API endpoints.

### Authentication Proxy Integration:

* Added the `blueprint-auth` crate dependency to both `Cargo.toml` files (`Cargo.toml` and `crates/manager/Cargo.toml`) to enable authentication proxy functionality. [[1]](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R67) [[2]](diffhunk://#diff-aca567fc21e8562c528fb2590c52ee12e11310aeb91a83964c3d7fa96e100cceR27-R29)
* Introduced the `AuthProxyOpts` struct in `crates/manager/src/config.rs` to configure the authentication proxy's host and port, with default values (`0.0.0.0:8276`). This struct was integrated into the `BlueprintManagerConfig` struct. [[1]](diffhunk://#diff-16df7b263aa6b4b070e766337cc1c9278e3b6a513db4945376f9c294c3ef31a9R64-R66) [[2]](diffhunk://#diff-16df7b263aa6b4b070e766337cc1c9278e3b6a513db4945376f9c294c3ef31a9R218-R237)
* Implemented the `run_auth_proxy` function in `crates/manager/src/executor/mod.rs` to initialize and run the authentication proxy server, which listens on the configured host and port.

### API Routing Updates:

* Refactored the API routing in `crates/auth/src/proxy.rs` to nest authentication endpoints under the `/v1` path using the new `internal_api_router_v1` method. Updated the corresponding test cases to reflect this change. [[1]](diffhunk://#diff-106118806535dd552775252baf12caa333758eb3424a450e97e83e6e52637fdeL53-R63) [[2]](diffhunk://#diff-106118806535dd552775252baf12caa333758eb3424a450e97e83e6e52637fdeL250-R256) [[3]](diffhunk://#diff-106118806535dd552775252baf12caa333758eb3424a450e97e83e6e52637fdeL281-R287)

### Error Handling Enhancements:

* Extended the `Error` enum in `crates/manager/src/error.rs` to include authentication-related errors from the `blueprint-auth` crate.

### Blueprint Manager Enhancements:

* Updated the `BlueprintManagerConfig` struct's `Default` implementation to include default values for the new `auth_proxy_opts` field.
* Modified the `run_blueprint_manager_with_keystore` function in `crates/manager/src/executor/mod.rs` to spawn the authentication proxy task and handle its lifecycle alongside the manager and shutdown tasks. [[1]](diffhunk://#diff-cfb6f837fafc0566c9451004344ec96889b4c7d0ea80c799e1609e1ed16bb299R195-R199) [[2]](diffhunk://#diff-cfb6f837fafc0566c9451004344ec96889b4c7d0ea80c799e1609e1ed16bb299R294-R296)

These changes collectively enhance the Blueprint Manager by adding robust authentication proxy support, improving API structure, and ensuring better error management.