### PR TITLE
feat: add rustls as default crypto provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4371,6 +4371,7 @@ dependencies = [
  "hex",
  "indicatif",
  "nix 0.30.1",
+ "rustls 0.23.28",
  "serde",
  "serde_json",
  "sp-core",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -225,6 +225,7 @@ axum = { version = "0.8", default-features = false }
 openssl-sys = { version = "0.9.109", default-features = false }
 rtnetlink = { version = "0.16.0", default-features = false }
 ipnet = { version = "2.11.0", default-features = false }
+rustls = { version = "0.23", default-features = false }
 
 # System & OS
 parking_lot = { version = "0.12.4", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -50,6 +50,7 @@ thiserror = { workspace = true }
 bip39 = { workspace = true, features = ["rand_core", "rand"] }
 dotenv = { workspace = true }
 url = { workspace = true }
+rustls = { workspace = true }
 toml = { workspace = true }
 indicatif = { workspace = true }
 tnt-core-bytecode = { workspace = true }

--- a/cli/src/lib.rs
+++ b/cli/src/lib.rs
@@ -25,3 +25,23 @@ pub(crate) async fn wait_for_in_block_success<T: Config>(
 pub(crate) fn decode_bounded_string(bounded_string: &BoundedString) -> String {
     String::from_utf8_lossy(&bounded_string.0.0).to_string()
 }
+
+/// This force installs the default crypto provider.
+///
+/// This is necessary in case there are more than one available backends enabled in rustls (ring,
+/// aws-lc-rs).
+///
+/// This should be called high in the main fn.
+///
+/// See also:
+///   <https://github.com/snapview/tokio-tungstenite/issues/353#issuecomment-2455100010>
+///   <https://github.com/awslabs/aws-sdk-rust/discussions/1257>
+///
+/// # Panics
+/// If the default crypto provider cannot be installed, this function will panic.
+pub fn install_crypto_provider() {
+    // https://github.com/snapview/tokio-tungstenite/issues/353
+    rustls::crypto::ring::default_provider()
+        .install_default()
+        .expect("Failed to install default rustls crypto provider");
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -463,6 +463,8 @@ pub enum DebugCommands {
 async fn main() -> color_eyre::Result<()> {
     color_eyre::install()?;
     init_tracing_subscriber();
+    // Install the default crypto provider for rustls
+    cargo_tangle::install_crypto_provider();
     let args: Vec<String> = if std::env::args().nth(1).is_some_and(|x| x.eq("tangle")) {
         // since this runs as a cargo subcommand, we need to skip the first argument
         // to get the actual arguments for the subcommand


### PR DESCRIPTION
This pull request introduces support for `rustls` as a TLS library in the project, along with necessary configuration and setup changes. The most important updates include adding `rustls` dependencies, implementing a function to install the default crypto provider, and ensuring the crypto provider is initialized in the main function.

### Dependency Updates:
* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R228): Added `rustls` as a dependency with version `0.23` and disabled default features. This enables TLS functionality using `rustls`.
* [`cli/Cargo.toml`](diffhunk://#diff-6057d83fb675b27e99f187fa354690b6597018c390cbd50eac854a56233d2addR53): Added `rustls` to the workspace dependencies for the CLI module.

### Crypto Provider Installation:
* [`cli/src/lib.rs`](diffhunk://#diff-c1f8f7498da827a634bddc8a7559198bc99b296e9d9e8b91a70b503662995b8cR28-R47): Added the `install_crypto_provider` function to enforce the installation of the default crypto provider for `rustls`. This function ensures compatibility when multiple backends are enabled. It includes detailed documentation and links to related issues.

### Initialization in Main Function:
* [`cli/src/main.rs`](diffhunk://#diff-37970e7d817d4316a093bb967d74ff7e26d9c6c01d93f5a79d3d195ba9f6155bR466-R467): Updated the `main` function to call `install_crypto_provider` at the start, ensuring the default crypto provider is installed before other operations.


Fixes #1067 