### PR TITLE
fix(ci): release-plz rate limit error

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -158,7 +158,7 @@ pub fn load_abi(input: TokenStream) -> TokenStream {
 //  xx |     pub async fn my_job(TangleArg(_): TangleArg<u64>)  {}
 //     |                                   ^^^^ not found in this scope
 /// ```
-/// 
+///
 /// # Performance
 ///
 /// This macro has no effect when compiled with the release profile. (eg. `cargo build --release`)

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -3,6 +3,7 @@ allow_dirty = true         # allow updating repositories with uncommitted change
 publish_allow_dirty = true # add `--allow-dirty` to `cargo publish`
 publish_no_verify = true   # add `--no-verify` to `cargo publish`
 publish_timeout = "10m"    # set a timeout for `cargo publish`
+publish_interval = "3s"    # delay between publishing crates to avoid crates.io rate limits (30/min)
 # TODO: Remove this when no longer in alpha
 # This is needed since the release workflow now takes ~90min, which goes outside the generated token's lifetime.
 # Will need to look into solutions:


### PR DESCRIPTION
# Overview

Fixes crates.io publish rate limit issue in release-plz workflow by adding a publish interval of 3 seconds (rate limit is 30 crates a minute).