### PR TITLE
feat(manager)!: add optional container source support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3360,6 +3360,9 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "ipnet",
+ "k8s-openapi",
+ "kube",
+ "local-ip-address",
  "netdev",
  "nftables",
  "nix 0.30.1",
@@ -8492,6 +8495,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "headers"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "headers-core",
+ "http 1.3.1",
+ "httpdate",
+ "mime",
+ "sha1",
+]
+
+[[package]]
+name = "headers-core"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
+dependencies = [
+ "http 1.3.1",
+]
+
+[[package]]
 name = "heapless"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8785,6 +8812,26 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-http-proxy"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ad4b0a1e37510028bc4ba81d0e38d239c39671b0f0ce9e02dfa93a8133f7c08"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "headers",
+ "http 1.3.1",
+ "hyper 1.6.0",
+ "hyper-rustls 0.27.7",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls-native-certs 0.7.3",
+ "tokio",
+ "tokio-rustls 0.26.2",
+ "tower-service",
 ]
 
 [[package]]
@@ -9541,6 +9588,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonpath-rust"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c00ae348f9f8fd2d09f82a98ca381c60df9e0820d8d79fce43e649b4dc3128b"
+dependencies = [
+ "pest",
+ "pest_derive",
+ "regex",
+ "serde_json",
+ "thiserror 2.0.12",
+]
+
+[[package]]
 name = "jsonrpc-core"
 version = "18.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9819,6 +9879,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "k8s-openapi"
