### PR TITLE
feat(webhooks): webhook producer crate for external HTTP event triggers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3695,6 +3695,7 @@ dependencies = [
  "blueprint-stores",
  "blueprint-tangle-extra",
  "blueprint-testing-utils",
+ "blueprint-webhooks",
  "blueprint-x402",
  "document-features",
  "eigensdk",
@@ -3815,6 +3816,30 @@ dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
  "blueprint-eigenlayer-testing-utils",
+]
+
+[[package]]
+name = "blueprint-webhooks"
+version = "0.1.0-alpha.1"
+dependencies = [
+ "axum",
+ "blueprint-core",
+ "blueprint-runner",
+ "bytes",
+ "futures",
+ "futures-core",
+ "hex",
+ "hmac",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "subtle",
+ "thiserror 2.0.17",
+ "tokio",
+ "toml 0.9.8",
+ "tower 0.5.2",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,6 +202,9 @@ blueprint-pricing-engine = { version = "0.2.6", path = "./crates/pricing-engine"
 # x402 Payment Gateway
 blueprint-x402 = { version = "0.1.0-alpha.1", path = "./crates/x402", default-features = false }
 
+# Webhook Producer
+blueprint-webhooks = { version = "0.1.0-alpha.1", path = "./crates/webhooks", default-features = false }
+
 # Macros
 blueprint-macros = { version = "0.1.0-alpha.7", path = "./crates/macros", default-features = false }
 blueprint-context-derive = { version = "0.1.0-alpha.13", path = "./crates/macros/context-derive", default-features = false }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -74,6 +74,9 @@ blueprint-build-utils = { workspace = true, optional = true }
 # x402 Payment Gateway
 blueprint-x402 = { workspace = true, optional = true }
 
+# Webhook Producer
+blueprint-webhooks = { workspace = true, optional = true }
+
 # Remote cloud deployments
 blueprint-remote-providers = { workspace = true, optional = true }
 
@@ -233,6 +236,9 @@ faas = ["blueprint-runner/faas"]
 
 ## Enable x402 payment gateway for cross-chain EVM job settlement
 x402 = ["dep:blueprint-x402"]
+
+## Enable webhook producer for external HTTP event triggers
+webhooks = ["dep:blueprint-webhooks"]
 
 [package.metadata.docs.rs]
 features = ["tangle", "tangle-aggregation", "tangle-p2p-aggregation", "evm", "eigenlayer", "networking", "round-based-compat", "gossip", "agg-sig-gossip", "local-store", "macros", "build", "testing", "cronjob"]

--- a/crates/sdk/src/lib.rs
+++ b/crates/sdk/src/lib.rs
@@ -193,6 +193,16 @@ pub mod x402 {
     pub use blueprint_x402::*;
 }
 
+// Webhook producer for external HTTP event triggers
+#[cfg(feature = "webhooks")]
+/// Webhook producer for triggering jobs from external HTTP events.
+///
+/// Enables blueprints to receive webhooks from external services (TradingView,
+/// exchange APIs, monitoring systems, etc.) and convert them into job executions.
+pub mod webhooks {
+    pub use blueprint_webhooks::*;
+}
+
 // Remote cloud deployment providers
 #[cfg(feature = "remote-providers")]
 /// Remote cloud deployment providers for Blueprint instances

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -1,0 +1,57 @@
+[package]
+name = "blueprint-webhooks"
+version = "0.1.0-alpha.1"
+description = "Webhook producer for Blueprint SDK — trigger jobs from external HTTP events"
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
+rust-version.workspace = true
+
+[lints]
+workspace = true
+
+[dependencies]
+# Core Blueprint dependencies
+blueprint-core = { workspace = true, features = ["tracing"] }
+blueprint-runner = { workspace = true }
+
+# HTTP server
+axum = { workspace = true, features = ["tokio", "http1", "http2", "json"] }
+http = { workspace = true }
+
+# Async runtime
+tokio = { workspace = true, features = ["sync", "rt", "time"] }
+futures-core = { workspace = true }
+
+# Serialization & config
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["std"] }
+toml = { workspace = true }
+
+# Crypto (HMAC auth)
+hmac = "0.12"
+sha2 = { workspace = true }
+hex = { workspace = true }
+subtle = "2"
+
+# Error handling & logging
+thiserror = { workspace = true }
+tracing = { workspace = true }
+
+# Misc
+bytes = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true, features = ["full"] }
+futures = { workspace = true }
+tower = { workspace = true, features = ["util"] }
+http = { workspace = true }
+
+[features]
+default = ["std"]
+std = ["blueprint-core/std", "blueprint-runner/std"]
+
+[package.metadata.docs.rs]
+rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/webhooks/src/auth.rs
+++ b/crates/webhooks/src/auth.rs
@@ -1,0 +1,233 @@
+//! Webhook authentication verification.
+
+use crate::config::WebhookEndpoint;
+use crate::error::WebhookError;
+use axum::http::HeaderMap;
+use hmac::{Hmac, Mac};
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Verify a webhook request against the endpoint's auth configuration.
+///
+/// Returns `Ok(())` if the request is authorized, or an error describing the failure.
+pub fn verify(
+    endpoint: &WebhookEndpoint,
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Result<(), WebhookError> {
+    match endpoint.auth.as_str() {
+        "none" => Ok(()),
+        "bearer" => verify_bearer(endpoint, headers),
+        "hmac-sha256" => verify_hmac(endpoint, headers, body),
+        "api-key" => verify_api_key(endpoint, headers),
+        other => Err(WebhookError::AuthFailed(format!(
+            "unknown auth method: {other}"
+        ))),
+    }
+}
+
+/// Bearer token: `Authorization: Bearer <token>`
+fn verify_bearer(endpoint: &WebhookEndpoint, headers: &HeaderMap) -> Result<(), WebhookError> {
+    let expected = endpoint
+        .resolve_secret()
+        .ok_or_else(|| WebhookError::AuthFailed("bearer secret not configured".into()))?;
+
+    let header = headers
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| WebhookError::AuthFailed("missing Authorization header".into()))?;
+
+    let token = header
+        .strip_prefix("Bearer ")
+        .ok_or_else(|| WebhookError::AuthFailed("Authorization must be 'Bearer <token>'".into()))?;
+
+    if token.as_bytes().ct_eq(expected.as_bytes()).into() {
+        Ok(())
+    } else {
+        Err(WebhookError::AuthFailed("invalid bearer token".into()))
+    }
+}
+
+/// HMAC-SHA256: signature in a header, computed over the raw body.
+///
+/// Checks these headers in order: `X-Signature-256`, `X-Hub-Signature-256`,
+/// `X-Webhook-Signature`. The signature value should be hex-encoded, optionally
+/// prefixed with `sha256=`.
+fn verify_hmac(
+    endpoint: &WebhookEndpoint,
+    headers: &HeaderMap,
+    body: &[u8],
+) -> Result<(), WebhookError> {
+    let secret = endpoint
+        .resolve_secret()
+        .ok_or_else(|| WebhookError::AuthFailed("HMAC secret not configured".into()))?;
+
+    // Find the signature header
+    let sig_header = ["x-signature-256", "x-hub-signature-256", "x-webhook-signature"]
+        .iter()
+        .find_map(|name| headers.get(*name).and_then(|v| v.to_str().ok()))
+        .ok_or_else(|| {
+            WebhookError::AuthFailed(
+                "missing signature header (X-Signature-256, X-Hub-Signature-256, or X-Webhook-Signature)".into(),
+            )
+        })?;
+
+    // Strip optional `sha256=` prefix
+    let sig_hex = sig_header.strip_prefix("sha256=").unwrap_or(sig_header);
+
+    let sig_bytes = hex::decode(sig_hex)
+        .map_err(|_| WebhookError::AuthFailed("signature is not valid hex".into()))?;
+
+    // Compute expected HMAC
+    let mut mac = HmacSha256::new_from_slice(secret.as_bytes())
+        .map_err(|e| WebhookError::AuthFailed(format!("HMAC init failed: {e}")))?;
+    mac.update(body);
+    let expected = mac.finalize().into_bytes();
+
+    if expected.as_slice().ct_eq(&sig_bytes).into() {
+        Ok(())
+    } else {
+        Err(WebhookError::AuthFailed("HMAC signature mismatch".into()))
+    }
+}
+
+/// API key: custom header with a static key value.
+fn verify_api_key(endpoint: &WebhookEndpoint, headers: &HeaderMap) -> Result<(), WebhookError> {
+    let expected = endpoint
+        .resolve_secret()
+        .ok_or_else(|| WebhookError::AuthFailed("API key not configured".into()))?;
+
+    let header_name = endpoint.api_key_header.as_deref().unwrap_or("x-api-key");
+
+    let provided = headers
+        .get(header_name)
+        .and_then(|v| v.to_str().ok())
+        .ok_or_else(|| WebhookError::AuthFailed(format!("missing {header_name} header")))?;
+
+    if provided.as_bytes().ct_eq(expected.as_bytes()).into() {
+        Ok(())
+    } else {
+        Err(WebhookError::AuthFailed("invalid API key".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::WebhookEndpoint;
+    use axum::http::HeaderMap;
+
+    fn make_endpoint(auth: &str, secret: &str) -> WebhookEndpoint {
+        WebhookEndpoint {
+            path: "/test".into(),
+            job_id: 1,
+            auth: auth.into(),
+            secret: Some(secret.into()),
+            api_key_header: None,
+            name: None,
+        }
+    }
+
+    #[test]
+    fn test_no_auth() {
+        let ep = WebhookEndpoint {
+            path: "/test".into(),
+            job_id: 1,
+            auth: "none".into(),
+            secret: None,
+            api_key_header: None,
+            name: None,
+        };
+        assert!(verify(&ep, &HeaderMap::new(), b"").is_ok());
+    }
+
+    #[test]
+    fn test_bearer_valid() {
+        let ep = make_endpoint("bearer", "my-token");
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer my-token".parse().unwrap());
+        assert!(verify(&ep, &headers, b"").is_ok());
+    }
+
+    #[test]
+    fn test_bearer_invalid() {
+        let ep = make_endpoint("bearer", "my-token");
+        let mut headers = HeaderMap::new();
+        headers.insert("authorization", "Bearer wrong-token".parse().unwrap());
+        assert!(verify(&ep, &headers, b"").is_err());
+    }
+
+    #[test]
+    fn test_bearer_missing_header() {
+        let ep = make_endpoint("bearer", "my-token");
+        assert!(verify(&ep, &HeaderMap::new(), b"").is_err());
+    }
+
+    #[test]
+    fn test_hmac_valid() {
+        let ep = make_endpoint("hmac-sha256", "secret-key");
+        let body = b"hello world";
+
+        let mut mac = HmacSha256::new_from_slice(b"secret-key").unwrap();
+        mac.update(body);
+        let sig = hex::encode(mac.finalize().into_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-signature-256", format!("sha256={sig}").parse().unwrap());
+        assert!(verify(&ep, &headers, body).is_ok());
+    }
+
+    #[test]
+    fn test_hmac_valid_no_prefix() {
+        let ep = make_endpoint("hmac-sha256", "secret-key");
+        let body = b"test";
+
+        let mut mac = HmacSha256::new_from_slice(b"secret-key").unwrap();
+        mac.update(body);
+        let sig = hex::encode(mac.finalize().into_bytes());
+
+        let mut headers = HeaderMap::new();
+        headers.insert("x-webhook-signature", sig.parse().unwrap());
+        assert!(verify(&ep, &headers, body).is_ok());
+    }
+
+    #[test]
+    fn test_hmac_invalid_signature() {
+        let ep = make_endpoint("hmac-sha256", "secret-key");
+        let mut headers = HeaderMap::new();
+        headers.insert(
+            "x-signature-256",
+            "sha256=0000000000000000000000000000000000000000000000000000000000000000"
+                .parse()
+                .unwrap(),
+        );
+        assert!(verify(&ep, &headers, b"hello").is_err());
+    }
+
+    #[test]
+    fn test_api_key_valid() {
+        let ep = make_endpoint("api-key", "my-api-key");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", "my-api-key".parse().unwrap());
+        assert!(verify(&ep, &headers, b"").is_ok());
+    }
+
+    #[test]
+    fn test_api_key_custom_header() {
+        let mut ep = make_endpoint("api-key", "my-key");
+        ep.api_key_header = Some("X-Custom-Auth".into());
+        let mut headers = HeaderMap::new();
+        headers.insert("x-custom-auth", "my-key".parse().unwrap());
+        assert!(verify(&ep, &headers, b"").is_ok());
+    }
+
+    #[test]
+    fn test_api_key_invalid() {
+        let ep = make_endpoint("api-key", "correct-key");
+        let mut headers = HeaderMap::new();
+        headers.insert("x-api-key", "wrong-key".parse().unwrap());
+        assert!(verify(&ep, &headers, b"").is_err());
+    }
+}

--- a/crates/webhooks/src/config.rs
+++ b/crates/webhooks/src/config.rs
@@ -1,0 +1,272 @@
+//! Configuration types for the webhook gateway.
+
+use crate::error::WebhookError;
+use serde::{Deserialize, Serialize};
+use std::net::SocketAddr;
+use std::path::Path;
+
+/// Top-level webhook gateway configuration.
+///
+/// ```toml
+/// bind_address = "0.0.0.0:9090"
+///
+/// [[endpoints]]
+/// path = "/hooks/tradingview"
+/// job_id = 30
+/// auth = "hmac-sha256"
+/// secret = "my-secret-key"
+///
+/// [[endpoints]]
+/// path = "/hooks/price-alert"
+/// job_id = 7
+/// auth = "bearer"
+/// secret = "my-api-token"
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookConfig {
+    /// Socket address to bind the HTTP server to.
+    #[serde(default = "default_bind_address")]
+    pub bind_address: SocketAddr,
+
+    /// Configured webhook endpoints.
+    pub endpoints: Vec<WebhookEndpoint>,
+
+    /// Service ID (set at runtime, not from TOML).
+    #[serde(default, skip_deserializing)]
+    pub service_id: u64,
+}
+
+/// A single webhook endpoint configuration.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WebhookEndpoint {
+    /// URL path for this webhook (e.g. `/hooks/tradingview`).
+    pub path: String,
+
+    /// Job ID to trigger when this webhook fires.
+    pub job_id: u64,
+
+    /// Authentication method: `"none"`, `"bearer"`, `"hmac-sha256"`, or `"api-key"`.
+    #[serde(default = "default_auth")]
+    pub auth: String,
+
+    /// Secret for authentication (bearer token, HMAC key, or API key value).
+    /// Can also reference an env var with `env:VAR_NAME`.
+    #[serde(default)]
+    pub secret: Option<String>,
+
+    /// Header name for API key auth (default: `X-API-Key`).
+    #[serde(default)]
+    pub api_key_header: Option<String>,
+
+    /// Optional human-readable name for logging.
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+impl WebhookEndpoint {
+    /// Resolve the secret, expanding `env:VAR_NAME` references.
+    pub fn resolve_secret(&self) -> Option<String> {
+        self.secret.as_ref().and_then(|s| {
+            if let Some(var_name) = s.strip_prefix("env:") {
+                std::env::var(var_name).ok()
+            } else {
+                Some(s.clone())
+            }
+        })
+    }
+
+    /// Display name for logging.
+    pub fn display_name(&self) -> &str {
+        self.name.as_deref().unwrap_or(&self.path)
+    }
+}
+
+impl WebhookConfig {
+    /// Load configuration from a TOML file.
+    pub fn from_toml(path: impl AsRef<Path>) -> Result<Self, WebhookError> {
+        let content = std::fs::read_to_string(path.as_ref())
+            .map_err(|e| WebhookError::Config(format!("failed to read config: {e}")))?;
+        let config: Self = toml::from_str(&content)?;
+        config.validate()?;
+        Ok(config)
+    }
+
+    /// Validate the configuration.
+    pub fn validate(&self) -> Result<(), WebhookError> {
+        if self.endpoints.is_empty() {
+            return Err(WebhookError::Config(
+                "at least one webhook endpoint must be configured".into(),
+            ));
+        }
+
+        for ep in &self.endpoints {
+            if !ep.path.starts_with('/') {
+                return Err(WebhookError::Config(format!(
+                    "endpoint path must start with '/': {}",
+                    ep.path,
+                )));
+            }
+
+            match ep.auth.as_str() {
+                "none" => {}
+                "bearer" | "hmac-sha256" | "api-key" => {
+                    if ep.secret.is_none() {
+                        return Err(WebhookError::Config(format!(
+                            "endpoint {} with auth={} requires a secret",
+                            ep.path, ep.auth,
+                        )));
+                    }
+                }
+                other => {
+                    return Err(WebhookError::Config(format!(
+                        "endpoint {}: unknown auth method '{}' (expected: none, bearer, hmac-sha256, api-key)",
+                        ep.path, other,
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+}
+
+fn default_bind_address() -> SocketAddr {
+    SocketAddr::from(([0, 0, 0, 0], 9090))
+}
+
+fn default_auth() -> String {
+    "none".into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn test_endpoint(auth: &str, secret: Option<&str>) -> WebhookEndpoint {
+        WebhookEndpoint {
+            path: "/hooks/test".into(),
+            job_id: 1,
+            auth: auth.into(),
+            secret: secret.map(|s| s.into()),
+            api_key_header: None,
+            name: None,
+        }
+    }
+
+    #[test]
+    fn test_valid_config() {
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![test_endpoint("bearer", Some("secret123"))],
+            service_id: 0,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_empty_endpoints_rejected() {
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![],
+            service_id: 0,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_no_auth_needs_no_secret() {
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![test_endpoint("none", None)],
+            service_id: 0,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_bearer_without_secret_rejected() {
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![test_endpoint("bearer", None)],
+            service_id: 0,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_hmac_without_secret_rejected() {
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![test_endpoint("hmac-sha256", None)],
+            service_id: 0,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_unknown_auth_rejected() {
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![test_endpoint("oauth2", Some("key"))],
+            service_id: 0,
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("unknown auth method"), "{err}");
+    }
+
+    #[test]
+    fn test_path_must_start_with_slash() {
+        let mut ep = test_endpoint("none", None);
+        ep.path = "hooks/test".into();
+        let config = WebhookConfig {
+            bind_address: default_bind_address(),
+            endpoints: vec![ep],
+            service_id: 0,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_env_secret_resolution() {
+        let ep = WebhookEndpoint {
+            path: "/hooks/test".into(),
+            job_id: 1,
+            auth: "bearer".into(),
+            secret: Some("env:WEBHOOK_TEST_SECRET_XYZ".into()),
+            api_key_header: None,
+            name: None,
+        };
+        // Env var not set → None
+        assert!(ep.resolve_secret().is_none());
+
+        // SAFETY: test-only, single-threaded
+        unsafe { std::env::set_var("WEBHOOK_TEST_SECRET_XYZ", "resolved_value") };
+        assert_eq!(ep.resolve_secret().unwrap(), "resolved_value");
+        unsafe { std::env::remove_var("WEBHOOK_TEST_SECRET_XYZ") };
+    }
+
+    #[test]
+    fn test_literal_secret_resolution() {
+        let ep = test_endpoint("bearer", Some("literal-secret"));
+        assert_eq!(ep.resolve_secret().unwrap(), "literal-secret");
+    }
+
+    #[test]
+    fn test_toml_round_trip() {
+        let toml_str = r#"
+bind_address = "127.0.0.1:9091"
+
+[[endpoints]]
+path = "/hooks/alert"
+job_id = 5
+auth = "bearer"
+secret = "my-token"
+name = "Price Alert"
+"#;
+        let config: WebhookConfig = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.endpoints.len(), 1);
+        assert_eq!(config.endpoints[0].job_id, 5);
+        assert_eq!(config.endpoints[0].display_name(), "Price Alert");
+        assert!(config.validate().is_ok());
+    }
+}

--- a/crates/webhooks/src/error.rs
+++ b/crates/webhooks/src/error.rs
@@ -1,0 +1,35 @@
+//! Error types for the webhook gateway.
+
+/// Errors that can occur in the webhook gateway.
+#[derive(Debug, thiserror::Error)]
+pub enum WebhookError {
+    /// Configuration error.
+    #[error("webhook config error: {0}")]
+    Config(String),
+
+    /// Authentication failed.
+    #[error("webhook auth failed: {0}")]
+    AuthFailed(String),
+
+    /// Server failed to start or encountered a runtime error.
+    #[error("server error: {0}")]
+    Server(String),
+
+    /// Producer channel closed.
+    #[error("producer channel closed")]
+    ProducerChannelClosed,
+
+    /// I/O error.
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// TOML parsing error.
+    #[error(transparent)]
+    TomlParse(#[from] toml::de::Error),
+}
+
+impl From<WebhookError> for blueprint_runner::error::RunnerError {
+    fn from(err: WebhookError) -> Self {
+        blueprint_runner::error::RunnerError::Other(Box::new(err))
+    }
+}

--- a/crates/webhooks/src/gateway.rs
+++ b/crates/webhooks/src/gateway.rs
@@ -1,0 +1,345 @@
+//! The webhook gateway server.
+//!
+//! Runs an axum HTTP server as a [`BackgroundService`] within the Blueprint runner.
+//! Each configured endpoint validates authentication and injects a [`JobCall`] into
+//! the runner's producer stream.
+
+use crate::auth;
+use crate::config::WebhookConfig;
+use crate::error::WebhookError;
+use crate::producer::WebhookEvent;
+
+use axum::extract::State;
+use axum::http::{HeaderMap, StatusCode};
+use axum::response::IntoResponse;
+use axum::routing::post;
+use axum::{Json, Router};
+use blueprint_runner::BackgroundService;
+use blueprint_runner::error::RunnerError;
+use bytes::Bytes;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
+use tokio::sync::{mpsc, oneshot};
+
+/// Shared state for the axum handlers.
+#[derive(Clone)]
+struct GatewayState {
+    config: Arc<WebhookConfig>,
+    /// Channel to send verified webhook events to the producer.
+    event_tx: mpsc::UnboundedSender<WebhookEvent>,
+    /// Monotonic call ID counter.
+    call_id_counter: Arc<AtomicU64>,
+}
+
+/// The webhook gateway.
+///
+/// Implements [`BackgroundService`] so it can be plugged into the Blueprint runner.
+///
+/// # Usage
+///
+/// ```rust,ignore
+/// let (gateway, producer) = WebhookGateway::new(config)?;
+///
+/// BlueprintRunner::builder((), env)
+///     .router(router)
+///     .producer(producer)
+///     .background_service(gateway)
+///     .run()
+///     .await?;
+/// ```
+pub struct WebhookGateway {
+    config: Arc<WebhookConfig>,
+    event_tx: mpsc::UnboundedSender<WebhookEvent>,
+}
+
+impl WebhookGateway {
+    /// Create a new gateway and its paired [`WebhookProducer`](crate::WebhookProducer).
+    pub fn new(config: WebhookConfig) -> Result<(Self, crate::WebhookProducer), WebhookError> {
+        if config.endpoints.is_empty() {
+            return Err(WebhookError::Config(
+                "at least one webhook endpoint must be configured".into(),
+            ));
+        }
+
+        let (producer, event_tx) = crate::WebhookProducer::channel();
+
+        let gateway = Self {
+            config: Arc::new(config),
+            event_tx,
+        };
+
+        Ok((gateway, producer))
+    }
+
+    /// Build the axum router with all configured webhook endpoints.
+    fn build_router(&self) -> Router {
+        let state = GatewayState {
+            config: self.config.clone(),
+            event_tx: self.event_tx.clone(),
+            call_id_counter: Arc::new(AtomicU64::new(1)),
+        };
+
+        let mut router = Router::new().route("/webhooks/health", axum::routing::get(health_check));
+
+        // Register each configured endpoint
+        for (idx, endpoint) in self.config.endpoints.iter().enumerate() {
+            tracing::info!(
+                path = %endpoint.path,
+                job_id = endpoint.job_id,
+                auth = %endpoint.auth,
+                name = %endpoint.display_name(),
+                "registering webhook endpoint"
+            );
+
+            // Each endpoint gets its own handler that captures its index
+            let ep_state = EndpointState {
+                index: idx,
+                gateway: state.clone(),
+            };
+
+            router = router.route(&endpoint.path, post(handle_webhook).with_state(ep_state));
+        }
+
+        // The health endpoint uses GatewayState
+        router.with_state(state)
+    }
+}
+
+impl BackgroundService for WebhookGateway {
+    async fn start(&self) -> Result<oneshot::Receiver<Result<(), RunnerError>>, RunnerError> {
+        let (tx, rx) = oneshot::channel();
+        let router = self.build_router();
+        let addr = self.config.bind_address;
+
+        tokio::spawn(async move {
+            tracing::info!(%addr, "webhook gateway starting");
+
+            let listener = match tokio::net::TcpListener::bind(addr).await {
+                Ok(l) => l,
+                Err(e) => {
+                    let _ = tx.send(Err(RunnerError::Other(Box::new(e))));
+                    return;
+                }
+            };
+
+            tracing::info!(%addr, "webhook gateway listening");
+
+            if let Err(e) = axum::serve(listener, router).await {
+                tracing::error!(error = %e, "webhook gateway server error");
+                let _ = tx.send(Err(RunnerError::Other(Box::new(WebhookError::Server(
+                    e.to_string(),
+                )))));
+            }
+        });
+
+        Ok(rx)
+    }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Axum Handlers
+// ═══════════════════════════════════════════════════════════════════════════
+
+/// Per-endpoint state that captures the endpoint index.
+#[derive(Clone)]
+struct EndpointState {
+    index: usize,
+    gateway: GatewayState,
+}
+
+async fn health_check() -> &'static str {
+    "ok"
+}
+
+/// Handle an incoming webhook request.
+async fn handle_webhook(
+    State(ep_state): State<EndpointState>,
+    headers: HeaderMap,
+    body: Bytes,
+) -> impl IntoResponse {
+    let endpoint = match ep_state.gateway.config.endpoints.get(ep_state.index) {
+        Some(ep) => ep,
+        None => {
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": "endpoint configuration missing" })),
+            )
+                .into_response();
+        }
+    };
+
+    // Verify authentication
+    if let Err(e) = auth::verify(endpoint, &headers, &body) {
+        tracing::warn!(
+            path = %endpoint.path,
+            error = %e,
+            "webhook auth failed"
+        );
+        return (
+            StatusCode::UNAUTHORIZED,
+            Json(serde_json::json!({ "error": "unauthorized" })),
+        )
+            .into_response();
+    }
+
+    let call_id = ep_state
+        .gateway
+        .call_id_counter
+        .fetch_add(1, Ordering::Relaxed);
+
+    let event = WebhookEvent {
+        service_id: ep_state.gateway.config.service_id,
+        job_id: endpoint.job_id,
+        body,
+        path: endpoint.path.clone(),
+        name: endpoint.name.clone(),
+        call_id,
+    };
+
+    tracing::info!(
+        path = %endpoint.path,
+        job_id = endpoint.job_id,
+        call_id,
+        name = %endpoint.display_name(),
+        "webhook event accepted"
+    );
+
+    if ep_state.gateway.event_tx.send(event).is_err() {
+        return (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(serde_json::json!({ "error": "service shutting down" })),
+        )
+            .into_response();
+    }
+
+    (
+        StatusCode::ACCEPTED,
+        Json(serde_json::json!({
+            "status": "accepted",
+            "job_id": endpoint.job_id,
+            "call_id": call_id,
+        })),
+    )
+        .into_response()
+}
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Integration Tests
+// ═══════════════════════════════════════════════════════════════════════════
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::WebhookConfig;
+    use axum::body::Body;
+    use http::Request;
+    use tower::util::ServiceExt;
+
+    fn test_config() -> WebhookConfig {
+        WebhookConfig {
+            bind_address: "127.0.0.1:0".parse().unwrap(),
+            endpoints: vec![
+                crate::config::WebhookEndpoint {
+                    path: "/hooks/open".into(),
+                    job_id: 1,
+                    auth: "none".into(),
+                    secret: None,
+                    api_key_header: None,
+                    name: Some("Open Hook".into()),
+                },
+                crate::config::WebhookEndpoint {
+                    path: "/hooks/secure".into(),
+                    job_id: 2,
+                    auth: "bearer".into(),
+                    secret: Some("test-token".into()),
+                    api_key_header: None,
+                    name: None,
+                },
+            ],
+            service_id: 42,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_open_endpoint_accepts() {
+        let (gateway, mut producer) = WebhookGateway::new(test_config()).unwrap();
+        let router = gateway.build_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/hooks/open")
+            .header("content-type", "application/json")
+            .body(Body::from(r#"{"action":"buy"}"#))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+
+        // Verify the producer received the event
+        use futures::StreamExt;
+        let job = producer.next().await.unwrap().unwrap();
+        assert_eq!(job.job_id(), blueprint_core::JobId::from(1u64));
+    }
+
+    #[tokio::test]
+    async fn test_bearer_auth_accepted() {
+        let (gateway, _producer) = WebhookGateway::new(test_config()).unwrap();
+        let router = gateway.build_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/hooks/secure")
+            .header("authorization", "Bearer test-token")
+            .body(Body::from("payload"))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::ACCEPTED);
+    }
+
+    #[tokio::test]
+    async fn test_bearer_auth_rejected() {
+        let (gateway, _producer) = WebhookGateway::new(test_config()).unwrap();
+        let router = gateway.build_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/hooks/secure")
+            .header("authorization", "Bearer wrong-token")
+            .body(Body::from("payload"))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_missing_auth_rejected() {
+        let (gateway, _producer) = WebhookGateway::new(test_config()).unwrap();
+        let router = gateway.build_router();
+
+        let req = Request::builder()
+            .method("POST")
+            .uri("/hooks/secure")
+            .body(Body::from("payload"))
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_health_check() {
+        let (gateway, _producer) = WebhookGateway::new(test_config()).unwrap();
+        let router = gateway.build_router();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/webhooks/health")
+            .body(Body::empty())
+            .unwrap();
+
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+}

--- a/crates/webhooks/src/lib.rs
+++ b/crates/webhooks/src/lib.rs
@@ -1,0 +1,43 @@
+//! # Blueprint Webhook Producer
+//!
+//! Trigger blueprint jobs from external HTTP webhooks (TradingView alerts,
+//! price feeds, exchange notifications, monitoring systems, etc.).
+//!
+//! ## Architecture
+//!
+//! ```text
+//! External Event ──► Webhook HTTP Server ──► Auth Verified ──► JobCall injected
+//!                        (axum)                (HMAC/Bearer)      (Producer stream)
+//!                                                                      │
+//!                                                                      ▼
+//!                                                              Router dispatches
+//! ```
+//!
+//! ## Quick Start
+//!
+//! ```rust,ignore
+//! use blueprint_webhooks::{WebhookGateway, WebhookConfig};
+//! use blueprint_runner::BlueprintRunner;
+//!
+//! let config = WebhookConfig::from_toml("webhooks.toml")?;
+//! let (gateway, producer) = WebhookGateway::new(config)?;
+//!
+//! BlueprintRunner::builder((), env)
+//!     .router(router)
+//!     .producer(producer)
+//!     .background_service(gateway)
+//!     .run()
+//!     .await?;
+//! ```
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
+
+pub mod auth;
+pub mod config;
+pub mod error;
+pub mod gateway;
+pub mod producer;
+
+pub use config::WebhookConfig;
+pub use error::WebhookError;
+pub use gateway::WebhookGateway;
+pub use producer::WebhookProducer;

--- a/crates/webhooks/src/producer.rs
+++ b/crates/webhooks/src/producer.rs
@@ -1,0 +1,142 @@
+//! Channel-based producer that feeds verified webhook events into the Blueprint runner.
+
+use blueprint_core::error::BoxError;
+use blueprint_core::job::call::Parts;
+use blueprint_core::metadata::{MetadataMap, MetadataValue};
+use blueprint_core::{JobCall, JobId};
+use bytes::Bytes;
+use futures_core::Stream;
+use std::pin::Pin;
+use std::task::{Context, Poll};
+use tokio::sync::mpsc;
+
+/// Metadata key marking this job as webhook-originated.
+pub const WEBHOOK_ORIGIN_KEY: &str = "X-WEBHOOK-ORIGIN";
+/// Metadata key for the webhook endpoint path that triggered this job.
+pub const WEBHOOK_PATH_KEY: &str = "X-WEBHOOK-PATH";
+/// Metadata key for the webhook endpoint name.
+pub const WEBHOOK_NAME_KEY: &str = "X-WEBHOOK-NAME";
+/// Metadata key for the service ID.
+pub const WEBHOOK_SERVICE_ID_KEY: &str = "X-TANGLE-SERVICE-ID";
+/// Metadata key for a synthetic call ID.
+pub const WEBHOOK_CALL_ID_KEY: &str = "X-TANGLE-CALL-ID";
+
+/// A verified webhook event ready to be converted into a [`JobCall`].
+#[derive(Debug, Clone)]
+pub struct WebhookEvent {
+    /// Service instance ID.
+    pub service_id: u64,
+    /// Job ID to trigger.
+    pub job_id: u64,
+    /// Raw request body from the webhook.
+    pub body: Bytes,
+    /// The webhook endpoint path that received this event.
+    pub path: String,
+    /// Human-readable endpoint name (if configured).
+    pub name: Option<String>,
+    /// Synthetic call ID for tracking.
+    pub call_id: u64,
+}
+
+impl WebhookEvent {
+    /// Convert into a [`JobCall`] with webhook-specific metadata.
+    pub fn into_job_call(self) -> JobCall {
+        let mut metadata = MetadataMap::new();
+        metadata.insert(WEBHOOK_ORIGIN_KEY, MetadataValue::from("webhook"));
+        metadata.insert(WEBHOOK_PATH_KEY, MetadataValue::from(self.path.as_str()));
+        if let Some(ref name) = self.name {
+            metadata.insert(WEBHOOK_NAME_KEY, MetadataValue::from(name.as_str()));
+        }
+        metadata.insert(WEBHOOK_SERVICE_ID_KEY, MetadataValue::from(self.service_id));
+        metadata.insert(WEBHOOK_CALL_ID_KEY, MetadataValue::from(self.call_id));
+
+        let parts = Parts::new(JobId::from(self.job_id)).with_metadata(metadata);
+
+        JobCall::from_parts(parts, self.body)
+    }
+}
+
+/// A producer stream that yields [`JobCall`]s from webhook events.
+///
+/// Created via [`WebhookProducer::channel`].
+pub struct WebhookProducer {
+    rx: mpsc::UnboundedReceiver<WebhookEvent>,
+}
+
+impl WebhookProducer {
+    /// Create a new producer and its corresponding sender.
+    pub fn channel() -> (Self, mpsc::UnboundedSender<WebhookEvent>) {
+        let (tx, rx) = mpsc::unbounded_channel();
+        (Self { rx }, tx)
+    }
+}
+
+impl Stream for WebhookProducer {
+    type Item = Result<JobCall, BoxError>;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
+        match self.rx.poll_recv(cx) {
+            Poll::Ready(Some(event)) => {
+                tracing::info!(
+                    job_id = event.job_id,
+                    path = %event.path,
+                    name = ?event.name,
+                    "webhook event verified, producing JobCall"
+                );
+                Poll::Ready(Some(Ok(event.into_job_call())))
+            }
+            Poll::Ready(None) => Poll::Ready(None),
+            Poll::Pending => Poll::Pending,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use futures::StreamExt;
+
+    #[tokio::test]
+    async fn test_producer_receives_events() {
+        let (mut producer, tx) = WebhookProducer::channel();
+
+        let event = WebhookEvent {
+            service_id: 42,
+            job_id: 30,
+            body: Bytes::from_static(b"{\"action\":\"buy\"}"),
+            path: "/hooks/tradingview".into(),
+            name: Some("TradingView Alert".into()),
+            call_id: 1,
+        };
+
+        tx.send(event).unwrap();
+        drop(tx);
+
+        let job_call = producer.next().await.unwrap().unwrap();
+        assert_eq!(job_call.job_id(), JobId::from(30u64));
+
+        let origin = job_call.metadata().get(WEBHOOK_ORIGIN_KEY).unwrap();
+        assert_eq!(origin.as_bytes(), b"webhook");
+
+        let path = job_call.metadata().get(WEBHOOK_PATH_KEY).unwrap();
+        assert_eq!(path.as_bytes(), b"/hooks/tradingview");
+    }
+
+    #[test]
+    fn test_webhook_event_to_job_call() {
+        let event = WebhookEvent {
+            service_id: 1,
+            job_id: 7,
+            body: Bytes::from_static(b"price_alert"),
+            path: "/hooks/price".into(),
+            name: None,
+            call_id: 99,
+        };
+
+        let call = event.into_job_call();
+        assert_eq!(call.job_id(), JobId::from(7u64));
+        assert_eq!(call.body(), &Bytes::from_static(b"price_alert"));
+        assert!(call.metadata().get(WEBHOOK_ORIGIN_KEY).is_some());
+        assert!(call.metadata().get(WEBHOOK_NAME_KEY).is_none());
+    }
+}


### PR DESCRIPTION
## Summary

- New `blueprint-webhooks` crate — trigger blueprint jobs from external HTTP webhooks
- Mirrors the x402 architecture: `WebhookGateway` (BackgroundService) + `WebhookProducer` (Stream → JobCall)
- Each endpoint maps a URL path → job ID with configurable auth (none, bearer, HMAC-SHA256, API key)
- Secrets support `env:VAR_NAME` references for production use
- Feature-gated behind `blueprint-sdk/webhooks`

Use cases: TradingView alerts, exchange notifications, price feed triggers, monitoring system webhooks, custom event pipelines.

## Test plan

- [x] `cargo test -p blueprint-webhooks` — 27 tests covering auth, config, producer, and gateway integration
- [x] Config validation (empty endpoints, missing secrets, unknown auth, path format)
- [x] Auth verification (bearer valid/invalid, HMAC valid/invalid/no-prefix, API key valid/invalid/custom header)
- [x] Gateway HTTP tests (open endpoint accepts, bearer accepted/rejected, health check)
- [x] Producer stream (event → JobCall conversion, metadata propagation)

🤖 Generated with [Claude Code](https://claude.com/claude-code)