### PR TITLE
chore: update tangle-subxt dependency to v0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,7 +2519,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -4835,7 +4835,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5746,7 +5746,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9971,7 +9971,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.1",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -19639,9 +19639,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tangle-subxt"
-version = "0.18.0"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b575640e59629a46b39842e5cfdf2f6018fe36dfc665e43605b37c8547b34c38"
+checksum = "521ddb4c76d5b0bd8a92152839ae0ce8f4afd9dbb10239e91b7313fb164c7468"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -20597,7 +20597,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.1",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
@@ -21440,7 +21440,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ bollard = { version = "0.18.0", features = ["ssl"] }
 tnt-core-bytecode = { version = "0.6.0", default-features = false }
 
 # Tangle-related dependencies
-tangle-subxt = { version = "0.18.0", default-features = false }
+tangle-subxt = { version = "0.19.0", default-features = false }
 round-based = { version = "0.4.1", default-features = false }
 
 # Substrate dependencies

--- a/crates/chain-setup/tangle/src/deploy.rs
+++ b/crates/chain-setup/tangle/src/deploy.rs
@@ -23,12 +23,7 @@ use std::sync::{
 use subxt::tx::Signer;
 use tangle_subxt::subxt;
 use tangle_subxt::tangle_testnet_runtime::api as TangleApi;
-use tangle_subxt::tangle_testnet_runtime::api::runtime_types::bounded_collections::bounded_vec::BoundedVec;
-use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::types::MembershipModel as RuntimeMembershipModel;
-use tangle_subxt::tangle_testnet_runtime::api::services::calls::types;
-use tangle_subxt::tangle_testnet_runtime::api::services::calls::types::create_blueprint::{
-    MembershipModel, Metadata, PriceTargets, SecurityRequirements,
-};
+use tangle_subxt::tangle_testnet_runtime::api::services::calls::types::create_blueprint::Blueprint;
 
 #[derive(Clone)]
 pub struct Opts {
@@ -81,13 +76,7 @@ async fn generate_service_blueprint<P: Into<PathBuf>, T: AsRef<str>>(
     pkg_name: Option<&String>,
     rpc_url: T,
     signer_evm: Option<PrivateKeySigner>,
-) -> Result<(
-    types::create_blueprint::Metadata,
-    types::create_blueprint::Typedef,
-    types::create_blueprint::MembershipModel,
-    types::create_blueprint::SecurityRequirements,
-    types::create_blueprint::PriceTargets,
-)> {
+) -> Result<Blueprint> {
     let manifest_path = manifest_metadata_path.into();
     let metadata = cargo_metadata::MetadataCommand::new()
         .manifest_path(manifest_path)
@@ -101,25 +90,7 @@ async fn generate_service_blueprint<P: Into<PathBuf>, T: AsRef<str>>(
     build_contracts_if_needed(&package, &blueprint).context("Building contracts")?;
     deploy_contracts_to_tangle(rpc_url.as_ref(), &package, &mut blueprint, signer_evm).await?;
 
-    let metadata_json = serde_json::to_string(&blueprint.metadata).unwrap_or_default();
-    let bytes = metadata_json.into_bytes();
-    let bounded_vec = BoundedVec(bytes);
-    let metadata = Metadata::from(bounded_vec);
-
-    let typedef = blueprint.try_into()?;
-
-    let membership_model =
-        MembershipModel::from(RuntimeMembershipModel::Fixed { min_operators: 1 });
-    let security_requirements = SecurityRequirements::default();
-    let price_targets = PriceTargets::default();
-
-    Ok((
-        metadata,
-        typedef,
-        membership_model,
-        security_requirements,
-        price_targets,
-    ))
+    Ok(blueprint.try_into()?)
 }
 
 /// Deploy a blueprint to the Tangle Network
@@ -179,14 +150,13 @@ pub async fn deploy_to_tangle(
 
     // Load the manifest file into cargo metadata
     update_progress(60, "Generating blueprint");
-    let (metadata, typedef, membership_model, security_requirements, price_targets) =
-        generate_service_blueprint(
-            manifest_path,
-            pkg_name.as_ref(),
-            ws_rpc_url.clone(),
-            signer_evm,
-        )
-        .await?;
+    let blueprint = generate_service_blueprint(
+        manifest_path,
+        pkg_name.as_ref(),
+        ws_rpc_url.clone(),
+        signer_evm,
+    )
+    .await?;
 
     // Signal the thread to stop
     should_stop.store(true, Ordering::Relaxed);
@@ -215,13 +185,7 @@ pub async fn deploy_to_tangle(
     let client = subxt::OnlineClient::from_url(ws_rpc_url.clone()).await?;
 
     update_progress(90, "Creating blueprint transaction");
-    let create_blueprint_tx = TangleApi::tx().services().create_blueprint(
-        metadata,
-        typedef,
-        membership_model,
-        security_requirements,
-        price_targets,
-    );
+    let create_blueprint_tx = TangleApi::tx().services().create_blueprint(blueprint);
 
     update_progress(93, "Signing and submitting transaction");
     let progress = client

--- a/crates/chain-setup/tangle/src/lib.rs
+++ b/crates/chain-setup/tangle/src/lib.rs
@@ -16,8 +16,8 @@ pub use testnet::NodeConfig;
 pub type InputValue = tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::Field<AccountId32>;
 pub type OutputValue = tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::Field<AccountId32>;
 
-const TANGLE_RELEASE_MAC: &str = "https://github.com/tangle-network/tangle/releases/download/b9264bd/tangle-testnet-manual-seal-testnet-darwin-amd64";
-const TANGLE_RELEASE_LINUX: &str = "https://github.com/tangle-network/tangle/releases/download/b9264bd/tangle-testnet-manual-seal-testnet-linux-amd64";
+const TANGLE_RELEASE_MAC: &str = "https://github.com/tangle-network/tangle/releases/download/v1.3.8/tangle-testnet-manual-seal-testnet-darwin-amd64";
+const TANGLE_RELEASE_LINUX: &str = "https://github.com/tangle-network/tangle/releases/download/v1.3.8/tangle-testnet-manual-seal-testnet-linux-amd64";
 
 /// Downloads the appropriate Tangle binary for the current platform and returns the path
 ///

--- a/crates/chain-setup/tangle/src/transactions.rs
+++ b/crates/chain-setup/tangle/src/transactions.rs
@@ -31,7 +31,7 @@ use tangle_subxt::tangle_testnet_runtime::api::{
     services::{
         calls::types::{
             call::{Args, Job},
-            create_blueprint::{Metadata, Typedef, MembershipModel as BlueprintMembershipModel, SecurityRequirements, PriceTargets},
+            create_blueprint::Blueprint,
             register::{Preferences, RegistrationArgs},
             request::RequestArgs,
         },
@@ -152,19 +152,9 @@ pub async fn deploy_new_mbsm_revision<T: Signer<TangleConfig>>(
 pub async fn create_blueprint<T: Signer<TangleConfig>>(
     client: &TestClient,
     account_id: &T,
-    metadata: Metadata,
-    typedef: Typedef,
-    membership_model: BlueprintMembershipModel,
-    security_requirements: SecurityRequirements,
-    price_targets: PriceTargets,
+    blueprint: Blueprint,
 ) -> Result<(), TransactionError> {
-    let call = api::tx().services().create_blueprint(
-        metadata,
-        typedef,
-        membership_model,
-        security_requirements,
-        price_targets,
-    );
+    let call = api::tx().services().create_blueprint(blueprint);
     let res = client
         .subxt_client()
         .tx()


### PR DESCRIPTION
This pull request simplifies the handling of blueprint-related data in the `chain-setup/tangle` crate by replacing multiple individual types with a single `Blueprint` type. Additionally, it updates the `tangle-subxt` dependency to its latest version. Below are the most important changes grouped by theme:

### Dependency Update:
* Updated the `tangle-subxt` dependency from version `0.18.0` to `0.19.0` in `Cargo.toml` to incorporate the latest features and improvements.

### Simplification of Blueprint Handling:
* Consolidated multiple individual types (`Metadata`, `Typedef`, `MembershipModel`, `SecurityRequirements`, and `PriceTargets`) into a single `Blueprint` type in the `generate_service_blueprint` function. This change simplifies the function's return type and internal logic. [[1]](diffhunk://#diff-b130117359ed17d3e8958fba1b9494995b057fc4b7578d50fd72af1621e73fd4L84-R79) [[2]](diffhunk://#diff-b130117359ed17d3e8958fba1b9494995b057fc4b7578d50fd72af1621e73fd4L104-R93)
* Updated the `deploy_to_tangle` function to use the new `Blueprint` type instead of handling individual blueprint-related components. This streamlines the blueprint transaction creation process. [[1]](diffhunk://#diff-b130117359ed17d3e8958fba1b9494995b057fc4b7578d50fd72af1621e73fd4L182-R153) [[2]](diffhunk://#diff-b130117359ed17d3e8958fba1b9494995b057fc4b7578d50fd72af1621e73fd4L218-R188)
* Refactored the `create_blueprint` function in `transactions.rs` to accept a `Blueprint` type instead of multiple parameters, aligning with the new data model.

### Code Cleanup:
* Removed unused imports related to the old individual blueprint types (`Metadata`, `Typedef`, etc.) and replaced them with the `Blueprint` type to ensure consistency across the codebase. [[1]](diffhunk://#diff-b130117359ed17d3e8958fba1b9494995b057fc4b7578d50fd72af1621e73fd4L26-R26) [[2]](diffhunk://#diff-2badf598962163a40ed251b077f99f8bad86d6f953584b11cc7f6e4642d7a6bfL34-R34)

Fixes #1072 