### PR TITLE
feat(pricing-engine): TOML-based per-job pricing config

### DIFF
--- a/crates/pricing-engine/config/job_pricing.toml
+++ b/crates/pricing-engine/config/job_pricing.toml
@@ -1,0 +1,15 @@
+# Per-job pricing configuration
+#
+# Controls GetJobPrice RFQ quotes. Each section is a service ID.
+# Keys are job indices, values are prices in wei (strings for large numbers).
+#
+# When a consumer calls GetJobPrice(service_id, job_index), the engine
+# looks up the price here and returns a signed EIP-712 quote.
+# If no entry exists, the RPC returns NOT_FOUND.
+
+# Service 1
+[1]
+0 = "1000000000000000"       # Job 0: 0.001 ETH
+1 = "5000000000000000"       # Job 1: 0.005 ETH
+6 = "20000000000000000"      # Job 6: 0.02 ETH (e.g. LLM prompt)
+7 = "250000000000000000"     # Job 7: 0.25 ETH (e.g. agent task)

--- a/crates/pricing-engine/src/lib.rs
+++ b/crates/pricing-engine/src/lib.rs
@@ -31,7 +31,6 @@ pub use app::{
     cleanup, init_operator_signer, load_operator_config, spawn_event_processor,
     start_blockchain_listener, wait_for_shutdown,
 };
-pub use service::rpc::server::JobPricingConfig;
 pub use benchmark::cpu::CpuBenchmarkResult;
 pub use benchmark::{BenchmarkProfile, BenchmarkRunConfig, run_benchmark, run_benchmark_suite};
 pub use benchmark_cache::BenchmarkCache;
@@ -47,6 +46,7 @@ pub use pricing::{
     load_pricing_from_toml,
 };
 pub use service::blockchain::event::BlockchainEvent;
+pub use service::rpc::server::JobPricingConfig;
 pub use service::rpc::server::{PricingEngineService, run_rpc_server};
 pub use signer::{OperatorId, OperatorSigner, SignableQuote, SignedJobQuote, SignedQuote};
 


### PR DESCRIPTION
## Summary
- Adds `config/job_pricing.toml` — operators configure per-job RFQ prices without code changes
- Adds `load_job_pricing_from_toml()` parser in `pricing.rs`
- Adds `--job-pricing-config` / `JOB_PRICING_CONFIG_PATH` CLI arg
- Wires job pricing into `run_rpc_server()` → `PricingEngineService::with_job_pricing()`
- Updates README with TOML format docs and CLI flag reference

Previously `JobPricingConfig` could only be populated programmatically. Operators had to recompile to change job prices.

## Test plan
- [x] `cargo build -p blueprint-pricing-engine` compiles
- [x] `cargo test -p blueprint-pricing-engine` — all tests pass
- [ ] Manual: run server with `--job-pricing-config config/job_pricing.toml`, verify `GetJobPrice` returns correct prices

🤖 Generated with [Claude Code](https://claude.com/claude-code)