+version = "0.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa60a41b57ae1a0a071af77dbcf89fc9819cfe66edaf2beeb204c34459dcf0b2"
+dependencies = [
+ "base64 0.22.1",
+ "chrono",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9855,6 +9927,71 @@ checksum = "558bf9508a558512042d3095138b1f7b8fe90c5467d94f9f1da28b3731c5dbd1"
 dependencies = [
  "serde",
  "static_assertions",
+]
+
+[[package]]
+name = "kube"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "778f98664beaf4c3c11372721e14310d1ae00f5e2d9aabcf8906c881aa4e9f51"
+dependencies = [
+ "k8s-openapi",
+ "kube-client",
+ "kube-core",
+]
+
+[[package]]
+name = "kube-client"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cb276b85b6e94ded00ac8ea2c68fcf4697ea0553cb25fddc35d4a0ab718db8d"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "chrono",
+ "either",
+ "futures",
+ "home",
+ "http 1.3.1",
+ "http-body 1.0.1",
+ "http-body-util",
+ "hyper 1.6.0",
+ "hyper-http-proxy",
+ "hyper-rustls 0.27.7",
+ "hyper-timeout",
+ "hyper-util",
+ "jsonpath-rust",
+ "k8s-openapi",
+ "kube-core",
+ "pem 3.0.5",
+ "rustls 0.23.31",
+ "secrecy 0.10.3",
+ "serde",
+ "serde_json",
+ "serde_yaml",
+ "thiserror 2.0.12",
+ "tokio",
+ "tokio-util 0.7.16",
+ "tower 0.5.2",
+ "tower-http",
+ "tracing",
+]
+
+[[package]]
+name = "kube-core"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c56ff45deb0031f2a476017eed60c06872251f271b8387ad8020b8fef60960"
+dependencies = [
+ "chrono",
+ "derive_more 2.0.1",
+ "form_urlencoded",
+ "http 1.3.1",
+ "k8s-openapi",
+ "serde",
+ "serde-value",
+ "serde_json",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -10642,6 +10779,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5e54036fe321fd421e10d732f155734c4e4afd610dd556d9a82833ab3ee0bed"
 
 [[package]]
+name = "local-ip-address"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "656b3b27f8893f7bbf9485148ff9a65f019e3f33bd5cdc87c83cab16b3fd9ec8"
+dependencies = [
+ "libc",
+ "neli",
+ "thiserror 2.0.12",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11188,6 +11337,31 @@ dependencies = [
  "security-framework 2.11.1",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "neli"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93062a0dce6da2517ea35f301dfc88184ce18d3601ec786a727a87bf535deca9"
+dependencies = [
+ "byteorder",
+ "libc",
+ "log",
+ "neli-proc-macros",
+]
+
+[[package]]
+name = "neli-proc-macros"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c8034b7fbb6f9455b2a96c19e6edf8dc9fc34c70449938d8ee3b4df363f61fe"
+dependencies = [
+ "either",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -16499,6 +16673,19 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework 2.11.1",
+]
+
+[[package]]
+name = "rustls-native-certs"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
@@ -20335,12 +20522,14 @@ version = "0.6.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adc82fd73de2a9722ac5da747f12383d2bfdb93591ee6c58486e0097890f05f2"
 dependencies = [
+ "base64 0.22.1",
  "bitflags 2.9.1",
  "bytes",
  "futures-util",
  "http 1.3.1",
  "http-body 1.0.1",
  "iri-string",
+ "mime",
  "pin-project-lite",
  "tower 0.5.2",
  "tower-layer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -222,11 +222,14 @@ hyper-util = { version = "0.1.16", default-features = false }
 http-body-util = { version = "0.1.3", default-features = false }
 dashmap = { version = "6.1.0", default-features = false }
 cloud-hypervisor-client = { version = "0.3.2", default-features = false }
+kube = { version = "1.1.0", default-features = false }
+k8s-openapi = { version = "0.25.0", default-features = false }
 axum = { version = "0.8", default-features = false }
 openssl-sys = { version = "0.9.109", default-features = false }
 rtnetlink = { version = "0.16.0", default-features = false }
 ipnet = { version = "2.11.0", default-features = false }
 rustls = { version = "0.23", default-features = false }
+local-ip-address = "0.6.5"
 
 # System & OS
 parking_lot = { version = "0.12.4", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -33,7 +33,7 @@ blueprint-crypto = { workspace = true, features = [
 ] }
 blueprint-crypto-core = { workspace = true, features = ["clap"] }
 blueprint-keystore = { workspace = true, features = ["tangle-full", "eigenlayer-full", "evm", "std"] }
-blueprint-manager = { workspace = true }
+blueprint-manager = { workspace = true, features = ["containers", "tee"] }
 
 anyhow = { workspace = true }
 clap = { workspace = true, features = ["derive", "wrap_help"] }

--- a/cli/src/command/debug/spawn.rs
+++ b/cli/src/command/debug/spawn.rs
@@ -1,3 +1,5 @@
+mod container;
+mod native;
 #[cfg(feature = "vm-debug")]
 mod vm;
 
@@ -11,21 +13,24 @@ use blueprint_crypto::sp_core::{SpEcdsa, SpSr25519};
 use blueprint_crypto::tangle_pair_signer::TanglePairSigner;
 use blueprint_keystore::backends::Backend;
 use blueprint_keystore::{Keystore, KeystoreConfig};
-use blueprint_manager::blueprint_auth::db::RocksDb;
-use blueprint_manager::config::{AuthProxyOpts, BlueprintManagerConfig};
+use blueprint_manager::config::{AuthProxyOpts, BlueprintManagerConfig, BlueprintManagerContext};
 use blueprint_manager::executor::run_auth_proxy;
-use blueprint_manager::rt::service::Service;
 use blueprint_manager::sources::{BlueprintArgs, BlueprintEnvVars};
 use blueprint_runner::config::{BlueprintEnvironment, Protocol, SupportedChains};
+use clap::ValueEnum;
 use std::future;
 use std::io;
 use std::path::{Path, PathBuf};
 use std::pin::Pin;
 use tokio::task::{JoinError, JoinHandle};
 use url::Url;
+use blueprint_manager::rt::ResourceLimits;
 
 async fn setup_tangle_node(
     tmp_path: &Path,
+    package: Option<String>,
+    manifest_path: &Path,
+    keystore_uri: String,
     mut http_rpc_url: Option<Url>,
     mut ws_rpc_url: Option<Url>,
 ) -> color_eyre::Result<(Option<SubstrateNode>, Url, Url)> {
@@ -86,12 +91,31 @@ async fn setup_tangle_node(
     )
     .await?;
 
+    Box::pin(deploy_tangle(
+        http.to_string(),
+        ws.to_string(),
+        package,
+        false,
+        Some(PathBuf::from(keystore_uri.clone())),
+        manifest_path.to_path_buf(),
+    ))
+    .await?;
+    register(ws.to_string(), 0, keystore_uri, "").await?;
+
     Ok((node, http, ws))
 }
 
 pub struct PtyIo {
     pub stdin_to_pty: JoinHandle<io::Result<()>>,
     pub pty_to_stdout: JoinHandle<io::Result<()>>,
+}
+
+#[derive(ValueEnum, Debug, Copy, Clone)]
+pub enum ServiceSpawnMethod {
+    Native,
+    #[cfg(feature = "vm-debug")]
+    Vm,
+    Container,
 }
 
 /// Spawns a Tangle testnet and virtual machine for the given blueprint
@@ -120,56 +144,46 @@ pub async fn execute(
     package: Option<String>,
     #[allow(unused_variables)] id: u32,
     service_name: String,
-    binary: PathBuf,
+    binary: Option<PathBuf>,
+    image: Option<String>,
     protocol: Protocol,
+    method: ServiceSpawnMethod,
     #[cfg(feature = "vm-debug")] _verify_network_connection: bool,
-    #[cfg(feature = "vm-debug")] no_vm: bool,
 ) -> color_eyre::Result<()> {
-    #[cfg(not(feature = "vm-debug"))]
-    #[allow(unused)]
-    let no_vm = true;
-
     let mut manager_config = BlueprintManagerConfig::default();
 
-    #[cfg(feature = "vm-debug")]
-    if !no_vm {
-        check_net_admin_capability()?;
-    }
-
     let tmp = tempfile::tempdir()?;
-    manager_config.data_dir = tmp.path().join("data");
-    manager_config.cache_dir = tmp.path().join("cache");
-    manager_config.runtime_dir = tmp.path().join("runtime");
-    manager_config.keystore_uri = tmp.path().join("keystore").to_string_lossy().into();
+    manager_config.paths.data_dir = tmp.path().join("data");
+    manager_config.paths.cache_dir = tmp.path().join("cache");
+    manager_config.paths.runtime_dir = tmp.path().join("runtime");
+    manager_config.paths.keystore_uri = tmp.path().join("keystore").to_string_lossy().into();
 
-    manager_config.verify_directories_exist()?;
+    let ctx = BlueprintManagerContext::new(manager_config).await?;
 
-    blueprint_testing_utils::tangle::keys::inject_tangle_key(
-        &manager_config.keystore_uri,
-        "//Alice",
-    )?;
+    blueprint_testing_utils::tangle::keys::inject_tangle_key(ctx.keystore_uri(), "//Alice")?;
 
-    let (_node, http, ws) = setup_tangle_node(tmp.path(), http_rpc_url, ws_rpc_url).await?;
-    Box::pin(deploy_tangle(
-        http.to_string(),
-        ws.to_string(),
+    let (_node, http, ws) = setup_tangle_node(
+        tmp.path(),
         package,
-        false,
-        Some(PathBuf::from(&manager_config.keystore_uri)),
-        manifest_path,
-    ))
+        &manifest_path,
+        ctx.keystore_uri().to_string(),
+        http_rpc_url,
+        ws_rpc_url,
+    )
     .await?;
-    register(ws.to_string(), 0, manager_config.keystore_uri.clone(), "").await?;
 
     let (db, auth_proxy_task) =
-        run_auth_proxy(manager_config.data_dir.clone(), AuthProxyOpts::default()).await?;
+        run_auth_proxy(ctx.data_dir().to_path_buf(), AuthProxyOpts::default()).await?;
+    ctx.set_db(db).await;
 
-    let args = BlueprintArgs::new(&manager_config);
+    let args = BlueprintArgs::new(&ctx);
     let env = BlueprintEnvVars {
         http_rpc_endpoint: http,
         ws_rpc_endpoint: ws,
-        keystore_uri: manager_config.keystore_uri.clone(),
-        data_dir: manager_config.data_dir.clone(),
+        // TODO
+        kms_endpoint: "https://127.0.0.1:19821".parse().unwrap(),
+        keystore_uri: ctx.keystore_uri().to_string(),
+        data_dir: ctx.data_dir().to_path_buf(),
         blueprint_id: 0,
         service_id: 0,
         protocol,
@@ -180,31 +194,27 @@ pub async fn execute(
         bridge_socket_path: None,
     };
 
-    #[allow(unused_mut, unused_variables)]
-    let mut network_interface: Option<String> = None;
-    let (mut service, pty_io) = if no_vm {
-        let service = setup_without_vm(manager_config, &service_name, binary, db, env, args)?;
-        (service, None)
-    } else {
-        #[cfg(not(feature = "vm-debug"))]
-        unreachable!();
+    // TODO: Allow setting resource limits on the CLI?
+    let limits = ResourceLimits::default();
 
+    let (mut service, pty_io) = match method {
+        ServiceSpawnMethod::Native => {
+            let service =
+                native::setup_native(&ctx, limits, &service_name, binary.unwrap(), env, args).await?;
+            (service, None)
+        }
         #[cfg(feature = "vm-debug")]
-        {
-            let (service, pty) = vm::setup_with_vm(
-                &mut manager_config,
-                &service_name,
-                id,
-                binary,
-                db,
-                env,
-                args,
-            )
-            .await?;
-
-            network_interface = manager_config.network_interface.clone();
+        ServiceSpawnMethod::Vm => {
+            let (service, pty) =
+                vm::setup_with_vm(&ctx, limits, &service_name, id, binary.unwrap(), env, args).await?;
 
             (service, Some(pty))
+        }
+        ServiceSpawnMethod::Container => {
+            let service =
+                container::setup_with_container(&ctx, limits, &service_name, image.unwrap(), env, args)
+                    .await?;
+            (service, None)
         }
     };
 
@@ -241,28 +251,9 @@ pub async fn execute(
     let shutdown_res = service.shutdown().await;
 
     #[cfg(feature = "vm-debug")]
-    if !no_vm {
-        vm::vm_shutdown(network_interface.as_deref().unwrap()).await?;
+    if method == ServiceSpawnMethod::Vm {
+        vm::vm_shutdown(&ctx.vm.network_interface).await?;
     }
 
     shutdown_res.map_err(Into::into)
-}
-
-fn setup_without_vm(
-    manager_config: BlueprintManagerConfig,
-    service_name: &str,
-    binary: PathBuf,
-    db: RocksDb,
-    env: BlueprintEnvVars,
-    args: BlueprintArgs,
-) -> color_eyre::Result<Service> {
-    let service = Service::new_native(
-        db,
-        manager_config.runtime_dir,
-        service_name,
-        binary,
-        env,
-        args,
-    )?;
-    Ok(service)
 }

--- a/cli/src/command/debug/spawn/container.rs
+++ b/cli/src/command/debug/spawn/container.rs
@@ -1,0 +1,27 @@
+use blueprint_manager::config::BlueprintManagerContext;
+use blueprint_manager::rt::ResourceLimits;
+use blueprint_manager::rt::service::Service;
+use blueprint_manager::sources::{BlueprintArgs, BlueprintEnvVars};
+
+pub async fn setup_with_container(
+    ctx: &BlueprintManagerContext,
+    limits: ResourceLimits,
+    service_name: &str,
+    image: String,
+    env: BlueprintEnvVars,
+    args: BlueprintArgs,
+) -> color_eyre::Result<Service> {
+    let service = Service::new_container(
+        ctx,
+        limits,
+        ctx.runtime_dir(),
+        service_name,
+        image,
+        env,
+        args,
+        true,
+    )
+    .await?;
+
+    Ok(service)
+}

--- a/cli/src/command/debug/spawn/native.rs
+++ b/cli/src/command/debug/spawn/native.rs
@@ -1,8 +1,8 @@
 use blueprint_manager::config::BlueprintManagerContext;
+use blueprint_manager::rt::ResourceLimits;
 use blueprint_manager::rt::service::Service;
 use blueprint_manager::sources::{BlueprintArgs, BlueprintEnvVars};
 use std::path::PathBuf;
-use blueprint_manager::rt::ResourceLimits;
 
 pub async fn setup_native(
     ctx: &BlueprintManagerContext,
@@ -12,7 +12,15 @@ pub async fn setup_native(
     env: BlueprintEnvVars,
     args: BlueprintArgs,
 ) -> color_eyre::Result<Service> {
-    let service =
-        Service::new_native(ctx, limits, ctx.runtime_dir(), service_name, binary, env, args).await?;
+    let service = Service::new_native(
+        ctx,
+        limits,
+        ctx.runtime_dir(),
+        service_name,
+        binary,
+        env,
+        args,
+    )
+    .await?;
     Ok(service)
 }

--- a/cli/src/command/debug/spawn/native.rs
+++ b/cli/src/command/debug/spawn/native.rs
@@ -1,0 +1,18 @@
+use blueprint_manager::config::BlueprintManagerContext;
+use blueprint_manager::rt::service::Service;
+use blueprint_manager::sources::{BlueprintArgs, BlueprintEnvVars};
+use std::path::PathBuf;
+use blueprint_manager::rt::ResourceLimits;
+
+pub async fn setup_native(
+    ctx: &BlueprintManagerContext,
+    limits: ResourceLimits,
+    service_name: &str,
+    binary: PathBuf,
+    env: BlueprintEnvVars,
+    args: BlueprintArgs,
+) -> color_eyre::Result<Service> {
+    let service =
+        Service::new_native(ctx, limits, ctx.runtime_dir(), service_name, binary, env, args).await?;
+    Ok(service)
+}

--- a/cli/src/command/debug/spawn/vm.rs
+++ b/cli/src/command/debug/spawn/vm.rs
@@ -2,6 +2,7 @@ use crate::command::debug::spawn::PtyIo;
 use blueprint_core::{error, info};
 use blueprint_manager::blueprint_auth::db::RocksDb;
 use blueprint_manager::config::BlueprintManagerContext;
+use blueprint_manager::rt::ResourceLimits;
 use blueprint_manager::rt::hypervisor::net::NetworkManager;
 use blueprint_manager::rt::hypervisor::{ServiceVmConfig, net};
 use blueprint_manager::rt::service::Service;
@@ -12,7 +13,6 @@ use std::path::PathBuf;
 use std::{fs, io};
 use tokio::io::AsyncWriteExt;
 use tokio::task::JoinHandle;
-use blueprint_manager::rt::ResourceLimits;
 
 pub(super) async fn setup_with_vm(
     ctx: &BlueprintManagerContext,

--- a/cli/src/command/run/eigenlayer.rs
+++ b/cli/src/command/run/eigenlayer.rs
@@ -84,6 +84,7 @@ pub async fn run_eigenlayer_avs(
     let env = BlueprintEnvVars {
         http_rpc_endpoint: config.http_rpc_endpoint,
         ws_rpc_endpoint: config.ws_rpc_endpoint,
+        kms_endpoint: config.kms_url,
         keystore_uri: config.keystore_uri,
         data_dir: config.data_dir,
         blueprint_id: 0,
@@ -103,7 +104,7 @@ pub async fn run_eigenlayer_avs(
         verbose: 0,
     };
 
-    command.args(args.encode());
+    command.args(args.encode(true));
 
     // Optional arguments
     // TODO: Implement Keystore Password

--- a/cli/src/command/run/tangle.rs
+++ b/cli/src/command/run/tangle.rs
@@ -1,6 +1,8 @@
 use alloy_signer_local::PrivateKeySigner;
 use blueprint_crypto::tangle_pair_signer::TanglePairSigner;
-use blueprint_manager::config::{BlueprintManagerConfig, DEFAULT_DOCKER_HOST};
+use blueprint_manager::config::{
+    BlueprintManagerConfig, BlueprintManagerContext, Paths,
+};
 use blueprint_manager::executor::run_blueprint_manager;
 use blueprint_runner::config::BlueprintEnvironment;
 use color_eyre::eyre::{Result, eyre};
@@ -32,8 +34,6 @@ pub struct RunOpts {
     ///
     /// This will also allow for running the manager without the GitHub CLI installed.
     pub allow_unchecked_attestations: bool,
-    /// The Podman host to use for containerized blueprints
-    pub podman_host: Option<Url>,
 }
 
 /// Runs a blueprint using the blueprint manager
@@ -69,15 +69,19 @@ pub async fn run_blueprint(opts: RunOpts) -> Result<()> {
     blueprint_config.data_dir = opts.data_dir.unwrap_or_else(|| PathBuf::from("./data"));
 
     let blueprint_manager_config = BlueprintManagerConfig {
-        keystore_uri: blueprint_config.keystore_uri.clone(),
-        data_dir: blueprint_config.data_dir.clone(),
+        paths: Paths {
+            keystore_uri: blueprint_config.keystore_uri.clone(),
+            data_dir: blueprint_config.data_dir.clone(),
+            ..Default::default()
+        },
         verbose: 2,
         pretty: true,
         instance_id: Some(format!("Blueprint-{}", blueprint_id)),
         allow_unchecked_attestations: opts.allow_unchecked_attestations,
-        podman_host: opts.podman_host.unwrap_or(DEFAULT_DOCKER_HOST.clone()),
         ..Default::default()
     };
+
+    let ctx = BlueprintManagerContext::new(blueprint_manager_config).await?;
 
     println!(
         "{}",
@@ -114,8 +118,7 @@ pub async fn run_blueprint(opts: RunOpts) -> Result<()> {
     pb.set_message("Initializing Blueprint");
     pb.enable_steady_tick(Duration::from_millis(100));
 
-    let mut handle =
-        run_blueprint_manager(blueprint_manager_config, blueprint_config, shutdown_signal).await?;
+    let mut handle = run_blueprint_manager(ctx, blueprint_config, shutdown_signal).await?;
 
     pb.finish_with_message("Blueprint initialized successfully!");
 

--- a/cli/src/command/run/tangle.rs
+++ b/cli/src/command/run/tangle.rs
@@ -1,8 +1,6 @@
 use alloy_signer_local::PrivateKeySigner;
 use blueprint_crypto::tangle_pair_signer::TanglePairSigner;
-use blueprint_manager::config::{
-    BlueprintManagerConfig, BlueprintManagerContext, Paths,
-};
+use blueprint_manager::config::{BlueprintManagerConfig, BlueprintManagerContext, Paths};
 use blueprint_manager::executor::run_blueprint_manager;
 use blueprint_runner::config::BlueprintEnvironment;
 use color_eyre::eyre::{Result, eyre};

--- a/cli/src/tests/tangle/run.rs
+++ b/cli/src/tests/tangle/run.rs
@@ -137,7 +137,6 @@ async fn test_run_blueprint() -> Result<()> {
         data_dir: Some(temp_path.clone()),
         signer: Some(harness.sr25519_signer.clone()),
         signer_evm: Some(harness.alloy_key.clone()),
-        podman_host: None,
         allow_unchecked_attestations: false,
     };
 

--- a/crates/clients/tangle/src/services.rs
+++ b/crates/clients/tangle/src/services.rs
@@ -11,6 +11,7 @@ use tangle_subxt::tangle_testnet_runtime::api;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::types::AssetSecurityCommitment;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::service::ServiceBlueprint;
+use tangle_subxt::tangle_testnet_runtime::api::services::calls::types::request::RequestArgs;
 
 /// A client for interacting with the services API
 #[derive(Debug, Clone)]
@@ -119,6 +120,23 @@ where
                 }
                 Ok(ret)
             }
+            None => Ok(Vec::new()),
+        }
+    }
+
+    /// Get the current service operators with their restake exposure
+    #[allow(clippy::missing_errors_doc)]
+    pub async fn current_service_request_arguments(&self, service_id: u64) -> Result<RequestArgs> {
+        let call = api::storage().services().instances(service_id);
+        let ret = self
+            .rpc_client
+            .storage()
+            .at_latest()
+            .await?
+            .fetch(&call)
+            .await?;
+        match ret {
+            Some(instances) => Ok(instances.args.0),
             None => Ok(Vec::new()),
         }
     }

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -63,6 +63,11 @@ fatfs = { workspace = true, features = ["std"], optional = true }
 nix = { workspace = true, features = ["process", "signal", "ioctl", "term", "fs"], optional = true }
 capctl = { workspace = true, features = ["std"], optional = true }
 
+# TEE
+kube = { workspace = true, features = ["client", "rustls-tls"], optional = true }
+k8s-openapi = { workspace = true, features = ["latest"], optional = true }
+local-ip-address.workspace = true
+
 ## Networking
 rtnetlink = { workspace = true, features = ["tokio_socket"], optional = true }
 ipnet = { workspace = true, optional = true }
@@ -76,8 +81,19 @@ default = ["vm-sandbox"]
 ##
 ## **NOTE**: This is only supported on Linux
 ##
-## Enabling this will also add additional CLI arguments: `--no-vm`, `--network-interface`, and `--default-address-pool`
+## Enabling this will also add additional CLI options: `--no-vm`, `--network-interface`, and `--default-address-pool`
 vm-sandbox = ["dep:cloud-hypervisor-client", "dep:fatfs", "dep:nix", "dep:capctl", "dep:rtnetlink", "dep:ipnet", "dep:netdev", "dep:nftables"]
+
+## Enable TEE (Trusted Execution Environment) support
+tee = ["blueprint-runner/tee"]
+
+## Enable containerized blueprints through [Kubernetes] and [kata-containers]
+##
+## Enabling this will also add additional CLI options:
+##
+## [kubernetes]: https://kubernetes.io/
+## [kata-containers]: https://katacontainers.io/
+containers = ["dep:kube", "dep:k8s-openapi"]
 
 [package.metadata.dist]
 dist = false

--- a/crates/manager/src/config/ctx.rs
+++ b/crates/manager/src/config/ctx.rs
@@ -1,0 +1,120 @@
+use crate::config::BlueprintManagerConfig;
+use crate::error::Result;
+#[cfg(feature = "vm-sandbox")]
+use crate::rt::hypervisor::net::NetworkManager;
+use blueprint_auth::db::RocksDb;
+use std::ops::{Deref, DerefMut};
+use tokio::sync::Mutex;
+
+#[cfg(feature = "containers")]
+pub struct ContainerContext {
+    pub kube_client: kube::Client,
+    pub kube_service_port: Mutex<crate::sdk::utils::PortLock>,
+    pub local_ip: std::net::IpAddr,
+}
+
+#[cfg(feature = "vm-sandbox")]
+pub struct VmContext {
+    pub network_manager: NetworkManager,
+    pub network_interface: String,
+}
+
+pub struct BlueprintManagerContext {
+    #[cfg(feature = "containers")]
+    pub containers: ContainerContext,
+    #[cfg(feature = "vm-sandbox")]
+    pub vm: VmContext,
+    pub(crate) db: Mutex<Option<RocksDb>>,
+    config: BlueprintManagerConfig,
+}
+
+impl BlueprintManagerContext {
+    /// Create a new `BlueprintManagerContext`
+    ///
+    /// # Errors
+    ///
+    /// * Unable to create the necessary directories
+    /// * With the `vm-sandbox` enabled
+    ///   * Unable to determine the default network interface if not specified in `config`
+    /// * With the `containers` feature enabled
+    ///   * Unable to connect to the Kubernetes cluster
+    ///   * Unable to bind to the [`BlueprintManagerConfig::kube_service_port()`]
+    ///   * Unable to determine the system's local IPv4 address
+    #[allow(clippy::unused_async)]
+    pub async fn new(mut config: BlueprintManagerConfig) -> Result<Self> {
+        config.paths.data_dir = std::path::absolute(config.data_dir())?;
+
+        config.verify_directories_exist()?;
+        #[cfg(feature = "vm-sandbox")]
+        let (network_manager, network_interface) = {
+            use tracing::info;
+
+            let interface = config.verify_network_interface()?;
+
+            crate::rt::hypervisor::net::nftables::check_net_admin_capability()?;
+
+            let network_candidates = config
+                .vm_sandbox_options
+                .default_address_pool
+                .hosts()
+                .filter(|ip| ip.octets()[3] != 0 && ip.octets()[3] != 255)
+                .collect();
+
+            if config.vm_sandbox_options.no_vm {
+                info!("Skipping VM image check, running in no-vm mode");
+            } else {
+                info!("Checking for VM images");
+                crate::rt::hypervisor::images::download_image_if_needed(config.cache_dir()).await?;
+            }
+
+            (NetworkManager::new(network_candidates).await?, interface)
+        };
+
+        Ok(Self {
+            #[cfg(feature = "containers")]
+            containers: ContainerContext {
+                kube_client: kube::Client::try_default().await?,
+                kube_service_port: Mutex::new(crate::sdk::utils::PortLock::lock(
+                    config.kube_service_port(),
+                )?),
+                local_ip: local_ip_address::local_ip()?,
+            },
+            #[cfg(feature = "vm-sandbox")]
+            vm: VmContext {
+                network_manager,
+                network_interface,
+            },
+            // Set in `run_blueprint_manager_with_keystore`
+            db: Mutex::new(None),
+            config,
+        })
+    }
+
+    pub async fn db(&self) -> Option<RocksDb> {
+        self.db.lock().await.clone()
+    }
+
+    pub async fn set_db(&self, db: RocksDb) {
+        self.db.lock().await.replace(db);
+    }
+
+    #[cfg(feature = "containers")]
+    pub async fn kube_service_port(&self) -> u16 {
+        let mut guard = self.containers.kube_service_port.lock().await;
+        guard.unlock()
+    }
+}
+
+impl Deref for BlueprintManagerContext {
+    type Target = BlueprintManagerConfig;
+
+    fn deref(&self) -> &Self::Target {
+        &self.config
+    }
+}
+
+impl DerefMut for BlueprintManagerContext {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.config
+    }
+}

--- a/crates/manager/src/config/mod.rs
+++ b/crates/manager/src/config/mod.rs
@@ -2,18 +2,10 @@ use crate::error::{Error, Result};
 use blueprint_auth::proxy::DEFAULT_AUTH_PROXY_PORT;
 use blueprint_core::{error, info};
 use clap::{Args, Parser};
-use docktopus::bollard::system::Version;
-use docktopus::bollard::{API_DEFAULT_VERSION, Docker};
-use http_body_util::Full;
-use hyper::body::Bytes;
-use hyper::header::HeaderValue;
-use hyper_util::client::legacy::Client;
-use hyper_util::rt::TokioExecutor;
 use std::fmt::Display;
 use std::net::{IpAddr, Ipv4Addr};
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use url::Url;
 
 mod ctx;
 pub use ctx::*;
@@ -32,7 +24,7 @@ pub struct BlueprintManagerCli {
     pub config: BlueprintManagerConfig,
 }
 
-#[derive(Debug, Args)]
+#[derive(Debug, Args, Default)]
 pub struct BlueprintManagerConfig {
     #[command(flatten)]
     pub paths: Paths,
@@ -277,25 +269,6 @@ fn default_runtime_dir() -> PathBuf {
     match dirs::runtime_dir() {
         Some(dir) => dir.join("blueprint-manager"),
         None => PathBuf::from("/run/blueprint-manager"),
-    }
-}
-
-impl Default for BlueprintManagerConfig {
-    fn default() -> Self {
-        Self {
-            paths: Paths::default(),
-            verbose: 0,
-            pretty: false,
-            instance_id: None,
-            test_mode: false,
-            allow_unchecked_attestations: false,
-            preferred_source: SourceType::default(),
-            #[cfg(feature = "vm-sandbox")]
-            vm_sandbox_options: VmSandboxOptions::default(),
-            #[cfg(feature = "containers")]
-            container_options: ContainerOptions::default(),
-            auth_proxy_opts: AuthProxyOpts::default(),
-        }
     }
 }
 

--- a/crates/manager/src/config/mod.rs
+++ b/crates/manager/src/config/mod.rs
@@ -52,10 +52,12 @@ pub struct BlueprintManagerConfig {
     #[arg(long, short = 's', default_value_t)]
     pub preferred_source: SourceType,
 
+    /// Options to configure the VM sandbox for native blueprints
     #[cfg(feature = "vm-sandbox")]
     #[command(flatten)]
     pub vm_sandbox_options: VmSandboxOptions,
 
+    /// Options to configure the container sandbox for containerized blueprints
     #[cfg(feature = "containers")]
     #[command(flatten)]
     pub container_options: ContainerOptions,

--- a/crates/manager/src/error.rs
+++ b/crates/manager/src/error.rs
@@ -39,6 +39,13 @@ pub enum Error {
     #[error("nftables error: {0}")]
     Nftables(#[from] nftables::helper::NftablesError),
 
+    #[cfg(feature = "containers")]
+    #[error("Kubernetes: {0}")]
+    Kube(#[from] kube::Error),
+    #[cfg(feature = "containers")]
+    #[error("Failed to determine the local IP: {0}")]
+    LocalIp(#[from] local_ip_address::Error),
+
     #[error("Failed to get initial block hash")]
     InitialBlock,
     #[error("Finality Notification stream died")]

--- a/crates/manager/src/executor/event_handler.rs
+++ b/crates/manager/src/executor/event_handler.rs
@@ -18,8 +18,6 @@ use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives:
 use tangle_subxt::tangle_testnet_runtime::api::services::events::{
     JobCalled, JobResultSubmitted, PreRegistration, Registered, ServiceInitiated, Unregistered,
 };
-#[cfg(feature = "vm-sandbox")]
-use crate::rt::hypervisor::{ServiceVmConfig, net::NetworkManager};
 use crate::rt::ResourceLimits;
 use crate::rt::service::Status;
 
@@ -70,7 +68,7 @@ impl VerifiedBlueprint {
                     blueprint_id = blueprint.blueprint_id
                 );
                 continue;
-            };
+            }
 
             // TODO(serial): Check preferred sources first
             let service_str = source.name();

--- a/crates/manager/src/executor/event_handler.rs
+++ b/crates/manager/src/executor/event_handler.rs
@@ -1,6 +1,5 @@
 use std::fs;
-use std::path::Path;
-use crate::config::BlueprintManagerConfig;
+use crate::config::{BlueprintManagerConfig, BlueprintManagerContext};
 use crate::error::{Error, Result};
 use crate::blueprint::native::FilteredBlueprint;
 use crate::blueprint::ActiveBlueprints;
@@ -19,10 +18,10 @@ use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives:
 use tangle_subxt::tangle_testnet_runtime::api::services::events::{
     JobCalled, JobResultSubmitted, PreRegistration, Registered, ServiceInitiated, Unregistered,
 };
-use blueprint_auth::db::RocksDb;
 #[cfg(feature = "vm-sandbox")]
 use crate::rt::hypervisor::{ServiceVmConfig, net::NetworkManager};
-use crate::rt::service::{Service, Status};
+use crate::rt::ResourceLimits;
+use crate::rt::service::Status;
 
 const DEFAULT_PROTOCOL: Protocol = Protocol::Tangle;
 
@@ -35,13 +34,11 @@ impl VerifiedBlueprint {
     #[allow(clippy::cast_possible_truncation)]
     pub async fn start_services_if_needed(
         &mut self,
-        db: RocksDb,
         blueprint_config: &BlueprintEnvironment,
-        manager_config: &BlueprintManagerConfig,
+        ctx: &BlueprintManagerContext,
         active_blueprints: &mut ActiveBlueprints,
-        #[cfg(feature = "vm-sandbox")] network_manager: NetworkManager,
     ) -> Result<()> {
-        let cache_dir = manager_config.cache_dir.join(format!(
+        let cache_dir = ctx.cache_dir().join(format!(
             "{}-{}",
             self.blueprint.blueprint_id, self.blueprint.name
         ));
@@ -63,19 +60,16 @@ impl VerifiedBlueprint {
                 return Ok(());
             }
 
-            let binary_path = match source.fetch(&cache_dir).await {
-                Ok(binary_path) => binary_path,
-                Err(e) => {
-                    error!(
-                        "Failed to fetch blueprint from source at index #{index}[{source_type}]: {e} (blueprint: {blueprint_name}, id: {blueprint_id}). attempting next source",
-                        index = index,
-                        source_type = core::any::type_name_of_val(source),
-                        e = e,
-                        blueprint_name = blueprint.name,
-                        blueprint_id = blueprint.blueprint_id
-                    );
-                    continue;
-                }
+            if let Err(e) = source.fetch(&cache_dir).await {
+                error!(
+                    "Failed to fetch blueprint from source at index #{index}[{source_type}]: {e} (blueprint: {blueprint_name}, id: {blueprint_id}). attempting next source",
+                    index = index,
+                    source_type = core::any::type_name_of_val(source),
+                    e = e,
+                    blueprint_name = blueprint.name,
+                    blueprint_id = blueprint.blueprint_id
+                );
+                continue;
             };
 
             // TODO(serial): Check preferred sources first
@@ -83,10 +77,10 @@ impl VerifiedBlueprint {
             for service_id in &blueprint.services {
                 let sub_service_str = format!("{service_str}-{service_id}");
 
-                let args = BlueprintArgs::new(manager_config);
+                let args = BlueprintArgs::new(ctx);
                 let env = BlueprintEnvVars::new(
                     blueprint_config,
-                    manager_config,
+                    ctx,
                     blueprint_id,
                     *service_id,
                     blueprint,
@@ -97,33 +91,25 @@ impl VerifiedBlueprint {
 
                 let id = active_blueprints.len() as u32;
 
-                let runtime_dir = manager_config.runtime_dir.join(id.to_string());
+                let runtime_dir = ctx.runtime_dir().join(id.to_string());
                 fs::create_dir_all(&runtime_dir)?;
 
-                #[cfg(feature = "vm-sandbox")]
-                let mut service = new_service(
-                    manager_config,
-                    network_manager.clone(),
-                    db.clone(),
-                    blueprint_config,
-                    id,
-                    env,
-                    args,
-                    &binary_path,
-                    &sub_service_str,
-                    &cache_dir,
-                    &runtime_dir,
-                )
-                .await?;
-                #[cfg(not(feature = "vm-sandbox"))]
-                let mut service = new_service_native(
-                    db.clone(),
-                    env,
-                    args,
-                    &binary_path,
-                    &sub_service_str,
-                    &runtime_dir,
-                )?;
+                // TODO: Actually configure resource limits
+                let limits = ResourceLimits::default();
+
+                let mut service = source
+                    .spawn(
+                        ctx,
+                        limits,
+                        blueprint_config,
+                        id,
+                        env,
+                        args,
+                        &sub_service_str,
+                        &cache_dir,
+                        &runtime_dir,
+                    )
+                    .await?;
 
                 let service_start_res = service.start().await;
                 match service_start_res {
@@ -148,57 +134,6 @@ impl VerifiedBlueprint {
 
         Ok(())
     }
-}
-
-#[cfg(feature = "vm-sandbox")]
-#[allow(clippy::too_many_arguments)]
-async fn new_service(
-    manager_config: &BlueprintManagerConfig,
-    network_manager: NetworkManager,
-    db: RocksDb,
-    blueprint_config: &BlueprintEnvironment,
-    id: u32,
-    env: BlueprintEnvVars,
-    args: BlueprintArgs,
-    binary_path: &Path,
-    sub_service_str: &str,
-    cache_dir: &Path,
-    runtime_dir: &Path,
-) -> Result<Service> {
-    if manager_config.no_vm {
-        new_service_native(db, env, args, binary_path, sub_service_str, runtime_dir)
-    } else {
-        Service::new(
-            // TODO: !!! Actually configure the VM with resource limits
-            ServiceVmConfig {
-                id,
-                ..Default::default()
-            },
-            network_manager,
-            manager_config.network_interface.clone().unwrap(),
-            db,
-            &blueprint_config.data_dir,
-            &blueprint_config.keystore_uri,
-            cache_dir,
-            runtime_dir,
-            sub_service_str,
-            binary_path,
-            env,
-            args,
-        )
-        .await
-    }
-}
-
-fn new_service_native(
-    db: RocksDb,
-    env: BlueprintEnvVars,
-    args: BlueprintArgs,
-    binary_path: &Path,
-    sub_service_str: &str,
-    runtime_dir: &Path,
-) -> Result<Service> {
-    Service::new_native(db, runtime_dir, sub_service_str, binary_path, env, args)
 }
 
 impl Debug for VerifiedBlueprint {
@@ -323,12 +258,10 @@ pub(crate) async fn handle_tangle_event(
     event: &TangleEvent,
     blueprints: &[RpcServicesWithBlueprint],
     blueprint_config: &BlueprintEnvironment,
-    db: RocksDb,
-    manager_config: &BlueprintManagerConfig,
+    ctx: &BlueprintManagerContext,
     active_blueprints: &mut ActiveBlueprints,
     poll_result: EventPollResult,
     client: &TangleServicesClient<TangleConfig>,
-    #[cfg(feature = "vm-sandbox")] network_manager: NetworkManager,
 ) -> Result<()> {
     info!("Received notification {}", event.number);
 
@@ -374,7 +307,7 @@ pub(crate) async fn handle_tangle_event(
         .chain(registration_blueprints)
     {
         let verified_blueprint = VerifiedBlueprint {
-            fetchers: get_fetcher_candidates(&blueprint, manager_config)?,
+            fetchers: get_fetcher_candidates(&blueprint, ctx)?,
             blueprint,
         };
 
@@ -392,14 +325,7 @@ pub(crate) async fn handle_tangle_event(
     // Step 3: Check to see if we need to start any new services
     for blueprint in &mut verified_blueprints {
         blueprint
-            .start_services_if_needed(
-                db.clone(),
-                blueprint_config,
-                manager_config,
-                active_blueprints,
-                #[cfg(feature = "vm-sandbox")]
-                network_manager.clone(),
-            )
+            .start_services_if_needed(blueprint_config, ctx, active_blueprints)
             .await?;
     }
 
@@ -491,8 +417,20 @@ fn get_fetcher_candidates(
                 }
             },
 
+            #[cfg(feature = "containers")]
+            BlueprintSource::Container(container) => {
+                let fetcher = crate::sources::container::ContainerSource::new(
+                    container.clone(),
+                    blueprint.blueprint_id,
+                    blueprint.name.clone(),
+                );
+
+                fetcher_candidates.push(DynBlueprintSource::boxed(fetcher));
+            }
+
+            #[cfg(not(feature = "containers"))]
             BlueprintSource::Container(_) => {
-                unimplemented!("Container sources")
+                return Err(Error::UnsupportedBlueprint);
             }
 
             BlueprintSource::Testing(test) => {

--- a/crates/manager/src/rt/container/mod.rs
+++ b/crates/manager/src/rt/container/mod.rs
@@ -1,17 +1,21 @@
-use std::collections::BTreeMap;
 use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
 use crate::rt::ResourceLimits;
 use crate::rt::service::Status;
 use crate::sources::{BlueprintArgs, BlueprintEnvVars};
 use blueprint_core::{info, warn};
-use k8s_openapi::api::core::v1::{Container, EndpointAddress, EndpointPort, EndpointSubset, Endpoints, EnvVar, HostPathVolumeSource, Namespace, Node, Pod, PodSpec, ResourceRequirements, Service, ServicePort, ServiceSpec, Volume, VolumeMount};
+use k8s_openapi::api::core::v1::{
+    Container, EndpointAddress, EndpointPort, EndpointSubset, Endpoints, EnvVar,
+    HostPathVolumeSource, Namespace, Node, Pod, PodSpec, ResourceRequirements, Service,
+    ServicePort, ServiceSpec, Volume, VolumeMount,
+};
+use k8s_openapi::api::node::v1::RuntimeClass;
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
 use kube::Client;
 use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
+use std::collections::BTreeMap;
 use std::net::IpAddr;
-use k8s_openapi::api::node::v1::RuntimeClass;
 use url::{Host, Url};
 
 const BLUEPRINT_NAMESPACE: &str = "blueprint-manager";
@@ -120,7 +124,8 @@ impl ContainerInstance {
                 annotations: {
                     let mut annotations = BTreeMap::new();
                     if let Some(runtime) = runtime.clone() {
-                        annotations.insert(String::from("io.containerd.cri.runtime-handler"), runtime);
+                        annotations
+                            .insert(String::from("io.containerd.cri.runtime-handler"), runtime);
                     }
                     Some(annotations)
                 },

--- a/crates/manager/src/rt/container/mod.rs
+++ b/crates/manager/src/rt/container/mod.rs
@@ -1,0 +1,292 @@
+use std::collections::BTreeMap;
+use crate::config::BlueprintManagerContext;
+use crate::error::{Error, Result};
+use crate::rt::ResourceLimits;
+use crate::rt::service::Status;
+use crate::sources::{BlueprintArgs, BlueprintEnvVars};
+use blueprint_core::{info, warn};
+use k8s_openapi::api::core::v1::{Container, EndpointAddress, EndpointPort, EndpointSubset, Endpoints, EnvVar, HostPathVolumeSource, Namespace, Node, Pod, PodSpec, ResourceRequirements, Service, ServicePort, ServiceSpec, Volume, VolumeMount};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::ObjectMeta;
+use kube::Client;
+use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, PostParams};
+use std::net::IpAddr;
+use k8s_openapi::api::node::v1::RuntimeClass;
+use url::{Host, Url};
+
+const BLUEPRINT_NAMESPACE: &str = "blueprint-manager";
+const BLUEPRINT_SERVICE: &str = "blueprint-service";
+const KEYSTORE_PATH: &str = "/mnt/keystore";
+
+async fn detect_kata(client: Client) -> Result<bool> {
+    let runtimeclass_api: Api<RuntimeClass> = Api::all(client.clone());
+    let runtimeclass_list = runtimeclass_api.list(&ListParams::default()).await?;
+
+    for runtimeclass in runtimeclass_list.items {
+        if runtimeclass.metadata.name.as_deref() == Some("kata") {
+            return Ok(true);
+        }
+    }
+
+    warn!("Kata Containers runtime not found, blueprint will **not** be sandboxed");
+    Ok(false)
+}
+
+pub struct ContainerInstance {
+    client: Client,
+    local_ip: IpAddr,
+    service_port: u16,
+
+    limits: ResourceLimits,
+    service_name: String,
+    image: String,
+    env: BlueprintEnvVars,
+    args: BlueprintArgs,
+    debug: bool,
+}
+
+impl ContainerInstance {
+    /// Create a new `ContainerInstance`
+    pub async fn new(
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
+        service_name: &str,
+        image: String,
+        env: BlueprintEnvVars,
+        args: BlueprintArgs,
+        debug: bool,
+    ) -> ContainerInstance {
+        Self {
+            client: ctx.containers.kube_client.clone(),
+            local_ip: ctx.containers.local_ip,
+            service_port: ctx.kube_service_port().await,
+
+            limits,
+            service_name: service_name.into(),
+            image,
+            env,
+            args,
+            debug,
+        }
+    }
+
+    pub async fn start(&mut self) -> Result<()> {
+        /// TODO: actually resolve the hosts to see if they're loopback
+        // For local testnets, we need to translate IPs to the host
+        fn translate_local_ip(url: &mut Url, host_ip: IpAddr) {
+            match url.host() {
+                Some(Host::Ipv4(ip)) if ip.is_loopback() => {
+                    let _ = url.set_ip_host(host_ip).ok();
+                }
+                _ => {}
+            }
+        }
+
+        self.ensure_namespace().await?;
+        self.ensure_host_service().await?;
+        self.ensure_host_endpoints().await?;
+
+        let runtime = if matches!(detect_kata(self.client.clone()).await, Ok(true)) {
+            Some(String::from("kata"))
+        } else {
+            None
+        };
+
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), BLUEPRINT_NAMESPACE);
+
+        let mem_mib = (self.limits.memory_size / 1024) / 1024;
+
+        let host_keystore_path = self.env.keystore_uri.clone();
+        self.env.keystore_uri = KEYSTORE_PATH.to_string();
+
+        translate_local_ip(&mut self.env.http_rpc_endpoint, self.local_ip);
+        translate_local_ip(&mut self.env.ws_rpc_endpoint, self.local_ip);
+
+        let env = self
+            .env
+            .encode()
+            .into_iter()
+            .map(|(k, v)| EnvVar {
+                name: k,
+                value: Some(v),
+                value_from: None,
+            })
+            .collect::<Vec<_>>();
+
+        let pod = Pod {
+            metadata: ObjectMeta {
+                name: Some(self.service_name.clone()),
+                labels: Some([("app".to_string(), "blueprint".to_string())].into()),
+                annotations: {
+                    let mut annotations = BTreeMap::new();
+                    if let Some(runtime) = runtime.clone() {
+                        annotations.insert(String::from("io.containerd.cri.runtime-handler"), runtime);
+                    }
+                    Some(annotations)
+                },
+                ..Default::default()
+            },
+            spec: Some(PodSpec {
+                runtime_class_name: runtime.clone(),
+                dns_policy: Some("ClusterFirst".to_string()),
+                containers: vec![Container {
+                    name: self.service_name.clone(),
+                    image: Some(self.image.clone()),
+                    resources: Some(ResourceRequirements {
+                        limits: Some(
+                            [("memory".to_string(), Quantity(format!("{mem_mib}Mi")))].into(),
+                        ),
+                        requests: Some(
+                            [("memory".to_string(), Quantity(format!("{mem_mib}Mi")))].into(),
+                        ),
+                        ..Default::default()
+                    }),
+                    env: Some(env),
+                    args: Some(self.args.encode(false)),
+                    volume_mounts: Some(vec![VolumeMount {
+                        name: "keystore-volume".to_string(),
+                        mount_path: KEYSTORE_PATH.to_string(),
+                        read_only: Some(true),
+                        ..Default::default()
+                    }]),
+                    ..Default::default()
+                }],
+                volumes: Some(vec![Volume {
+                    name: "keystore-volume".to_string(),
+                    host_path: Some(HostPathVolumeSource {
+                        path: host_keystore_path,
+                        type_: Some("Directory".to_string()),
+                    }),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let pp = PatchParams::apply("blueprint-mgr").force();
+        pods.patch(&self.service_name, &pp, &Patch::Apply(&pod))
+            .await?;
+
+        info!(target: "containers", service_name = self.service_name, "Pod started successfully.");
+        Ok(())
+    }
+
+    /// Fetches the current status of the Pod from Kubernetes
+    pub async fn status(&self) -> Result<Status> {
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), BLUEPRINT_NAMESPACE);
+        let pod = pods.get(&self.service_name).await?;
+
+        let phase = pod.status.and_then(|s| s.phase).unwrap_or_default();
+        info!(target: "containers", service_name = self.service_name, phase = phase, "Checked pod status");
+
+        let status = match phase.as_str() {
+            "Running" => Status::Running,
+            "Pending" => Status::Pending,
+            "Failed" => Status::Error,
+            "Succeeded" => Status::Finished,
+            _ => Status::Unknown,
+        };
+
+        Ok(status)
+    }
+
+    /// Deletes the Pod from the Kubernetes cluster
+    pub async fn shutdown(self) -> Result<()> {
+        let pods: Api<Pod> = Api::namespaced(self.client.clone(), BLUEPRINT_NAMESPACE);
+        info!(target: "containers", service_name = self.service_name, "Shutting down pod...");
+
+        match pods
+            .delete(&self.service_name, &DeleteParams::default())
+            .await
+        {
+            Ok(_) => {
+                info!(target: "containers", service_name = self.service_name, "Pod deleted successfully.");
+                Ok(())
+            }
+            Err(kube::Error::Api(e)) if e.code == 404 => {
+                warn!(target: "containers", service_name = self.service_name, "Pod was already deleted.");
+                Ok(())
+            }
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    async fn ensure_namespace(&self) -> Result<()> {
+        let namespaces: Api<Namespace> = Api::all(self.client.clone());
+
+        let new_ns = Namespace {
+            metadata: ObjectMeta {
+                name: Some(BLUEPRINT_NAMESPACE.to_string()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+
+        match namespaces.create(&PostParams::default(), &new_ns).await {
+            Ok(o) => {
+                info!(target: "containers", "Created namespace '{}'", o.metadata.name.unwrap_or_default());
+            }
+            // Already exists
+            Err(kube::Error::Api(e)) if e.code == 409 => {}
+            Err(e) => return Err(e.into()),
+        }
+        Ok(())
+    }
+
+    async fn ensure_host_service(&self) -> Result<()> {
+        let services: Api<Service> = Api::namespaced(self.client.clone(), BLUEPRINT_NAMESPACE);
+
+        let service = Service {
+            metadata: ObjectMeta {
+                name: Some(String::from(BLUEPRINT_SERVICE)),
+                ..Default::default()
+            },
+            spec: Some(ServiceSpec {
+                ports: Some(vec![ServicePort {
+                    port: 8080,
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let pp = PatchParams::apply("blueprint-mgr").force();
+        services
+            .patch(BLUEPRINT_SERVICE, &pp, &Patch::Apply(&service))
+            .await?;
+        Ok(())
+    }
+
+    async fn ensure_host_endpoints(&self) -> Result<()> {
+        let endpoints_api: Api<Endpoints> =
+            Api::namespaced(self.client.clone(), BLUEPRINT_NAMESPACE);
+
+        let endpoints = Endpoints {
+            metadata: ObjectMeta {
+                name: Some(String::from(BLUEPRINT_SERVICE)),
+                ..Default::default()
+            },
+            subsets: Some(vec![EndpointSubset {
+                addresses: Some(vec![EndpointAddress {
+                    ip: self.local_ip.to_string(),
+                    ..Default::default()
+                }]),
+                ports: Some(vec![EndpointPort {
+                    port: i32::from(self.service_port),
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            }]),
+        };
+
+        let pp = PatchParams::apply("blueprint-mgr").force();
+        endpoints_api
+            .patch(BLUEPRINT_SERVICE, &pp, &Patch::Apply(&endpoints))
+            .await?;
+        Ok(())
+    }
+}

--- a/crates/manager/src/rt/hypervisor/mod.rs
+++ b/crates/manager/src/rt/hypervisor/mod.rs
@@ -1,8 +1,6 @@
 pub mod images;
 pub mod net;
 
-use net::NetworkManager;
-
 use super::service::Status;
 use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};

--- a/crates/manager/src/rt/hypervisor/mod.rs
+++ b/crates/manager/src/rt/hypervisor/mod.rs
@@ -4,7 +4,9 @@ pub mod net;
 use net::NetworkManager;
 
 use super::service::Status;
+use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
+use crate::rt::ResourceLimits;
 use crate::rt::hypervisor::images::CloudImage;
 use crate::rt::hypervisor::net::Lease;
 use crate::sources::{BlueprintArgs, BlueprintEnvVars};
@@ -31,30 +33,15 @@ use url::{Host, Url};
 
 const VM_DATA_DIR: &str = "/mnt/data";
 
+#[derive(Default)]
 pub struct ServiceVmConfig {
     pub id: u32,
     pub pty: bool,
-    /// Allocated storage space in bytes
-    pub storage_space: u64,
-    /// Allocated memory space in bytes
-    pub memory_size: u64,
-}
-
-impl Default for ServiceVmConfig {
-    fn default() -> Self {
-        Self {
-            id: 0,
-            pty: false,
-            // 20GB
-            storage_space: 1024 * 1024 * 1024 * 20,
-            // 4GB
-            memory_size: 4_294_967_296,
-        }
-    }
 }
 
 pub struct HypervisorInstance {
     config: ServiceVmConfig,
+    limits: ResourceLimits,
     sock_path: PathBuf,
     guest_logs_path: PathBuf,
     binary_image_path: PathBuf,
@@ -73,11 +60,12 @@ impl HypervisorInstance {
     /// * Unable to start a `cloud-hypervisor` instance
     ///     * In this case, the issue may be logged in `<cache_dir>/<service_name>.log.stderr`
     pub fn new(
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
         config: ServiceVmConfig,
         cache_dir: impl AsRef<Path>,
         runtime_dir: impl AsRef<Path>,
         service_name: &str,
-        network_interface: String,
     ) -> Result<HypervisorInstance> {
         info!("Initializing hypervisor for service `{service_name}`...");
 
@@ -115,13 +103,14 @@ impl HypervisorInstance {
 
         Ok(HypervisorInstance {
             config,
+            limits,
             sock_path,
             guest_logs_path,
             binary_image_path,
             cloud_init_image_path,
             hypervisor: hypervisor_handle,
             lease: None,
-            network_interface,
+            network_interface: ctx.vm.network_interface.clone(),
         })
     }
 
@@ -146,7 +135,7 @@ impl HypervisorInstance {
             writeln!(&mut env_vars_str, "export {key}=\"{val}\"").unwrap();
         }
 
-        let args = arguments.encode().join(" ");
+        let args = arguments.encode(true).join(" ");
 
         let launcher_script = LAUNCHER_SCRIPT_TEMPLATE
             .replace("{{ENV_VARS}}", &env_vars_str)
@@ -261,7 +250,7 @@ impl HypervisorInstance {
         let out = Command::new("qemu-img")
             .args(["create", "-f", "qcow2"])
             .arg(&image_path)
-            .arg(self.config.storage_space.to_string())
+            .arg(self.limits.storage_space.to_string())
             .output()
             .await?;
 
@@ -290,7 +279,7 @@ impl HypervisorInstance {
     #[allow(clippy::too_many_arguments)]
     pub async fn prepare(
         &mut self,
-        network_manager: NetworkManager,
+        ctx: &BlueprintManagerContext,
         keystore: impl AsRef<Path>,
         data_dir: impl AsRef<Path>,
         cache_dir: impl AsRef<Path>,
@@ -317,7 +306,7 @@ impl HypervisorInstance {
         env_vars.data_dir = PathBuf::from(VM_DATA_DIR);
         env_vars.keystore_uri = String::from("/srv/keystore");
 
-        let Some(lease) = network_manager.allocate().await else {
+        let Some(lease) = ctx.vm.network_manager.allocate().await else {
             return Err(io::Error::new(io::ErrorKind::QuotaExceeded, "IP pool exhausted").into());
         };
 
@@ -344,7 +333,7 @@ impl HypervisorInstance {
         #[allow(clippy::cast_possible_wrap)]
         let vm_conf = VmConfig {
             memory: Some(MemoryConfig {
-                size: self.config.memory_size as i64,
+                size: self.limits.memory_size as i64,
                 shared: Some(true),
                 ..Default::default()
             }),

--- a/crates/manager/src/rt/hypervisor/net/mod.rs
+++ b/crates/manager/src/rt/hypervisor/net/mod.rs
@@ -1,6 +1,5 @@
 pub mod nftables;
 
-use crate::config::BlueprintManagerConfig;
 use crate::error::{Error, Result};
 use blueprint_core::debug;
 use futures::channel::mpsc::UnboundedReceiver;

--- a/crates/manager/src/rt/hypervisor/net/mod.rs
+++ b/crates/manager/src/rt/hypervisor/net/mod.rs
@@ -164,25 +164,3 @@ pub(super) async fn wait_for_interface(iface_name: &str) -> Result<()> {
 
     res
 }
-
-pub(crate) async fn init_manager_config(
-    manager_config: &mut BlueprintManagerConfig,
-) -> Result<(NetworkManager, String)> {
-    nftables::check_net_admin_capability()?;
-    manager_config.verify_network_interface()?;
-
-    let network_interface = manager_config
-        .network_interface
-        .clone()
-        .expect("interface set by verify_network_interface");
-
-    let network_candidates = manager_config
-        .default_address_pool
-        .hosts()
-        .filter(|ip| ip.octets()[3] != 0 && ip.octets()[3] != 255)
-        .collect();
-
-    let manager = NetworkManager::new(network_candidates).await?;
-
-    Ok((manager, network_interface))
-}

--- a/crates/manager/src/rt/mod.rs
+++ b/crates/manager/src/rt/mod.rs
@@ -1,4 +1,24 @@
+#[cfg(feature = "containers")]
+pub mod container;
 #[cfg(feature = "vm-sandbox")]
 pub mod hypervisor;
 pub mod native;
 pub mod service;
+
+pub struct ResourceLimits {
+    /// Allocated storage space in bytes
+    pub storage_space: u64,
+    /// Allocated memory space in bytes
+    pub memory_size: u64,
+}
+
+impl Default for ResourceLimits {
+    fn default() -> Self {
+        Self {
+            // 20GB
+            storage_space: 1024 * 1024 * 1024 * 20,
+            // 4GB
+            memory_size: 1024 * 1024 * 1024 * 4,
+        }
+    }
+}

--- a/crates/manager/src/rt/native.rs
+++ b/crates/manager/src/rt/native.rs
@@ -1,6 +1,7 @@
 use super::service::Status;
 use tokio::sync::mpsc::UnboundedReceiver;
 
+/// Handle for a natively (no sandbox) running service
 pub struct ProcessHandle {
     status: UnboundedReceiver<Status>,
     cached_status: Status,

--- a/crates/manager/src/rt/service.rs
+++ b/crates/manager/src/rt/service.rs
@@ -3,6 +3,7 @@ use super::hypervisor::{HypervisorInstance, ServiceVmConfig, net::NetworkManager
 use super::native::ProcessHandle;
 use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
+use crate::rt::ResourceLimits;
 #[cfg(feature = "containers")]
 use crate::rt::container::ContainerInstance;
 use crate::sources::{BlueprintArgs, BlueprintEnvVars};
@@ -14,7 +15,6 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::time;
-use crate::rt::ResourceLimits;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Status {
@@ -126,7 +126,16 @@ impl Service {
             .await;
         }
 
-        Service::new_native(ctx, limits, runtime_dir, sub_service_str, binary_path, env, args).await
+        Service::new_native(
+            ctx,
+            limits,
+            runtime_dir,
+            sub_service_str,
+            binary_path,
+            env,
+            args,
+        )
+        .await
     }
 
     /// Create a new `Service` instance, sandboxed via `cloud-hypervisor`

--- a/crates/manager/src/rt/service.rs
+++ b/crates/manager/src/rt/service.rs
@@ -1,5 +1,5 @@
 #[cfg(feature = "vm-sandbox")]
-use super::hypervisor::{HypervisorInstance, ServiceVmConfig, net::NetworkManager};
+use super::hypervisor::{HypervisorInstance, ServiceVmConfig};
 use super::native::ProcessHandle;
 use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
@@ -27,6 +27,7 @@ pub enum Status {
 }
 
 struct NativeProcessInfo {
+    #[expect(unused, reason = "Host processes aren't resource constrained yet")]
     limits: ResourceLimits,
     binary_path: PathBuf,
     service_name: String,
@@ -92,6 +93,7 @@ impl Service {
     /// See:
     /// * [`Service::new_vm()`]
     /// * [`Service::new_native()`]
+    #[allow(clippy::too_many_arguments)]
     pub async fn from_binary(
         ctx: &BlueprintManagerContext,
         limits: ResourceLimits,

--- a/crates/manager/src/rt/service.rs
+++ b/crates/manager/src/rt/service.rs
@@ -1,26 +1,33 @@
 #[cfg(feature = "vm-sandbox")]
 use super::hypervisor::{HypervisorInstance, ServiceVmConfig, net::NetworkManager};
 use super::native::ProcessHandle;
+use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
+#[cfg(feature = "containers")]
+use crate::rt::container::ContainerInstance;
 use crate::sources::{BlueprintArgs, BlueprintEnvVars};
-use blueprint_auth::db::RocksDb;
 use blueprint_core::error;
+use blueprint_core::{info, warn};
 use blueprint_manager_bridge::server::{Bridge, BridgeHandle};
+use blueprint_runner::config::BlueprintEnvironment;
 use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tokio::sync::oneshot;
 use tokio::time;
-use tracing::{info, warn};
+use crate::rt::ResourceLimits;
 
 #[derive(Copy, Clone, Debug, PartialEq, Eq)]
 pub enum Status {
     NotStarted,
+    Pending,
     Running,
     Finished,
     Error,
+    Unknown,
 }
 
 struct NativeProcessInfo {
+    limits: ResourceLimits,
     binary_path: PathBuf,
     service_name: String,
     env_vars: BlueprintEnvVars,
@@ -35,6 +42,8 @@ enum NativeProcess {
 enum Runtime {
     #[cfg(feature = "vm-sandbox")]
     Hypervisor(HypervisorInstance),
+    #[cfg(feature = "containers")]
+    Container(ContainerInstance),
     Native(NativeProcess),
 }
 
@@ -45,12 +54,17 @@ pub struct Service {
     alive_rx: Option<oneshot::Receiver<()>>,
 }
 
-fn create_bridge(
+async fn create_bridge(
+    ctx: &BlueprintManagerContext,
     runtime_dir: impl AsRef<Path>,
     service_name: &str,
-    db: RocksDb,
     no_vm: bool,
 ) -> Result<(PathBuf, BridgeHandle, oneshot::Receiver<()>)> {
+    let db = ctx
+        .db()
+        .await
+        .expect("not possible to get to this point without a db set");
+
     let bridge = Bridge::new(
         runtime_dir.as_ref().to_path_buf(),
         service_name.to_string(),
@@ -68,7 +82,54 @@ fn create_bridge(
 }
 
 impl Service {
-    /// Create a new `Service` instance
+    /// Create a new `Service` instance for the given binary at `binary_path`
+    ///
+    /// This is the same as calling [`Service::new_vm()`] or [`Service::new_native()`], with the runtime
+    /// being determined by the [`BlueprintManagerContext`] and enabled features.
+    ///
+    /// # Errors
+    ///
+    /// See:
+    /// * [`Service::new_vm()`]
+    /// * [`Service::new_native()`]
+    pub async fn from_binary(
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
+        blueprint_config: &BlueprintEnvironment,
+        id: u32,
+        env: BlueprintEnvVars,
+        args: BlueprintArgs,
+        binary_path: &Path,
+        sub_service_str: &str,
+        cache_dir: &Path,
+        runtime_dir: &Path,
+    ) -> Result<Service> {
+        #[cfg(feature = "vm-sandbox")]
+        if !ctx.vm_sandbox_options.no_vm {
+            return Service::new_vm(
+                ctx,
+                limits,
+                // TODO: !!! Actually configure the VM with resource limits
+                ServiceVmConfig {
+                    id,
+                    ..Default::default()
+                },
+                &blueprint_config.data_dir,
+                &blueprint_config.keystore_uri,
+                cache_dir,
+                runtime_dir,
+                sub_service_str,
+                binary_path,
+                env,
+                args,
+            )
+            .await;
+        }
+
+        Service::new_native(ctx, limits, runtime_dir, sub_service_str, binary_path, env, args).await
+    }
+
+    /// Create a new `Service` instance, sandboxed via `cloud-hypervisor`
     ///
     /// This will:
     /// * Spawn a [`Bridge`]
@@ -82,11 +143,10 @@ impl Service {
     /// * [`HypervisorInstance::prepare()`]
     #[allow(clippy::too_many_arguments)]
     #[cfg(feature = "vm-sandbox")]
-    pub async fn new(
+    pub async fn new_vm(
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
         vm_config: ServiceVmConfig,
-        network_manager: NetworkManager,
-        network_interface: String,
-        db: RocksDb,
         data_dir: impl AsRef<Path>,
         keystore: impl AsRef<Path>,
         cache_dir: impl AsRef<Path>,
@@ -100,19 +160,20 @@ impl Service {
         env_vars.bridge_socket_path = None;
 
         let (bridge_base_socket, bridge_handle, alive_rx) =
-            create_bridge(runtime_dir.as_ref(), service_name, db, false)?;
+            create_bridge(ctx, runtime_dir.as_ref(), service_name, false).await?;
 
         let mut hypervisor = HypervisorInstance::new(
+            ctx,
+            limits,
             vm_config,
             cache_dir.as_ref(),
             runtime_dir.as_ref(),
             service_name,
-            network_interface,
         )?;
 
         hypervisor
             .prepare(
-                network_manager,
+                ctx,
                 keystore,
                 data_dir,
                 cache_dir,
@@ -130,7 +191,7 @@ impl Service {
         })
     }
 
-    /// Create a new `Service` instance
+    /// Create a new `Service` instance, sandboxed via `kata-containers`
     ///
     /// This will:
     /// * Spawn a [`Bridge`]
@@ -140,11 +201,50 @@ impl Service {
     ///
     /// See:
     /// * [`Bridge::spawn()`]
-    /// * [`HypervisorInstance::new()`]
-    /// * [`HypervisorInstance::prepare()`]
+    /// * [`ContainerInstance::new()`]
+    /// * [`ContainerInstance::prepare()`]
     #[allow(clippy::too_many_arguments)]
-    pub fn new_native(
-        db: RocksDb,
+    #[cfg(feature = "containers")]
+    pub async fn new_container(
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
+        runtime_dir: impl AsRef<Path>,
+        service_name: &str,
+        image: String,
+        mut env_vars: BlueprintEnvVars,
+        arguments: BlueprintArgs,
+        debug: bool,
+    ) -> Result<Service> {
+        let (bridge_base_socket, bridge_handle, alive_rx) =
+            create_bridge(ctx, runtime_dir.as_ref(), service_name, false).await?;
+
+        env_vars.bridge_socket_path = Some(bridge_base_socket);
+
+        let instance =
+            ContainerInstance::new(ctx, limits, service_name, image, env_vars, arguments, debug)
+                .await;
+
+        Ok(Self {
+            runtime: Runtime::Container(instance),
+            bridge: bridge_handle,
+            alive_rx: Some(alive_rx),
+        })
+    }
+
+    /// Create a new `Service` instance **with no sandbox**
+    ///
+    /// NOTE: This should only be used for local testing.
+    ///
+    /// This will spawn a [`Bridge`] in preparation for the service to be started.
+    ///
+    /// # Errors
+    ///
+    /// See:
+    /// * [`Bridge::spawn()`]
+    #[allow(clippy::too_many_arguments)]
+    pub async fn new_native(
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
         runtime_dir: impl AsRef<Path>,
         service_name: &str,
         binary_path: impl AsRef<Path>,
@@ -152,12 +252,13 @@ impl Service {
         arguments: BlueprintArgs,
     ) -> Result<Service> {
         let (bridge_base_socket, bridge_handle, alive_rx) =
-            create_bridge(runtime_dir.as_ref(), service_name, db, true)?;
+            create_bridge(ctx, runtime_dir.as_ref(), service_name, true).await?;
 
         env_vars.bridge_socket_path = Some(bridge_base_socket);
 
         Ok(Self {
             runtime: Runtime::Native(NativeProcess::NotStarted(NativeProcessInfo {
+                limits,
                 binary_path: binary_path.as_ref().to_path_buf(),
                 service_name: service_name.to_string(),
                 env_vars,
@@ -180,6 +281,8 @@ impl Service {
         match &mut self.runtime {
             #[cfg(feature = "vm-sandbox")]
             Runtime::Hypervisor(hypervisor) => hypervisor.status().await,
+            #[cfg(feature = "containers")]
+            Runtime::Container(container) => container.status().await,
             Runtime::Native(NativeProcess::Started(instance)) => Ok(instance.status()),
             Runtime::Native(NativeProcess::NotStarted(_)) => Ok(Status::NotStarted),
         }
@@ -209,14 +312,22 @@ impl Service {
                     e
                 })?;
             }
+            #[cfg(feature = "containers")]
+            Runtime::Container(container) => {
+                container.start().await.map_err(|e| {
+                    error!("Failed to start container: {e}");
+                    e
+                })?;
+            }
             Runtime::Native(instance) => match instance {
                 NativeProcess::NotStarted(info) => {
+                    // TODO: Resource limits
                     let process_handle = tokio::process::Command::new(&info.binary_path)
                         .kill_on_drop(true)
                         .stdin(std::process::Stdio::null())
                         .current_dir(&std::env::current_dir()?)
                         .envs(info.env_vars.encode())
-                        .args(info.arguments.encode())
+                        .args(info.arguments.encode(true))
                         .spawn()?;
 
                     let handle =
@@ -257,6 +368,13 @@ impl Service {
             Runtime::Hypervisor(hypervisor) => {
                 hypervisor.shutdown().await.map_err(|e| {
                     error!("Failed to shut down hypervisor: {e}");
+                    e
+                })?;
+            }
+            #[cfg(feature = "containers")]
+            Runtime::Container(container) => {
+                container.shutdown().await.map_err(|e| {
+                    error!("Failed to shut down container instance: {e}");
                     e
                 })?;
             }

--- a/crates/manager/src/sources/container.rs
+++ b/crates/manager/src/sources/container.rs
@@ -1,0 +1,123 @@
+use super::{BlueprintArgs, BlueprintEnvVars};
+use super::BlueprintSourceHandler;
+use crate::error::{Error, Result};
+use docktopus::bollard::Docker;
+use docktopus::container::Container;
+use std::sync::Arc;
+use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::sources::ImageRegistryFetcher;
+use tokio::process::Command;
+use tokio::sync::{mpsc, oneshot};
+use tracing::{info, log, warn};
+use blueprint_runner::config::BlueprintEnvironment;
+use std::future::Future;
+use url::Url;
+use std::net::IpAddr;
+use std::path::{Path, PathBuf};
+use tokio::net::lookup_host;
+use crate::config::BlueprintManagerContext;
+use crate::rt::ResourceLimits;
+use crate::rt::service::{Service, Status};
+
+pub struct ContainerSource {
+    pub fetcher: ImageRegistryFetcher,
+    pub blueprint_id: u64,
+    pub blueprint_name: String,
+    resolved_image: Option<String>,
+}
+
+impl ContainerSource {
+    #[must_use]
+    pub fn new(fetcher: ImageRegistryFetcher, blueprint_id: u64, blueprint_name: String) -> Self {
+        Self {
+            fetcher,
+            blueprint_id,
+            blueprint_name,
+            resolved_image: None,
+        }
+    }
+}
+
+/// Returns true if the given URL appears to refer to a local endpoint,
+/// using the OS's resolver configuration.
+async fn is_local_endpoint(url: &mut Url) -> bool {
+    let Some(host) = url.host_str() else {
+        return false;
+    };
+
+    if host.eq_ignore_ascii_case("localhost") {
+        return true;
+    }
+
+    if let Ok(ip) = host.parse::<IpAddr>() {
+        return ip.is_loopback();
+    }
+
+    // Default to 9944, since this is only ever used to determine the RPC endpoint for a Tangle node anyway.
+    let port = url.port_or_known_default().unwrap_or(9944);
+    if let Ok(mut addrs) = lookup_host((host, port)).await {
+        return addrs.all(|addr| addr.ip().is_loopback());
+    }
+
+    false
+}
+
+/// Convert any local endpoints to `host.docker.internal`
+async fn adjust_url_for_container(url: &mut Url) {
+    if is_local_endpoint(url).await {
+        url.set_host(Some("172.17.0.1"))
+            .expect("Failed to set host in URL");
+    }
+}
+
+// TODO(serial): Stop using `Error::Other` everywhere.
+impl BlueprintSourceHandler for ContainerSource {
+    async fn fetch(&mut self, _cache_dir: &Path) -> Result<PathBuf> {
+        if let Some(resolved_image) = &self.resolved_image {
+            return Ok(PathBuf::from(resolved_image));
+        }
+
+        let registry = String::from_utf8(self.fetcher.registry.0.0.clone())
+            .map_err(|e| Error::Other(e.to_string()))?;
+        let image = String::from_utf8(self.fetcher.image.0.0.clone())
+            .map_err(|e| Error::Other(e.to_string()))?;
+        let tag = String::from_utf8(self.fetcher.tag.0.0.clone())
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        let full = format!("{registry}/{image}:{tag}");
+        log::info!("Pulling image {full}");
+
+        Command::new("docker")
+            .arg("pull")
+            .arg(&full)
+            .status()
+            .await
+            .map_err(|e| Error::Other(e.to_string()))?;
+
+        self.resolved_image = Some(full);
+        Ok(PathBuf::from(self.resolved_image.as_ref().unwrap()))
+    }
+
+    async fn spawn(
+        &mut self,
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
+        _blueprint_config: &BlueprintEnvironment,
+        _id: u32,
+        env: BlueprintEnvVars,
+        args: BlueprintArgs,
+        sub_service_str: &str,
+        cache_dir: &Path,
+        runtime_dir: &Path,
+    ) -> Result<Service> {
+        let image = self.fetch(cache_dir).await?;
+        Service::new_container(ctx, limits, runtime_dir, sub_service_str, image.to_string_lossy().to_string(), env, args, false).await
+    }
+
+    fn blueprint_id(&self) -> u64 {
+        self.blueprint_id
+    }
+
+    fn name(&self) -> String {
+        self.blueprint_name.clone()
+    }
+}

--- a/crates/manager/src/sources/container.rs
+++ b/crates/manager/src/sources/container.rs
@@ -110,7 +110,17 @@ impl BlueprintSourceHandler for ContainerSource {
         runtime_dir: &Path,
     ) -> Result<Service> {
         let image = self.fetch(cache_dir).await?;
-        Service::new_container(ctx, limits, runtime_dir, sub_service_str, image.to_string_lossy().to_string(), env, args, false).await
+        Service::new_container(
+            ctx,
+            limits,
+            runtime_dir,
+            sub_service_str,
+            image.to_string_lossy().to_string(),
+            env,
+            args,
+            false,
+        )
+        .await
     }
 
     fn blueprint_id(&self) -> u64 {

--- a/crates/manager/src/sources/container.rs
+++ b/crates/manager/src/sources/container.rs
@@ -1,22 +1,14 @@
 use super::{BlueprintArgs, BlueprintEnvVars};
 use super::BlueprintSourceHandler;
 use crate::error::{Error, Result};
-use docktopus::bollard::Docker;
-use docktopus::container::Container;
-use std::sync::Arc;
 use tangle_subxt::tangle_testnet_runtime::api::runtime_types::tangle_primitives::services::sources::ImageRegistryFetcher;
 use tokio::process::Command;
-use tokio::sync::{mpsc, oneshot};
-use tracing::{info, log, warn};
+use tracing::log;
 use blueprint_runner::config::BlueprintEnvironment;
-use std::future::Future;
-use url::Url;
-use std::net::IpAddr;
 use std::path::{Path, PathBuf};
-use tokio::net::lookup_host;
 use crate::config::BlueprintManagerContext;
 use crate::rt::ResourceLimits;
-use crate::rt::service::{Service, Status};
+use crate::rt::service::Service;
 
 pub struct ContainerSource {
     pub fetcher: ImageRegistryFetcher,
@@ -34,38 +26,6 @@ impl ContainerSource {
             blueprint_name,
             resolved_image: None,
         }
-    }
-}
-
-/// Returns true if the given URL appears to refer to a local endpoint,
-/// using the OS's resolver configuration.
-async fn is_local_endpoint(url: &mut Url) -> bool {
-    let Some(host) = url.host_str() else {
-        return false;
-    };
-
-    if host.eq_ignore_ascii_case("localhost") {
-        return true;
-    }
-
-    if let Ok(ip) = host.parse::<IpAddr>() {
-        return ip.is_loopback();
-    }
-
-    // Default to 9944, since this is only ever used to determine the RPC endpoint for a Tangle node anyway.
-    let port = url.port_or_known_default().unwrap_or(9944);
-    if let Ok(mut addrs) = lookup_host((host, port)).await {
-        return addrs.all(|addr| addr.ip().is_loopback());
-    }
-
-    false
-}
-
-/// Convert any local endpoints to `host.docker.internal`
-async fn adjust_url_for_container(url: &mut Url) {
-    if is_local_endpoint(url).await {
-        url.set_host(Some("172.17.0.1"))
-            .expect("Failed to set host in URL");
     }
 }
 
@@ -93,8 +53,9 @@ impl BlueprintSourceHandler for ContainerSource {
             .await
             .map_err(|e| Error::Other(e.to_string()))?;
 
+        let ret = PathBuf::from(&full);
         self.resolved_image = Some(full);
-        Ok(PathBuf::from(self.resolved_image.as_ref().unwrap()))
+        Ok(ret)
     }
 
     async fn spawn(

--- a/crates/manager/src/sources/github.rs
+++ b/crates/manager/src/sources/github.rs
@@ -1,5 +1,5 @@
 use std::fs::File;
-use super::BlueprintSourceHandler;
+use super::{BlueprintArgs, BlueprintEnvVars, BlueprintSourceHandler};
 use crate::error::{Error, Result};
 use crate::blueprint::native::get_blueprint_binary;
 use crate::sdk::utils::{make_executable, valid_file_exists};
@@ -13,6 +13,10 @@ use tar::Archive;
 use tokio::io::AsyncWriteExt;
 use blueprint_core::{error, warn};
 use xz::read::XzDecoder;
+use blueprint_runner::config::BlueprintEnvironment;
+use crate::config::BlueprintManagerContext;
+use crate::rt::ResourceLimits;
+use crate::rt::service::Service;
 
 pub struct GithubBinaryFetcher {
     pub fetcher: GithubFetcher,
@@ -143,7 +147,12 @@ impl GithubBinaryFetcher {
 impl BlueprintSourceHandler for GithubBinaryFetcher {
     async fn fetch(&mut self, cache_dir: &Path) -> Result<PathBuf> {
         if let Some(resolved_binary_path) = &self.resolved_binary_path {
-            return Ok(resolved_binary_path.clone());
+            if resolved_binary_path.exists() {
+                return Ok(resolved_binary_path.clone());
+            }
+
+            // Re-resolve
+            self.resolved_binary_path = None;
         }
 
         let archive_path = self.get_binary(cache_dir).await?;
@@ -195,6 +204,34 @@ impl BlueprintSourceHandler for GithubBinaryFetcher {
         binary_path = make_executable(&binary_path)?;
         self.resolved_binary_path = Some(binary_path.clone());
         Ok(binary_path)
+    }
+
+    async fn spawn(
+        &mut self,
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
+        blueprint_config: &BlueprintEnvironment,
+        id: u32,
+        env: BlueprintEnvVars,
+        args: BlueprintArgs,
+        sub_service_str: &str,
+        cache_dir: &Path,
+        runtime_dir: &Path,
+    ) -> Result<Service> {
+        let resolved_binary_path = self.fetch(cache_dir).await?;
+        Service::from_binary(
+            ctx,
+            limits,
+            blueprint_config,
+            id,
+            env,
+            args,
+            &resolved_binary_path,
+            sub_service_str,
+            cache_dir,
+            &runtime_dir,
+        )
+        .await
     }
 
     fn blueprint_id(&self) -> u64 {

--- a/crates/manager/src/sources/github.rs
+++ b/crates/manager/src/sources/github.rs
@@ -229,7 +229,7 @@ impl BlueprintSourceHandler for GithubBinaryFetcher {
             &resolved_binary_path,
             sub_service_str,
             cache_dir,
-            &runtime_dir,
+            runtime_dir,
         )
         .await
     }

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -1,15 +1,15 @@
 use crate::blueprint::native::FilteredBlueprint;
 use crate::config::{BlueprintManagerConfig, BlueprintManagerContext};
+use crate::rt::ResourceLimits;
 use crate::rt::service::Service;
 use blueprint_runner::config::{BlueprintEnvironment, Protocol, SupportedChains};
 use std::path::{Path, PathBuf};
 use url::Url;
-use crate::rt::ResourceLimits;
 
-pub mod github;
-pub mod testing;
 #[cfg(feature = "containers")]
 pub mod container;
+pub mod github;
+pub mod testing;
 
 #[auto_impl::auto_impl(Box)]
 #[dynosaur::dynosaur(pub(crate) DynBlueprintSource)]

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -1,11 +1,15 @@
 use crate::blueprint::native::FilteredBlueprint;
-use crate::config::BlueprintManagerConfig;
+use crate::config::{BlueprintManagerConfig, BlueprintManagerContext};
+use crate::rt::service::Service;
 use blueprint_runner::config::{BlueprintEnvironment, Protocol, SupportedChains};
 use std::path::{Path, PathBuf};
 use url::Url;
+use crate::rt::ResourceLimits;
 
 pub mod github;
 pub mod testing;
+#[cfg(feature = "containers")]
+pub mod container;
 
 #[auto_impl::auto_impl(Box)]
 #[dynosaur::dynosaur(pub(crate) DynBlueprintSource)]
@@ -14,6 +18,18 @@ pub trait BlueprintSourceHandler: Send + Sync {
         &mut self,
         cache_dir: &Path,
     ) -> impl Future<Output = crate::error::Result<PathBuf>> + Send;
+    fn spawn(
+        &mut self,
+        ctx: &BlueprintManagerContext,
+        limits: ResourceLimits,
+        blueprint_config: &BlueprintEnvironment,
+        id: u32,
+        env: BlueprintEnvVars,
+        args: BlueprintArgs,
+        sub_service_str: &str,
+        cache_dir: &Path,
+        runtime_dir: &Path,
+    ) -> impl Future<Output = crate::error::Result<Service>> + Send;
     fn blueprint_id(&self) -> u64;
     fn name(&self) -> String;
 }
@@ -47,9 +63,11 @@ impl BlueprintArgs {
     }
 
     #[must_use]
-    pub fn encode(&self) -> Vec<String> {
+    pub fn encode(&self, run: bool) -> Vec<String> {
         let mut arguments = vec![];
-        arguments.push("run".to_string());
+        if run {
+            arguments.push("run".to_string());
+        }
 
         if self.test_mode {
             arguments.push("--test-mode".to_string());
@@ -71,6 +89,8 @@ impl BlueprintArgs {
 pub struct BlueprintEnvVars {
     pub http_rpc_endpoint: Url,
     pub ws_rpc_endpoint: Url,
+    #[cfg(feature = "tee")]
+    pub kms_endpoint: Url,
     pub keystore_uri: String,
     pub data_dir: PathBuf,
     pub blueprint_id: u64,
@@ -92,8 +112,9 @@ impl BlueprintEnvVars {
         blueprint: &FilteredBlueprint,
         sub_service_str: &str,
     ) -> BlueprintEnvVars {
-        let base_data_dir = &manager_config.data_dir;
-        let data_dir = base_data_dir.join(format!("blueprint-{blueprint_id}-{sub_service_str}"));
+        let data_dir = manager_config
+            .data_dir()
+            .join(format!("blueprint-{blueprint_id}-{sub_service_str}"));
 
         let bootnodes = env
             .bootnodes
@@ -103,6 +124,8 @@ impl BlueprintEnvVars {
         BlueprintEnvVars {
             http_rpc_endpoint: env.http_rpc_endpoint.clone(),
             ws_rpc_endpoint: env.ws_rpc_endpoint.clone(),
+            #[cfg(feature = "tee")]
+            kms_endpoint: env.kms_url.clone(),
             keystore_uri: env.keystore_uri.to_string(),
             data_dir,
             blueprint_id,
@@ -120,6 +143,8 @@ impl BlueprintEnvVars {
         let BlueprintEnvVars {
             http_rpc_endpoint,
             ws_rpc_endpoint,
+            #[cfg(feature = "tee")]
+            kms_endpoint,
             keystore_uri,
             data_dir,
             blueprint_id,
@@ -142,6 +167,8 @@ impl BlueprintEnvVars {
         let mut env_vars = vec![
             ("HTTP_RPC_URL".to_string(), http_rpc_endpoint.to_string()),
             ("WS_RPC_URL".to_string(), ws_rpc_endpoint.to_string()),
+            #[cfg(feature = "tee")]
+            ("KMS_URL".to_string(), kms_endpoint.to_string()),
             ("KEYSTORE_URI".to_string(), keystore_uri.clone()),
             ("DATA_DIR".to_string(), data_dir.display().to_string()),
             ("BLUEPRINT_ID".to_string(), blueprint_id.to_string()),

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -18,6 +18,7 @@ pub trait BlueprintSourceHandler: Send + Sync {
         &mut self,
         cache_dir: &Path,
     ) -> impl Future<Output = crate::error::Result<PathBuf>> + Send;
+    #[allow(clippy::too_many_arguments)]
     fn spawn(
         &mut self,
         ctx: &BlueprintManagerContext,

--- a/crates/manager/src/sources/testing.rs
+++ b/crates/manager/src/sources/testing.rs
@@ -168,7 +168,7 @@ impl BlueprintSourceHandler for TestSourceFetcher {
             &resolved_binary_path,
             sub_service_str,
             cache_dir,
-            &runtime_dir,
+            runtime_dir,
         )
         .await
     }

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -74,6 +74,9 @@ std = ["blueprint-tangle-extra?/std", "blueprint-evm-extra?/std", "blueprint-key
 ## Enable networking support for [`BlueprintEnvironment`](crate::config::BlueprintEnvironment)
 networking = ["dep:blueprint-networking", "dep:crossbeam-channel", "dep:libp2p", "blueprint-keystore/zebra"]
 
+## Enable Trusted Execution Environment (TEE) support for the runner
+tee = []
+
 #! ### Protocols
 
 ## Enable [Tangle] support

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -997,6 +997,7 @@ fn default_ws_rpc_url() -> Url {
     Url::from_str("ws://127.0.0.1:9944").unwrap()
 }
 
+#[cfg(feature = "tee")]
 fn default_kms_url() -> Url {
     Url::from_str("https://kms.tangle.tools").unwrap()
 }

--- a/crates/runner/src/config.rs
+++ b/crates/runner/src/config.rs
@@ -237,6 +237,10 @@ pub struct BlueprintEnvironment {
     #[serde(skip)]
     bridge: Arc<Mutex<Option<Arc<Bridge>>>>,
 
+    /// KMS HTTP endpoint
+    #[cfg(feature = "tee")]
+    pub kms_url: Url,
+
     #[cfg(feature = "networking")]
     pub bootnodes: Vec<Multiaddr>,
     /// The port to bind the network to
@@ -263,6 +267,9 @@ impl Default for BlueprintEnvironment {
             test_mode: false,
             bridge_socket_path: None,
             bridge: Arc::new(Mutex::new(None)),
+
+            #[cfg(feature = "tee")]
+            kms_url: default_kms_url(),
 
             #[cfg(feature = "networking")]
             bootnodes: Vec::new(),
@@ -326,6 +333,9 @@ fn load_inner(config: ContextConfig) -> Result<BlueprintEnvironment, ConfigError
     let keystore_uri = settings.keystore_uri.clone();
     let bridge_socket_path = settings.bridge_socket_path.clone();
 
+    #[cfg(feature = "tee")]
+    let kms_url = settings.kms_url.clone();
+
     #[cfg(feature = "networking")]
     let bootnodes = settings.bootnodes.clone().unwrap_or_default();
     #[cfg(feature = "networking")]
@@ -348,6 +358,9 @@ fn load_inner(config: ContextConfig) -> Result<BlueprintEnvironment, ConfigError
         protocol_settings,
         bridge_socket_path,
         bridge: Arc::new(Mutex::new(None)),
+
+        #[cfg(feature = "tee")]
+        kms_url,
 
         #[cfg(feature = "networking")]
         bootnodes,
@@ -567,6 +580,8 @@ impl ContextConfig {
                 enable_kademlia,
                 #[cfg(feature = "networking")]
                 target_peer_count: None,
+                #[cfg(feature = "tee")]
+                kms_url: default_kms_url(),
                 keystore_uri,
                 data_dir,
                 chain,
@@ -767,6 +782,17 @@ pub struct BlueprintSettings {
     #[serde(default)]
     pub target_peer_count: Option<u32>,
 
+    // ========
+    // TEE
+    // ========
+    /// URL of the Key Brokerage Service (KBS)
+    ///
+    /// This defaults to the central KBS hosted by Tangle
+    #[cfg(feature = "tee")]
+    #[arg(long, env, default_value_t = default_kms_url())]
+    #[serde(default = "default_kms_url")]
+    pub kms_url: Url,
+
     // =======
     // TANGLE
     // =======
@@ -920,6 +946,12 @@ impl Default for BlueprintSettings {
             #[cfg(feature = "networking")]
             target_peer_count: None,
 
+            // ========
+            // TEE
+            // ========
+            #[cfg(feature = "tee")]
+            kms_url: default_kms_url(),
+
             // =======
             // TANGLE
             // =======
@@ -963,6 +995,10 @@ fn default_http_rpc_url() -> Url {
 
 fn default_ws_rpc_url() -> Url {
     Url::from_str("ws://127.0.0.1:9944").unwrap()
+}
+
+fn default_kms_url() -> Url {
+    Url::from_str("https://kms.tangle.tools").unwrap()
 }
 
 #[derive(Copy, Clone, Default, Debug, Serialize, Deserialize, PartialEq, Eq, clap::ValueEnum)]


### PR DESCRIPTION
Adds back container source support. This time under Kubernetes + Kata Containers, and gated by the `containers` feature in the manager.

This also adds a container sources to the `cargo tangle debug spawn` command, which previously only supported VM spawning. You can switch methods with the new `--method` option, like:

`cargo tangle debug spawn --method container --image "docker.io/bls-blueprint:latest`

and for VMs:

`cargo tangle debug spawn --method vm --binary "./target/debug/bls-blueprint-bin"`