### PR TITLE
feat(cli): blueprint create without interaction

### DIFF
--- a/cli/src/command/create/mod.rs
+++ b/cli/src/command/create/mod.rs
@@ -13,10 +13,22 @@ pub mod types;
 /// # Errors
 ///
 /// See [`cargo_generate::generate()`]
+///
+/// # Parameters
+///
+/// * `name` - The name of the blueprint
+/// * `source` - Optional source information (repo, branch, path)
+/// * `blueprint_type` - Optional blueprint type (Tangle or Eigenlayer)
+/// * `define` - Template variable definitions (key=value pairs)
+/// * `template_values_file` - Optional path to a file containing template values
+/// * `interactive` - Whether to run in interactive mode, prompting for all variables
 pub fn new_blueprint(
     name: &str,
     source: Option<Source>,
     blueprint_type: Option<BlueprintType>,
+    mut define: Vec<String>,
+    template_values_file: &Option<String>,
+    interactive: bool,
 ) -> Result<(), Error> {
     println!("Generating blueprint with name: {}", name);
 
@@ -45,21 +57,67 @@ pub fn new_blueprint(
         }
     });
 
+    if interactive {
+        println!("Running in interactive mode - will prompt for all template variables");
+    } else {
+        println!("Using default values for unspecified template variables");
+
+        // Create a map of existing variable definitions
+        let mut defined_vars = std::collections::HashMap::new();
+        for def in &define {
+            if let Some((key, value)) = def.split_once('=') {
+                defined_vars.insert(key.to_string(), value.to_string());
+            }
+        }
+
+        // Define default values for common template variables
+        // These are specific to Tangle's Blueprint Templates
+        let defaults = [
+            ("project-description", ""),
+            ("project-homepage", ""),
+            ("flakes", "false"),
+            ("container", "true"),
+            ("base-image", "rustlang/rust:nightly"),
+            ("container-registry", "docker.io"),
+            ("ci", "true"),
+            ("rust-ci", "true"),
+            ("release-ci", "true"),
+        ];
+
+        // Add default values for any variables that aren't already defined
+        for (key, value) in defaults {
+            if !defined_vars.contains_key(key) {
+                define.push(format!("{key}={value}"));
+                println!("  Using default value for {key}: {value}");
+            }
+        }
+    }
+
+    if !define.is_empty() {
+        println!("Using template variables: {:?}", define);
+    }
+    let (silent, template_values_file) = if let Some(file) = &template_values_file {
+        println!("Using template values file: {}", file);
+        (true, Some(file.clone()))
+    } else {
+        (false, None)
+    };
+
     let path = cargo_generate::generate(cargo_generate::GenerateArgs {
         template_path,
         list_favorites: false,
         name: Some(name.to_string()),
         force: false,
         verbose: false,
-        template_values_file: None,
-        silent: false,
+        template_values_file,
+        silent,
         config: None,
         vcs: Some(cargo_generate::Vcs::Git),
         lib: false,
         bin: true,
         ssh_identity: None,
         gitconfig: None,
-        define: Vec::new(),
+        define,
         init: false,
         destination: None,
         force_git_init: false,

--- a/cli/src/command/create/mod.rs
+++ b/cli/src/command/create/mod.rs
@@ -21,14 +21,14 @@ pub mod types;
 /// * `blueprint_type` - Optional blueprint type (Tangle or Eigenlayer)
 /// * `define` - Template variable definitions (key=value pairs)
 /// * `template_values_file` - Optional path to a file containing template values
-/// * `interactive` - Whether to run in interactive mode, prompting for all variables
+/// * `skip_prompts` - Whether to skip all interactive prompts, using defaults for unspecified values
 pub fn new_blueprint(
     name: &str,
     source: Option<Source>,
     blueprint_type: Option<BlueprintType>,
     mut define: Vec<String>,
     template_values_file: &Option<String>,
-    interactive: bool,
+    skip_prompts: bool,
 ) -> Result<(), Error> {
     println!("Generating blueprint with name: {}", name);
 
@@ -57,10 +57,8 @@ pub fn new_blueprint(
         }
     });
 
-    if interactive {
-        println!("Running in interactive mode - will prompt for all template variables");
-    } else {
-        println!("Using default values for unspecified template variables");
+    if skip_prompts {
+        println!("Skipping prompts and using default values for unspecified template variables");
 
         // Create a map of existing variable definitions
         let mut defined_vars = std::collections::HashMap::new();
@@ -91,6 +89,8 @@ pub fn new_blueprint(
                 println!("  Using default value for {key}: {value}");
             }
         }
+    } else {
+        println!("Running in interactive mode - will prompt for template variables as needed");
     }
 
     if !define.is_empty() {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -148,6 +148,21 @@ pub enum BlueprintCommands {
 
         #[command(flatten)]
         blueprint_type: Option<BlueprintType>,
+
+        /// Define a value for template variables (can be used multiple times)
+        /// Example: --define gh-username=myusername
+        /// By default, sensible defaults will be used for unspecified variables
+        #[arg(long, short = 'd', number_of_values = 1)]
+        define: Vec<String>,
+
+        /// Path to a file containing template values
+        /// File should contain key=value pairs, one per line
+        #[arg(long, value_name = "FILE")]
+        template_values_file: Option<String>,
+
+        /// Run in interactive mode, prompting for all template variables
+        #[arg(long, short = 'i')]
+        interactive: bool,
     },
 
     /// Deploy a blueprint to the Tangle Network or Eigenlayer.
@@ -420,8 +435,18 @@ async fn main() -> color_eyre::Result<()> {
                 name,
                 source,
                 blueprint_type,
+                define,
+                template_values_file,
+                interactive,
             } => {
-                new_blueprint(&name, source, blueprint_type)?;
+                new_blueprint(
+                    &name,
+                    source,
+                    blueprint_type,
+                    define,
+                    &template_values_file,
+                    interactive,
+                )?;
             }
             BlueprintCommands::Deploy { target } => match target {
                 DeployTarget::Tangle {

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -151,18 +151,23 @@ pub enum BlueprintCommands {
 
         /// Define a value for template variables (can be used multiple times)
         /// Example: --define gh-username=myusername
-        /// By default, sensible defaults will be used for unspecified variables
-        #[arg(long, short = 'd', number_of_values = 1)]
+        /// Example with spaces: --define "project-description=My Blueprint description"
+        #[arg(
+            long,
+            short = 'd',
+            number_of_values = 1,
+            conflicts_with = "template_values_file"
+        )]
         define: Vec<String>,
 
         /// Path to a file containing template values
         /// File should contain key=value pairs, one per line
-        #[arg(long, value_name = "FILE")]
+        #[arg(long, value_name = "FILE", conflicts_with = "define")]
         template_values_file: Option<String>,
 
-        /// Run in interactive mode, prompting for all template variables
-        #[arg(long, short = 'i')]
-        interactive: bool,
+        /// Skip all interactive prompts, using defaults for any variables not provided with `--define` or `--template-values-file`
+        #[arg(long)]
+        skip_prompts: bool,
     },
 
     /// Deploy a blueprint to the Tangle Network or Eigenlayer.
@@ -437,7 +442,7 @@ async fn main() -> color_eyre::Result<()> {
                 blueprint_type,
                 define,
                 template_values_file,
-                interactive,
+                skip_prompts,
             } => {
                 new_blueprint(
                     &name,
@@ -445,7 +450,7 @@ async fn main() -> color_eyre::Result<()> {
                     blueprint_type,
                     define,
                     &template_values_file,
-                    interactive,
+                    skip_prompts,
                 )?;
             }
             BlueprintCommands::Deploy { target } => match target {

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -158,7 +158,7 @@ pub fn load_abi(input: TokenStream) -> TokenStream {
 //  xx |     pub async fn my_job(TangleArg(_): TangleArg<u64>)  {}
 //     |                                   ^^^^ not found in this scope
 /// ```
-///
+/// 
 /// # Performance
 ///
 /// This macro has no effect when compiled with the release profile. (eg. `cargo build --release`)

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -26,7 +26,7 @@ blueprint-networking = { workspace = true, features = ["std"] }
 blueprint-std = { workspace = true, features = ["std"] }
 blueprint-auth = { workspace = true, features = ["std"] }
 
-axum = { workspace = true, default-features = false, features = ["json"] }
+axum = { workspace = true, default-features = false, features = ["json", "tokio", "http2"] }
 docktopus = { workspace = true, features = ["deploy"] }
 clap = { workspace = true, features = ["derive", "wrap_help"] }
 color-eyre = { workspace = true, features = ["tracing-error", "color-spantrace", "issue-url"] }


### PR DESCRIPTION
# Overview

Allows `cargo-tangle blueprint create` to be run without requiring interaction. 

## What's changed?
The following flags/functionalities were added:

- `--define`: Allows users to define individual variables for the templates i.e., `--define gh-username=myname`. Any missing values from our templates are automatically passed with their default value (or an empty string for string values)
- `--template_values_file`: Allows a user to specify a file with `key=value` pairs that define template variables. Using this will result in cargo-generate running in silent mode, so it will fail if there are missing values. This is required so that it doesn't hang while waiting for user input if it were automated
- `--skip-prompts`: Removes the interactive part of the command, making it possible to run when user input is not possible. If no template input values are given with the two above additions, all values will default (as long as there is one - custom templates won't have defaults supported automatically)