### PR TITLE
chore(ci): add free disk space action to clippy/tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,8 @@ jobs:
       - name: checkout code
         uses: actions/checkout@v2
 
+      - uses: ./.github/actions/free-disk-space
+
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
 
@@ -135,6 +137,8 @@ jobs:
     steps:
       - name: checkout code
         uses: actions/checkout@v2
+
+      - uses: ./.github/actions/free-disk-space
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1


### PR DESCRIPTION
Getting to the point where jobs are failing due to disk space