### PR TITLE
fix(ci): eigenlayer example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3225,10 +3225,13 @@ version = "0.1.0-alpha.14"
 dependencies = [
  "alloy-primitives 0.8.25",
  "alloy-provider",
+ "axum 0.8.4",
+ "blueprint-auth",
  "blueprint-chain-setup",
  "blueprint-core",
  "blueprint-core-testing-utils",
  "blueprint-evm-extra",
+ "blueprint-manager-bridge",
  "blueprint-runner",
  "eigensdk",
  "futures",

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -16,10 +16,13 @@ workspace = true
 blueprint-runner = { workspace = true, features = ["eigenlayer"] }
 blueprint-evm-extra.workspace = true
 blueprint-core = { workspace = true }
-
-futures = { workspace = true }
+blueprint-auth = { workspace = true }
+blueprint-manager-bridge = { workspace = true, features = ["server"] }
 blueprint-core-testing-utils = { workspace = true }
 blueprint-chain-setup = { workspace = true, features = ["std", "anvil"] }
+
+axum = { workspace = true }
+futures = { workspace = true }
 tempfile = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-provider = { workspace = true }

--- a/crates/testing-utils/eigenlayer/src/harness.rs
+++ b/crates/testing-utils/eigenlayer/src/harness.rs
@@ -2,13 +2,20 @@ use crate::Error;
 use crate::env::{EigenlayerTestEnvironment, setup_eigenlayer_test_environment};
 use alloy_primitives::Address;
 use alloy_provider::RootProvider;
+use blueprint_auth::db::RocksDb;
 use blueprint_chain_setup::anvil::keys::{ANVIL_PRIVATE_KEYS, inject_anvil_key};
 use blueprint_chain_setup::anvil::{Container, start_empty_anvil_testnet};
+use blueprint_core::{error, info};
 use blueprint_evm_extra::util::get_provider_http;
+use blueprint_manager_bridge::server::{Bridge, BridgeHandle};
 use blueprint_runner::config::{BlueprintEnvironment, ContextConfig, SupportedChains};
 use blueprint_runner::eigenlayer::config::EigenlayerProtocolSettings;
+use std::future::Future;
 use std::marker::PhantomData;
+use std::net::Ipv4Addr;
+use std::path::PathBuf;
 use tempfile::TempDir;
+use tokio::task::JoinHandle;
 use url::Url;
 
 /// Configuration for the Eigenlayer test harness
@@ -30,6 +37,8 @@ pub struct EigenlayerTestHarness<Ctx> {
     _temp_dir: TempDir,
     _container: Container,
     _phantom: PhantomData<Ctx>,
+    _auth_proxy: JoinHandle<Result<(), Error>>,
+    _bridge: BridgeHandle,
 }
 
 impl EigenlayerTestHarness<()> {
@@ -76,6 +85,22 @@ where
         let data_dir = test_dir.path().join("data");
         tokio::fs::create_dir_all(&data_dir).await?;
 
+        // Setup auth proxy
+        const DEFAULT_AUTH_PROXY_PORT: u16 = 50051;
+        let (auth_proxy_db, auth_proxy_task) =
+            run_auth_proxy(test_dir.path().to_path_buf(), DEFAULT_AUTH_PROXY_PORT).await?;
+
+        let auth_proxy = tokio::spawn(auth_proxy_task);
+
+        // Setup bridge
+        let runtime_dir = test_dir.path().join("runtime");
+        tokio::fs::create_dir_all(&runtime_dir).await?;
+
+        let bridge = Bridge::new(runtime_dir, String::from("service"), auth_proxy_db, true);
+        let bridge_socket_path = bridge.base_socket_path();
+
+        let (bridge_handle, _alive_rx) = bridge.spawn()?;
+
         // Create context config
         let context_config = ContextConfig::create_eigenlayer_config(
             Url::parse(&http_endpoint)?,
@@ -88,9 +113,12 @@ where
             eigenlayer_contract_addresses,
         );
 
-        // Load environment
-        let env = BlueprintEnvironment::load_with_config(context_config)
+        // Load environment with bridge configuration
+        let mut env = BlueprintEnvironment::load_with_config(context_config)
             .map_err(|e| Error::Setup(e.to_string()))?;
+
+        env.bridge_socket_path = Some(bridge_socket_path);
+        env.test_mode = true;
 
         // Create config
         let config = EigenlayerTestConfig {
@@ -109,6 +137,8 @@ where
             _temp_dir: test_dir,
             _container: testnet.container,
             _phantom: core::marker::PhantomData,
+            _auth_proxy: auth_proxy,
+            _bridge: bridge_handle,
         })
     }
 
@@ -128,6 +158,8 @@ where
             _temp_dir: self._temp_dir,
             _container: self._container,
             _phantom: PhantomData::<Ctx2>,
+            _auth_proxy: self._auth_proxy,
+            _bridge: self._bridge,
         }
     }
 
@@ -167,4 +199,50 @@ impl<Ctx> EigenlayerTestHarness<Ctx> {
     pub fn task_generator_account(&self) -> Address {
         self.accounts[4]
     }
+}
+
+/// Runs the authentication proxy server.
+///
+/// This function sets up and runs an authenticated proxy server that listens on the configured host and port.
+/// It creates necessary directories for the proxy's database and then starts the server.
+///
+/// # Arguments
+///
+/// * `data_dir` - The path to the data directory where the proxy's database will be stored.
+/// * `auth_proxy_port` - The port on which the proxy server will listen.
+///
+/// # Errors
+///
+/// This function will return an error if:
+/// - It fails to create the necessary directories for the database.
+/// - It fails to bind to the specified host and port.
+/// - The Axum server encounters an error during operation.
+async fn run_auth_proxy(
+    data_dir: PathBuf,
+    auth_proxy_port: u16,
+) -> Result<(RocksDb, impl Future<Output = Result<(), Error>>), Error> {
+    let db_path = data_dir.join("private").join("auth-proxy").join("db");
+    tokio::fs::create_dir_all(&db_path).await?;
+
+    let proxy = blueprint_auth::proxy::AuthenticatedProxy::new(&db_path)?;
+    let db = proxy.db();
+
+    let task = async move {
+        let router = proxy.router();
+        let listener =
+            tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, auth_proxy_port)).await?;
+        info!(
+            "Auth proxy listening on {}:{}",
+            Ipv4Addr::LOCALHOST,
+            auth_proxy_port
+        );
+        let result = axum::serve(listener, router).await;
+        if let Err(err) = result {
+            error!("Auth proxy error: {err}");
+        }
+
+        Ok(())
+    };
+
+    Ok((db, task))
 }

--- a/examples/incredible-squaring-eigenlayer/src/tests.rs
+++ b/examples/incredible-squaring-eigenlayer/src/tests.rs
@@ -328,8 +328,6 @@ async fn run_eigenlayer_incredible_squaring_test(
     )
     .await;
 
-    info!("Responses found, shutting down...");
-
     // Start the shutdown/cleanup process
     aggregator_context_clone.shutdown().await;
 


### PR DESCRIPTION
# Overview

Fixes the failing CI check for the incredible squaring eigenlayer example by adding the bridge to the eigenlayer testing harness so the test runner doesn't fail.