### PR TITLE
fix: assert the rpc url starts with `ws` not `ws:` to support `wss` too

### DIFF
--- a/crates/chain-setup/tangle/src/deploy.rs
+++ b/crates/chain-setup/tangle/src/deploy.rs
@@ -473,7 +473,7 @@ async fn deploy_contracts_to_tangle(
     };
 
     let wallet = alloy_provider::network::EthereumWallet::from(signer);
-    assert!(rpc_url.starts_with("ws:"));
+    assert!(rpc_url.starts_with("ws"));
 
     let provider = alloy_provider::ProviderBuilder::new()
         .network::<AnyNetwork>()

--- a/crates/chain-setup/tangle/src/deploy.rs
+++ b/crates/chain-setup/tangle/src/deploy.rs
@@ -473,7 +473,7 @@ async fn deploy_contracts_to_tangle(
     };
 
     let wallet = alloy_provider::network::EthereumWallet::from(signer);
-    assert!(rpc_url.starts_with("ws"));
+    assert!(rpc_url.starts_with("ws://") || rpc_url.starts_with("wss://"));
 
     let provider = alloy_provider::ProviderBuilder::new()
         .network::<AnyNetwork>()


### PR DESCRIPTION
This pull request includes a small but important change to the `deploy_contracts_to_tangle` function in `crates/chain-setup/tangle/src/deploy.rs`. The change expands the validation of the `rpc_url` to allow both `ws://` and `wss://` protocols, improving compatibility with secure WebSocket connections.