### PR TITLE
fix(cli): missing template defaults

### DIFF
--- a/cli/src/command/create/mod.rs
+++ b/cli/src/command/create/mod.rs
@@ -69,8 +69,10 @@ pub fn new_blueprint(
         }
 
         // Define default values for common template variables
-        // These are specific to Tangle's Blueprint Templates
         let defaults = [
+            ("gh-username", ""),
+            ("gh-repo", ""),
+            ("gh-organization", ""),
             ("project-description", ""),
             ("project-homepage", ""),
             ("flakes", "false"),


### PR DESCRIPTION
# Overview

Adds a few missing default template input variables used for creating a new blueprint with `cargo tangle blueprint create`. This ensures it can be run with **_zero_** specified values