### PR TITLE
chore: update tangle-subxt to v0.20.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2519,7 +2519,7 @@ dependencies = [
  "bitflags 2.9.1",
  "cexpr",
  "clang-sys",
- "itertools 0.10.5",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
@@ -4823,7 +4823,7 @@ version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -5734,7 +5734,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d162beedaa69905488a8da94f5ac3edb4dd4788b732fadb7bd120b2625c1976"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.104",
 ]
 
 [[package]]
@@ -9970,7 +9970,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07033963ba89ebaf1584d767badaa2e8fcec21aedea6b8c0346d487d49c28667"
 dependencies = [
  "cfg-if 1.0.1",
- "windows-targets 0.48.5",
+ "windows-targets 0.53.2",
 ]
 
 [[package]]
@@ -19635,9 +19635,9 @@ checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tangle-subxt"
-version = "0.19.0"
+version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "521ddb4c76d5b0bd8a92152839ae0ce8f4afd9dbb10239e91b7313fb164c7468"
+checksum = "ef72db13eaf0fa786eaa74cb851793acb2d07b4ac58bb0d88bed1d60eb6c7386"
 dependencies = [
  "parity-scale-codec",
  "scale-info",
@@ -20414,7 +20414,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ba3beec919fbdf99d719de8eda6adae3281f8a5b71ae40431f44dc7423053d34"
 dependencies = [
  "loki-api",
- "reqwest 0.11.27",
+ "reqwest 0.12.22",
  "serde",
  "serde_json",
  "snap",
@@ -20595,7 +20595,7 @@ version = "1.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
- "cfg-if 0.1.10",
+ "cfg-if 1.0.1",
  "digest 0.10.7",
  "rand 0.8.5",
  "static_assertions",
@@ -21438,7 +21438,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -135,7 +135,7 @@ bollard = { version = "0.18.0", features = ["ssl"] }
 tnt-core-bytecode = { version = "0.6.0", default-features = false }
 
 # Tangle-related dependencies
-tangle-subxt = { version = "0.19.0", default-features = false }
+tangle-subxt = { version = "0.20.0", default-features = false }
 round-based = { version = "0.4.1", default-features = false }
 
 # Substrate dependencies

--- a/crates/chain-setup/tangle/src/lib.rs
+++ b/crates/chain-setup/tangle/src/lib.rs
@@ -16,8 +16,8 @@ pub use testnet::NodeConfig;
 pub type InputValue = tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::Field<AccountId32>;
 pub type OutputValue = tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::field::Field<AccountId32>;
 
-const TANGLE_RELEASE_MAC: &str = "https://github.com/tangle-network/tangle/releases/download/v1.3.8/tangle-testnet-manual-seal-testnet-darwin-amd64";
-const TANGLE_RELEASE_LINUX: &str = "https://github.com/tangle-network/tangle/releases/download/v1.3.8/tangle-testnet-manual-seal-testnet-linux-amd64";
+const TANGLE_RELEASE_MAC: &str = "https://github.com/tangle-network/tangle/releases/download/v1.3.9/tangle-testnet-manual-seal-testnet-darwin-amd64";
+const TANGLE_RELEASE_LINUX: &str = "https://github.com/tangle-network/tangle/releases/download/v1.3.9/tangle-testnet-manual-seal-testnet-linux-amd64";
 
 /// Downloads the appropriate Tangle binary for the current platform and returns the path
 ///


### PR DESCRIPTION
This pull request updates dependencies and constants to align with the latest versions of the Tangle network. The changes ensure compatibility with the updated Tangle testnet runtime and binaries.

### Dependency Updates:
* Updated the `tangle-subxt` dependency from version `0.19.0` to `0.20.0` in `Cargo.toml` to use the latest features and fixes.

### Constant Updates:
* Updated the Tangle release URLs in `crates/chain-setup/tangle/src/lib.rs` to point to version `1.3.9` binaries for both macOS and Linux platforms, replacing the previous `1.3.8` version.