### PR TITLE
fix: release.yml generation

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -4,10 +4,14 @@
   uses: foundry-rs/foundry-toolchain@v1
 
 - name: Verify Forge installation
-  run: forge --version
+  run: |
+    forge --version
+    echo "Forge version check completed"
 
 - name: Install Solidity Dependencies
-  run: forge soldeer update -d
+  run: |
+    forge soldeer update -d
+    echo "Solidity dependencies installed"
 
 - name: install protobuf and gmp (Linux)
   if: runner.os == 'Linux'
@@ -19,6 +23,7 @@
   if: runner.os == 'macOS'
   run: |
     brew install protobuf gmp
+    echo "Installed protobuf and gmp on macOS"
 
 - name: Install LLVM and Clang
   uses: KyleMayes/install-llvm-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,9 +131,13 @@ jobs:
       - name: "Install Foundry"
         uses: "foundry-rs/foundry-toolchain@v1"
       - name: "Verify Forge installation"
-        run: "forge --version"
+        run: |
+          forge --version
+          echo "Forge version check completed"
       - name: "Install Solidity Dependencies"
-        run: "forge soldeer update -d"
+        run: |
+          forge soldeer update -d
+          echo "Solidity dependencies installed"
       - name: "install protobuf and gmp (Linux)"
         if: "runner.os == 'Linux'"
         run: |
@@ -142,7 +146,8 @@ jobs:
       - name: "install protobuf and gmp (macOS)"
         if: "runner.os == 'macOS'"
         run: |
-          "brew install protobuf gmp"
+          brew install protobuf gmp
+          echo "Installed protobuf and gmp on macOS"
       - name: "Install LLVM and Clang"
         uses: "KyleMayes/install-llvm-action@v2"
         with:


### PR DESCRIPTION
# Overview

For some reason, `cargo-dist` generates a `release.yml` with double quotes around commands when they are written in a run section of the `build-setup.yml` with only a single command/line. To circumvent this issue, we add dummy echo commands so it is correctly generated.

## Example
A `build-setup.yml` with:
```yml
- name: Install Solidity Dependencies
  run: forge soldeer update -d
```

results in a `release.yml` with:
```yml
- name: "Install Solidity Dependencies"
  run: "forge soldeer update -d"
```

So instead, we use:
```yml
- name: Install Solidity Dependencies
  run: |
    forge soldeer update -d
    echo "Solidity dependencies installed"
```

Which results in the `release.yml` output, but without the unnecessary double quotes:
```yml
- name: "Install Solidity Dependencies"
  run: |
     forge soldeer update -d
     echo "Solidity dependencies installed"
```