### PR TITLE
feat: standalone auth proxy

### DIFF
--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -17,7 +17,7 @@ tower = { workspace = true, features = ["util"] }
 tower-http = { workspace = true, features = ["cors", "request-id", "sensitive-headers", "trace"] }
 hashbrown = { workspace = true, default-features = false, features = ["default-hasher", "inline-more"] }
 tiny-keccak = { workspace = true, features = ["keccak"] }
-tracing = { workspace = true }
+tracing = { workspace = true, features = ["attributes"] }
 serde = { workspace = true, features = ["derive", "alloc"] }
 hex = { workspace = true, features = ["serde", "alloc"] }
 base64 = { workspace = true, features = ["alloc"] }
@@ -32,6 +32,10 @@ hyper-util = { workspace = true, features = ["client", "client-legacy", "tokio",
 # Database
 rocksdb = { workspace = true, features = ["lz4"] }
 prost = { workspace = true, features = ["derive"] }
+
+# Standalone Binary
+tokio = { workspace = true, features = ["full"], optional = true }
+tempfile = { workspace = true, optional = true }
 
 
 [dev-dependencies]
@@ -50,4 +54,10 @@ tracing-subscriber = { workspace = true, features = ["fmt", "env-filter", "regis
 [features]
 default = ["std", "tracing"]
 std = ["blueprint-std/std", "crc32fast/std", "k256/std", "schnorrkel/std", "base64/std", "prost/std"]
+standalone = ["tokio", "tempfile", "axum/http1", "axum/http2", "axum/tokio"]
 tracing = []
+
+[[bin]]
+name = "auth-server"
+path = "src/main.rs"
+required-features = ["standalone"]

--- a/crates/auth/src/main.rs
+++ b/crates/auth/src/main.rs
@@ -1,0 +1,29 @@
+use std::net::IpAddr;
+
+use blueprint_auth::proxy::DEFAULT_AUTH_PROXY_PORT;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    let tmp_dir = tempfile::tempdir()?;
+    let db_path = tmp_dir.path().join("db");
+    tokio::fs::create_dir_all(&db_path).await?;
+
+    let auth_proxy_port = DEFAULT_AUTH_PROXY_PORT;
+    let auth_proxy_host = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
+
+    let proxy = blueprint_auth::proxy::AuthenticatedProxy::new(&db_path)?;
+
+    let router = proxy.router();
+
+    let listener = tokio::net::TcpListener::bind((auth_proxy_host, auth_proxy_port)).await?;
+    eprintln!(
+        "Auth proxy listening on {}:{}",
+        auth_proxy_host, auth_proxy_port
+    );
+    let result = axum::serve(listener, router).await;
+    if let Err(err) = result {
+        eprintln!("Auth proxy error: {err}");
+    }
+
+    Ok(())
+}

--- a/crates/auth/src/main.rs
+++ b/crates/auth/src/main.rs
@@ -1,6 +1,7 @@
 use std::net::IpAddr;
 
 use blueprint_auth::proxy::DEFAULT_AUTH_PROXY_PORT;
+use blueprint_auth::types::ServiceId;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -12,6 +13,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let auth_proxy_host = IpAddr::V4(std::net::Ipv4Addr::UNSPECIFIED);
 
     let proxy = blueprint_auth::proxy::AuthenticatedProxy::new(&db_path)?;
+
+    blueprint_auth::models::ServiceModel {
+        api_key_prefix: String::from("mcp_test"),
+        owners: vec![blueprint_auth::models::ServiceOwnerModel {
+            key_type: blueprint_auth::types::KeyType::Ecdsa as _,
+            // Alice's public key in hex format
+            key_bytes: hex::decode(
+                "020a1091341fe5664bfa1782d5e04779689068c916b04cb365ec3153755684d9a1",
+            )
+            .expect("Failed to decode hex public key"),
+        }],
+        // The URL of the upstream service that this proxy will forward requests to
+        upstream_url: String::from("http://localhost:3000"),
+    }
+    .save(ServiceId::new(0), &proxy.db())?;
 
     let router = proxy.router();
 

--- a/crates/pricing-engine/Cargo.toml
+++ b/crates/pricing-engine/Cargo.toml
@@ -37,7 +37,7 @@ parity-scale-codec = { workspace = true, features = ["derive"] }
 uuid = { workspace = true, features = ["v4"] }
 hex = { workspace = true }
 anyhow = { workspace = true }
-toml = { workspace = true, features = ["parse"] }
+toml = { workspace = true, features = ["parse", "serde", "std"] }
 tiny-keccak = { workspace = true }
 
 # Substrate RPC and runtime API dependencies

--- a/flake.lock
+++ b/flake.lock
@@ -28,11 +28,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746090613,
-        "narHash": "sha256-Si8nvKH31lzwbJ8aSncgQDYxf3IHreNVJVzSvovnLSM=",
+        "lastModified": 1752867797,
+        "narHash": "sha256-oT129SDSr7SI9ThTd6ZbpmShh5f2tzUH3S4hl6c5/7w=",
         "owner": "shazow",
         "repo": "foundry.nix",
-        "rev": "2b56cb8bae12b0a0608e5ba6dd4af4a9cf9609b4",
+        "rev": "d4445852933ab5bc61ca532cb6c5d3276d89c478",
         "type": "github"
       },
       "original": {
@@ -44,11 +44,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1746576598,
-        "narHash": "sha256-FshoQvr6Aor5SnORVvh/ZdJ1Sa2U4ZrIMwKBX5k2wu0=",
+        "lastModified": 1752997324,
+        "narHash": "sha256-vtTM4oDke3SeDj+1ey6DjmzXdq8ZZSCLWSaApADDvIE=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b3582c75c7f21ce0b429898980eddbbf05c68e55",
+        "rev": "7c688a0875df5a8c28a53fb55ae45e94eae0dddb",
         "type": "github"
       },
       "original": {
@@ -73,11 +73,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1746931022,
-        "narHash": "sha256-cXn1RsYZjS23n0+YP3TiH7XBlEvy8FA2mG54MdAL6x0=",
+        "lastModified": 1753066249,
+        "narHash": "sha256-j2UBrfDRIePGx3532Bbb9UeosNX2F73hfOAHtmACfnM=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "c46d2764319f962b20ce9c03ce6644dd0de87bc9",
+        "rev": "0751b65633a1785743ca44fd7c14a633c54c1f91",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
This pull request adds an easy way to run the auth proxy locally for testing and it can be ran using the following command:
```
cargo run -p blueprint-auth --features standalone
```
---

This pull request introduces a new standalone binary for the `auth-server` in the `crates/auth` crate, along with updates to dependencies and features to support its functionality. The key changes include defining the binary, adding necessary dependencies, and implementing the main entry point for the server.

### Standalone Binary Implementation:

* **Binary Definition**: Added a new standalone binary named `auth-server` in `crates/auth/Cargo.toml`. It requires the `standalone` feature and specifies `src/main.rs` as its entry point.
* **Main Entry Point**: Implemented the `main` function in `crates/auth/src/main.rs`, which initializes a temporary directory for database storage, sets up an authenticated proxy, and starts an Axum-based HTTP server listening on a specified port.

### Dependency Updates:

* **New Dependencies**: Added `tokio` and `tempfile` as optional dependencies to support asynchronous operations and temporary file management for the standalone binary.
* **Feature Enhancements**: Updated the `tracing` dependency to include the `attributes` feature for enhanced tracing capabilities.
* **Standalone Feature**: Introduced a new `standalone` feature in `Cargo.toml` that bundles dependencies like `tokio`, `tempfile`, and Axum features (`http1`, `http2`, `tokio`) required for the `auth-server`.
