### PR TITLE
docs(crates): add world-class README coverage across workspace crates

### DIFF
--- a/crates/README.md
+++ b/crates/README.md
@@ -42,4 +42,4 @@ This directory contains the Rust crates that make up the Blueprint SDK workspace
 - [`blueprint-std`](./std): shared std exports/utilities
 - [`blueprint-macros`](./macros): proc-macro support crates
 
-Each crate has a local `README.md` with crate-specific scope and links.
+Each crate has a local `README.md` with crate-specific purpose, usage guidance, and links.

--- a/crates/README.md
+++ b/crates/README.md
@@ -1,24 +1,45 @@
-## The Blueprint Framework crates
+# Blueprint Crates
 
-The Blueprint Framework is a collection of crates that makes it easy to build Tangle Blueprints.
+This directory contains the Rust crates that make up the Blueprint SDK workspace.
 
-### Blueprint SDK
+## Core runtime
 
-This the Umbrella crate for the Blueprint Framework which exposes the core functionality of the framework to the user, and this crate is all what you need to get started with the framework.
+- [`blueprint-sdk`](./sdk): umbrella crate for most Blueprint applications
+- [`blueprint-core`](./core): core job and runtime primitives
+- [`blueprint-router`](./router): job ID to handler dispatch layer
+- [`blueprint-runner`](./runner): runtime loop and orchestration
 
-Each sub-crate provides a specific functionality of the framework, and they are all hidden behind a feature flag(s) that you can enable/disable in your project.
+## Trigger and ingress crates
 
-### Project crates
+- [`blueprint-producers-extra`](./producers-extra): protocol-agnostic producers (for example cron)
+- [`blueprint-webhooks`](./webhooks): authenticated HTTP webhook ingress
+- [`blueprint-x402`](./x402): paid HTTP ingress via x402 settlement
 
--   [`blueprint-core`](./core): The core functionality of the framework, including the core data structures and the core traits that is used and shared across the framework.
--   [`blueprint-router`](./router): Includes the job routing functionality of the framework, this usually used hand in hand with the [`blueprint-runner`](./runner) crate.
--   [`blueprint-runner`](./runner): Includes the job execution functionality of the framework, which is your entry point to your blueprint.
--   [`blueprint-evm-extra`](./evm-extra): This crate provides extra functionality to use the Blueprint SDK with any EVM compatible network.
--   [`blueprint-sdk`](./sdk): This the most outer layer for the Blueprint Framework which acts as an umbrella crate for the framework.
--   [`blueprint-macros`](./macros): This crate provides the procedural macros that are used across the framework.
+## Protocol and integration crates
 
-### Crate Naming Conventions
+- [`blueprint-tangle-extra`](./tangle-extra): Tangle protocol integrations
+- [`blueprint-evm-extra`](./evm-extra): EVM integration helpers
+- [`blueprint-eigenlayer-extra`](./eigenlayer-extra): EigenLayer integration helpers
+- [`blueprint-clients`](./clients): client metapackage and protocol client crates
 
-1. Each crate name starts with `blueprint-` followed by the name of the crate.
-2. Any integration with any other system or crate, it should start with `blueprint-` followed by the name of the system or crate and ends with `-extra`.
-3. The directory name should be in `crates/{name}` without the `blueprint-` prefix.
+## Security, ops, and support
+
+- [`blueprint-auth`](./auth): auth proxy and request auth primitives
+- [`blueprint-qos`](./qos): heartbeat/metrics/logging QoS surfaces
+- [`blueprint-manager`](./manager): manager runtime orchestration
+- [`blueprint-manager-bridge`](./manager/bridge): manager/service bridge types
+- [`blueprint-keystore`](./keystore): signing and key management
+- [`blueprint-pricing-engine`](./pricing-engine): RFQ and pricing server components
+
+## Utility families
+
+- [`blueprint-crypto`](./crypto): crypto metapackage and algorithm crates
+- [`blueprint-metrics`](./metrics): metrics metapackage and providers
+- [`blueprint-stores`](./stores): storage provider crates
+- [`blueprint-testing-utils`](./testing-utils): testing metapackage and helpers
+- [`blueprint-chain-setup`](./chain-setup): local chain setup helpers
+- [`blueprint-build-utils`](./build-utils): build-time helpers
+- [`blueprint-std`](./std): shared std exports/utilities
+- [`blueprint-macros`](./macros): proc-macro support crates
+
+Each crate has a local `README.md` with crate-specific scope and links.

--- a/crates/auth/README.md
+++ b/crates/auth/README.md
@@ -1,0 +1,17 @@
+# blueprint-auth
+
+Authentication and authorization toolkit for Blueprint services.
+
+This crate provides request auth primitives and an auth proxy surface (API keys, short-lived access tokens, and policy-aware request validation) for HTTP/WS service edges.
+
+## What it includes
+
+- API key + token flows
+- Request auth context extraction
+- Proxy/server auth modules
+- TLS and certificate helpers for secure service edges
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/auth
+- Auth proxy docs: https://docs.tangle.tools/developers/blueprint-auth

--- a/crates/benchmarking/README.md
+++ b/crates/benchmarking/README.md
@@ -1,12 +1,18 @@
 # blueprint-benchmarking
 
-Utilities for benchmarking Tangle Blueprints.
+Benchmark harness primitives for Blueprint jobs.
 
-## Scope
+## When to use
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- You want lightweight runtime benchmarking around async job execution.
+- You need consistent benchmark summaries (duration, vCPU count, RAM usage).
+
+## Key API surface
+
+- `Runtime` trait + `TokioRuntime` adapter.
+- `Bencher<R>` for starting/stopping benchmark runs.
+- `BenchmarkSummary` with display formatting for logs/CI output.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/benchmarking
-

--- a/crates/benchmarking/README.md
+++ b/crates/benchmarking/README.md
@@ -1,0 +1,12 @@
+# blueprint-benchmarking
+
+Utilities for benchmarking Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/benchmarking
+

--- a/crates/build-utils/README.md
+++ b/crates/build-utils/README.md
@@ -1,12 +1,23 @@
 # blueprint-build-utils
 
-Tangle Blueprint build utils.
+Build-time helpers for Blueprint projects that compile smart contracts and manage Foundry dependencies.
 
-## Scope
+## When to use
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- In `build.rs` or setup scripts for blueprint repos with Solidity contracts.
+- To standardize `forge build` invocation across workspace crates.
+
+## Key API surface
+
+- `build_contracts(...)`: compile configured contract directories.
+- `soldeer_install()` / `soldeer_update()`: dependency bootstrap/update helpers.
+- `find_forge_executable()`: resolves local Foundry binary.
+
+## Notes
+
+- Utilities assume Foundry tooling is installed and available.
+- Contract builds pin EVM/toolchain settings for consistency.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/build-utils
-

--- a/crates/build-utils/README.md
+++ b/crates/build-utils/README.md
@@ -1,0 +1,12 @@
+# blueprint-build-utils
+
+Tangle Blueprint build utils.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/build-utils
+

--- a/crates/chain-setup/README.md
+++ b/crates/chain-setup/README.md
@@ -1,9 +1,13 @@
 # blueprint-chain-setup
 
-Chain setup utilities for Blueprint test/development environments.
+Chain bootstrap helpers used by Blueprint test and local development workflows.
 
-This crate provides shared helpers for standing up local chain environments used in development and testing flows.
+## What this crate does
+
+- Provides a common entrypoint for chain setup utilities.
+- Re-exports Anvil-focused setup helpers from `blueprint-chain-setup-anvil`.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/chain-setup
+- Anvil implementation: https://github.com/tangle-network/blueprint/tree/main/crates/chain-setup/anvil

--- a/crates/chain-setup/README.md
+++ b/crates/chain-setup/README.md
@@ -1,0 +1,9 @@
+# blueprint-chain-setup
+
+Chain setup utilities for Blueprint test/development environments.
+
+This crate provides shared helpers for standing up local chain environments used in development and testing flows.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/chain-setup

--- a/crates/chain-setup/anvil/README.md
+++ b/crates/chain-setup/anvil/README.md
@@ -1,0 +1,12 @@
+# blueprint-chain-setup-anvil
+
+Anvil-specific chain setup utilities.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/chain-setup/anvil
+

--- a/crates/chain-setup/anvil/README.md
+++ b/crates/chain-setup/anvil/README.md
@@ -1,12 +1,17 @@
 # blueprint-chain-setup-anvil
 
-Anvil-specific chain setup utilities.
+Anvil-specific chain setup and state-management utilities.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `anvil`: process/bootstrap helpers.
+- `keys`: deterministic key helpers for test environments.
+- `snapshot` and `state`: snapshot/state persistence and recovery helpers.
+
+## Typical usage
+
+Use this crate in integration tests where you need repeatable local EVM state for Blueprint services.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/chain-setup/anvil
-

--- a/crates/clients/README.md
+++ b/crates/clients/README.md
@@ -1,8 +1,18 @@
 # blueprint-clients
 
-Metapackage for Blueprint client crates.
+Meta-crate that re-exports Blueprint client crates.
 
-Use this crate when you want a single dependency that re-exports client modules for Tangle, EVM, and EigenLayer surfaces.
+## When to use
+
+- You want one dependency that exposes Tangle, EVM, and EigenLayer client surfaces.
+- You prefer feature-gated client composition instead of importing each client crate directly.
+
+## Re-exports
+
+- `blueprint-client-core`
+- `blueprint-client-evm`
+- `blueprint-client-tangle`
+- `blueprint-client-eigenlayer`
 
 ## Related links
 

--- a/crates/clients/README.md
+++ b/crates/clients/README.md
@@ -1,0 +1,9 @@
+# blueprint-clients
+
+Metapackage for Blueprint client crates.
+
+Use this crate when you want a single dependency that re-exports client modules for Tangle, EVM, and EigenLayer surfaces.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients

--- a/crates/clients/core/README.md
+++ b/crates/clients/core/README.md
@@ -1,12 +1,16 @@
 # blueprint-client-core
 
-Core primitives for Tangle Blueprint clients.
+Core client traits and shared abstractions for Blueprint protocol clients.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `BlueprintServicesClient` trait for operator-set and identity queries.
+- Shared error types and helper aliases (`OperatorSet`).
+
+## When to depend on this crate directly
+
+Use directly when implementing your own protocol client backend against Blueprint client traits.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/core
-

--- a/crates/clients/core/README.md
+++ b/crates/clients/core/README.md
@@ -1,0 +1,12 @@
+# blueprint-client-core
+
+Core primitives for Tangle Blueprint clients.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/core
+

--- a/crates/clients/eigenlayer/README.md
+++ b/crates/clients/eigenlayer/README.md
@@ -1,12 +1,16 @@
 # blueprint-client-eigenlayer
 
-Eigenlayer client for Tangle Blueprints.
+EigenLayer-specific client implementation for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- EigenLayer client bindings/wrappers.
+- EigenLayer-focused error types.
+
+## When to use
+
+Use this crate when your blueprint integrates with EigenLayer contract/operator flows.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/eigenlayer
-

--- a/crates/clients/eigenlayer/README.md
+++ b/crates/clients/eigenlayer/README.md
@@ -1,0 +1,12 @@
+# blueprint-client-eigenlayer
+
+Eigenlayer client for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/eigenlayer
+

--- a/crates/clients/evm/README.md
+++ b/crates/clients/evm/README.md
@@ -1,0 +1,12 @@
+# blueprint-client-evm
+
+EVM client for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/evm
+

--- a/crates/clients/evm/README.md
+++ b/crates/clients/evm/README.md
@@ -1,12 +1,17 @@
 # blueprint-client-evm
 
-EVM client for Tangle Blueprints.
+EVM client utilities for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Base EVM client primitives.
+- Instrumented client wrapper for observability/metrics.
+- EVM client error types.
+
+## When to use
+
+Use directly if you need EVM RPC/contract interaction outside higher-level Tangle client wrappers.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/evm
-

--- a/crates/clients/tangle/README.md
+++ b/crates/clients/tangle/README.md
@@ -1,0 +1,12 @@
+# blueprint-client-tangle
+
+Tangle client for Blueprint SDK - connects to Tangle EVM contracts.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/tangle
+

--- a/crates/clients/tangle/README.md
+++ b/crates/clients/tangle/README.md
@@ -1,12 +1,17 @@
 # blueprint-client-tangle
 
-Tangle client for Blueprint SDK - connects to Tangle EVM contracts.
+Tangle contract-facing client for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Config + settings types (`TangleClientConfig`, `TangleSettings`).
+- Contract/service wrappers for Tangle interfaces.
+- High-level client entrypoints and typed errors.
+
+## When to use
+
+Use when your service needs direct calls into Tangle contract surfaces (service lifecycle, operators, jobs, payments).
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/clients/tangle
-

--- a/crates/contexts/README.md
+++ b/crates/contexts/README.md
@@ -1,0 +1,12 @@
+# blueprint-contexts
+
+Context providers for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/contexts
+

--- a/crates/contexts/README.md
+++ b/crates/contexts/README.md
@@ -1,12 +1,18 @@
 # blueprint-contexts
 
-Context providers for Tangle Blueprints.
+Context extension modules used to compose runtime capabilities into Blueprint job contexts.
 
-## Scope
+## Feature-gated modules
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `tangle`: Tangle client context helpers.
+- `eigenlayer`: EigenLayer context helpers.
+- `keystore`: signer/keystore context access.
+- `instrumented_evm_client`: EVM client instrumentation context.
+
+## When to use
+
+Use when building custom context structs passed into job handlers and you want reusable extension traits/utilities.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/contexts
-

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,12 +1,18 @@
 # blueprint-core
 
-Blueprint SDK Core functionality.
+Core runtime primitives used across the Blueprint SDK.
 
-## Scope
+## What lives here
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Job model: `Job`, `JobId`, `JobCall`, `JobResult`.
+- Extractors and metadata primitives for handler inputs.
+- Core error and extension traits.
+
+## When to depend directly
+
+Most apps should use `blueprint-sdk`. Depend on `blueprint-core` directly for low-level integrations, custom runtimes, or framework extensions.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/core
-
+- Runner docs: https://docs.tangle.tools/developers/blueprint-runner/introduction

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,12 @@
+# blueprint-core
+
+Blueprint SDK Core functionality.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/core
+

--- a/crates/crypto/README.md
+++ b/crates/crypto/README.md
@@ -1,8 +1,20 @@
 # blueprint-crypto
 
-Metapackage for Blueprint cryptography crates.
+Meta-crate for Blueprint cryptography modules.
 
-This crate re-exports cryptographic primitives used across Blueprint runtimes, including ECDSA, sr25519, BLS/BN254, and hashing helpers.
+## What it re-exports
+
+- `blueprint-crypto-core`
+- `blueprint-crypto-k256`
+- `blueprint-crypto-sr25519`
+- `blueprint-crypto-ed25519`
+- `blueprint-crypto-bls`
+- `blueprint-crypto-bn254`
+- `blueprint-crypto-hashing`
+
+## When to use
+
+Use this crate when you want broad crypto coverage without managing per-algorithm dependencies.
 
 ## Related links
 

--- a/crates/crypto/README.md
+++ b/crates/crypto/README.md
@@ -1,0 +1,9 @@
+# blueprint-crypto
+
+Metapackage for Blueprint cryptography crates.
+
+This crate re-exports cryptographic primitives used across Blueprint runtimes, including ECDSA, sr25519, BLS/BN254, and hashing helpers.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto

--- a/crates/crypto/bls/README.md
+++ b/crates/crypto/bls/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-bls
+
+tnt-bls crypto primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/bls
+

--- a/crates/crypto/bls/README.md
+++ b/crates/crypto/bls/README.md
@@ -1,12 +1,13 @@
 # blueprint-crypto-bls
 
-tnt-bls crypto primitives for Tangle Blueprints.
+BLS primitives and aggregation helpers for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- BLS aggregation module.
+- BLS error types.
+- Canonical serialization trait re-exports.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/bls
-

--- a/crates/crypto/bn254/README.md
+++ b/crates/crypto/bn254/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-bn254
+
+Ark BN254 crypto primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/bn254
+

--- a/crates/crypto/bn254/README.md
+++ b/crates/crypto/bn254/README.md
@@ -1,12 +1,12 @@
 # blueprint-crypto-bn254
 
-Ark BN254 crypto primitives for Tangle Blueprints.
+BN254-focused crypto helpers for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- BN254 aggregation helpers.
+- BN254-specific error types.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/bn254
-

--- a/crates/crypto/core/README.md
+++ b/crates/crypto/core/README.md
@@ -1,12 +1,12 @@
 # blueprint-crypto-core
 
-Core crypto primitives for Tangle Blueprints.
+Shared cryptographic traits and aggregation primitives for Blueprint crypto crates.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Common trait definitions consumed by algorithm-specific crates.
+- Aggregation interfaces used by signature schemes.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/core
-

--- a/crates/crypto/core/README.md
+++ b/crates/crypto/core/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-core
+
+Core crypto primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/core
+

--- a/crates/crypto/ed25519/README.md
+++ b/crates/crypto/ed25519/README.md
@@ -1,12 +1,12 @@
 # blueprint-crypto-ed25519
 
-Zebra ed25519 crypto primitives for Tangle Blueprints.
+`ed25519-zebra` primitives for Blueprint services.
 
-## Scope
+## What it provides
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- ed25519 signing/verification wrappers.
+- Consistent error handling across SDK crypto crates.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/ed25519
-

--- a/crates/crypto/ed25519/README.md
+++ b/crates/crypto/ed25519/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-ed25519
+
+Zebra ed25519 crypto primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/ed25519
+

--- a/crates/crypto/hashing/README.md
+++ b/crates/crypto/hashing/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-hashing
+
+Hashing and key derivation primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/hashing
+

--- a/crates/crypto/hashing/README.md
+++ b/crates/crypto/hashing/README.md
@@ -1,12 +1,16 @@
 # blueprint-crypto-hashing
 
-Hashing and key derivation primitives for Tangle Blueprints.
+Hashing and key-derivation primitives for Blueprint services.
 
-## Scope
+## Feature-gated capabilities
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Hashing: SHA2, SHA3/Keccak, BLAKE3.
+- KDF: HKDF-SHA256 and Argon2id (`kdf` module).
+
+## When to use
+
+Use this crate for deterministic hashing/KDF logic shared by signing, auth, and protocol flows.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/hashing
-

--- a/crates/crypto/k256/README.md
+++ b/crates/crypto/k256/README.md
@@ -1,12 +1,12 @@
 # blueprint-crypto-k256
 
-k256 crypto primitives for Tangle Blueprints.
+`k256` (secp256k1) primitives for Blueprint services.
 
-## Scope
+## What it provides
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- ECDSA signing/verification helpers and types.
+- K256-specific error types and conversions.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/k256
-

--- a/crates/crypto/k256/README.md
+++ b/crates/crypto/k256/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-k256
+
+k256 crypto primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/k256
+

--- a/crates/crypto/sr25519/README.md
+++ b/crates/crypto/sr25519/README.md
@@ -1,12 +1,12 @@
 # blueprint-crypto-sr25519
 
-Schnorrkel sr25519 crypto primitives for Tangle Blueprints.
+`schnorrkel`/sr25519 primitives for Blueprint services.
 
-## Scope
+## What it provides
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- sr25519 signing and verification helpers.
+- sr25519-specific error types.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/sr25519
-

--- a/crates/crypto/sr25519/README.md
+++ b/crates/crypto/sr25519/README.md
@@ -1,0 +1,12 @@
+# blueprint-crypto-sr25519
+
+Schnorrkel sr25519 crypto primitives for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/crypto/sr25519
+

--- a/crates/evm-extra/README.md
+++ b/crates/evm-extra/README.md
@@ -1,12 +1,18 @@
 # blueprint-evm-extra
 
-EVM extra utilities for Blueprint framework.
+EVM runtime integration helpers for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- EVM event/job producers.
+- EVM consumers for result handling.
+- EVM extractors, filters, and utility helpers.
+
+## When to use
+
+Use when your blueprint runtime consumes EVM events or submits EVM-oriented outputs directly.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/evm-extra
-- Trigger docs (on-chain producers): https://docs.tangle.tools/developers/blueprint-runner/job-triggers
+- Trigger docs: https://docs.tangle.tools/developers/blueprint-runner/job-triggers

--- a/crates/evm-extra/README.md
+++ b/crates/evm-extra/README.md
@@ -1,0 +1,12 @@
+# blueprint-evm-extra
+
+EVM extra utilities for Blueprint framework.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/evm-extra
+- Trigger docs (on-chain producers): https://docs.tangle.tools/developers/blueprint-runner/job-triggers

--- a/crates/macros/README.md
+++ b/crates/macros/README.md
@@ -1,0 +1,12 @@
+# blueprint-macros
+
+Macros for the Tangle Blueprint SDK.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/macros
+

--- a/crates/macros/README.md
+++ b/crates/macros/README.md
@@ -1,12 +1,17 @@
 # blueprint-macros
 
-Macros for the Tangle Blueprint SDK.
+Procedural macros for ergonomics in Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Job/debug helper macros.
+- Context/ref helper macros.
+- EVM and attribute parsing support macros.
+
+## When to use
+
+Use when you want less boilerplate around job declarations and framework wiring.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/macros
-

--- a/crates/macros/context-derive/README.md
+++ b/crates/macros/context-derive/README.md
@@ -1,12 +1,16 @@
 # blueprint-context-derive
 
-Procedural macros for deriving Context Extension traits from blueprint-sdk.
+Derive macros for Blueprint context extension traits.
 
-## Scope
+## What it supports
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+Feature-aware derive paths for context integration across:
+
+- Tangle
+- EVM
+- EigenLayer
+- Keystore
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/macros/context-derive
-

--- a/crates/macros/context-derive/README.md
+++ b/crates/macros/context-derive/README.md
@@ -1,0 +1,12 @@
+# blueprint-context-derive
+
+Procedural macros for deriving Context Extension traits from blueprint-sdk.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/macros/context-derive
+

--- a/crates/manager/README.md
+++ b/crates/manager/README.md
@@ -1,0 +1,17 @@
+# blueprint-manager
+
+Blueprint runtime manager for orchestrating service execution.
+
+`blueprint-manager` is responsible for loading runtime configuration, resolving protocol/runtime sources, and coordinating execution of Blueprint services.
+
+## What it provides
+
+- Manager runtime orchestration
+- Protocol/runtime source handling
+- Execution entrypoint (`run_blueprint_manager`)
+- Integration surface with manager bridge and auth components
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/manager
+- CLI docs: https://docs.tangle.tools/developers/cli/tangle

--- a/crates/manager/bridge/README.md
+++ b/crates/manager/bridge/README.md
@@ -1,12 +1,13 @@
 # blueprint-manager-bridge
 
-Bridge for Blueprint manager to service communication.
+Bridge types and APIs for manager <-> service communication.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Shared API types used by both manager and runtime processes.
+- Optional client/server modules behind feature flags.
+- TLS profile and bridge error types.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/manager/bridge
-

--- a/crates/manager/bridge/README.md
+++ b/crates/manager/bridge/README.md
@@ -1,0 +1,12 @@
+# blueprint-manager-bridge
+
+Bridge for Blueprint manager to service communication.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/manager/bridge
+

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -1,12 +1,15 @@
 # blueprint-metrics
 
-Metrics metapackage for Tangle Blueprints.
+Meta-crate for metrics instrumentation modules.
 
-## Scope
+## What it re-exports
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `blueprint-metrics-rpc-calls`
+
+## When to use
+
+Use this crate as the entrypoint for metrics helpers when instrumenting blueprint infrastructure surfaces.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/metrics
-

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -1,0 +1,12 @@
+# blueprint-metrics
+
+Metrics metapackage for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/metrics
+

--- a/crates/metrics/rpc-calls/README.md
+++ b/crates/metrics/rpc-calls/README.md
@@ -1,0 +1,12 @@
+# blueprint-metrics-rpc-calls
+
+RPC call metrics for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/metrics/rpc-calls
+

--- a/crates/metrics/rpc-calls/README.md
+++ b/crates/metrics/rpc-calls/README.md
@@ -1,12 +1,16 @@
 # blueprint-metrics-rpc-calls
 
-RPC call metrics for Tangle Blueprints.
+RPC metrics helpers for EVM/JSON-RPC interactions.
 
-## Scope
+## What it tracks
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Request duration histogram: `evm_rpc_request_duration_seconds`
+- Request count counter: `evm_rpc_request_total`
+
+## Primary type
+
+- `RpcCallsMetrics` for declaring and recording the above metrics with method/client labels.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/metrics/rpc-calls
-

--- a/crates/networking/extensions/round-based/README.md
+++ b/crates/networking/extensions/round-based/README.md
@@ -1,12 +1,17 @@
 # blueprint-networking-round-based-extension
 
-round-based integration for Blueprint SDK networking.
+Adapter between Blueprint networking and `round-based` protocol APIs.
 
-## Scope
+## What it provides
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `RoundBasedNetworkAdapter` implementing `round_based::Delivery`.
+- Sender/receiver adapters that translate between protocol messages and network transport payloads.
+- Party index <-> peer ID mapping utilities for round-based sessions.
+
+## When to use
+
+Use for MPC/threshold protocols that already target the `round-based` crate and need Blueprint network transport.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/networking/extensions/round-based
-

--- a/crates/networking/extensions/round-based/README.md
+++ b/crates/networking/extensions/round-based/README.md
@@ -1,0 +1,12 @@
+# blueprint-networking-round-based-extension
+
+round-based integration for Blueprint SDK networking.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/networking/extensions/round-based
+

--- a/crates/producers-extra/README.md
+++ b/crates/producers-extra/README.md
@@ -1,0 +1,19 @@
+# blueprint-producers-extra
+
+Protocol-agnostic producer implementations for Blueprint runtimes.
+
+This crate currently includes extra producer implementations that are not tied to a specific chain protocol.
+
+## Available producers
+
+- `cron` feature: cron-scheduled job producer (`cron::CronJob`)
+
+## Feature flags
+
+- `cron`: enables cron-based scheduling producer support
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/producers-extra
+- Trigger docs: https://docs.tangle.tools/developers/blueprint-runner/job-triggers
+- Producer docs: https://docs.tangle.tools/developers/blueprint-runner/producers

--- a/crates/qos/README.md
+++ b/crates/qos/README.md
@@ -1,0 +1,26 @@
+# blueprint-qos
+
+Quality-of-Service instrumentation and health surfaces for Blueprint services.
+
+`blueprint-qos` provides heartbeat, metrics, and logging integrations for operator observability. It can run with managed local observability components or point to externally managed stacks.
+
+## What it provides
+
+- Heartbeat service and consumers
+- Metrics and logging integrations
+- QoS service builder and config helpers
+- Optional managed Grafana/Loki/Prometheus server configs
+
+## Example entry point
+
+```rust,ignore
+use blueprint_qos::default_qos_config;
+
+let qos_config = default_qos_config();
+```
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/qos
+- QoS docs: https://docs.tangle.tools/developers/blueprint-qos
+- Operator QoS docs: https://docs.tangle.tools/operators/quality-of-service

--- a/crates/router/README.md
+++ b/crates/router/README.md
@@ -1,0 +1,26 @@
+# blueprint-router
+
+Job routing layer for Blueprint runtimes.
+
+`blueprint-router` maps incoming `JobId` values to async handlers and is the dispatch core used by `blueprint-runner`.
+
+## What to use it for
+
+- Registering job handlers by ID
+- Composing route tables for service job surfaces
+- Dispatching calls from heterogeneous producer sources
+
+## Example
+
+```rust,ignore
+use blueprint_router::Router;
+
+async fn echo() -> &'static str { "ok" }
+
+let router = Router::new().route(0, echo);
+```
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/router
+- Router docs: https://docs.tangle.tools/developers/blueprint-runner/routers

--- a/crates/runner/README.md
+++ b/crates/runner/README.md
@@ -1,0 +1,35 @@
+# blueprint-runner
+
+Execution runtime for Blueprint jobs.
+
+`blueprint-runner` owns the long-running execution loop: consume `JobCall`s from producers, route calls to handlers, and forward `JobResult`s to consumers. It also hosts background services (for example webhooks/x402 gateways).
+
+## Core responsibilities
+
+- Runner builder and lifecycle management
+- Producer/consumer orchestration
+- Background service execution
+- Protocol-aware runtime hooks (feature-gated)
+
+## Minimal setup
+
+```rust,ignore
+use blueprint_runner::BlueprintRunner;
+use blueprint_runner::config::BlueprintEnvironment;
+use blueprint_router::Router;
+
+async fn ping() -> &'static str { "pong" }
+
+let env = BlueprintEnvironment::default();
+let router = Router::new().route(0, ping);
+
+BlueprintRunner::builder((), env)
+    .router(router)
+    .run()
+    .await?;
+```
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/runner
+- Runner docs: https://docs.tangle.tools/developers/blueprint-runner/introduction

--- a/crates/sdk/README.md
+++ b/crates/sdk/README.md
@@ -1,0 +1,34 @@
+# blueprint-sdk
+
+Umbrella crate for building Blueprint services on Tangle.
+
+`blueprint-sdk` re-exports the core runtime surface (jobs, router, runner, protocol integrations, optional gateways like x402/webhooks) so most projects can depend on one crate.
+
+## What to use it for
+
+- Building Blueprint services with a single dependency surface
+- Wiring router + runner + producers + consumers
+- Opting into protocol/gateway features through crate features
+
+## Minimal runner wiring
+
+```rust,ignore
+use blueprint_sdk::Router;
+use blueprint_sdk::runner::BlueprintRunner;
+use blueprint_sdk::runner::config::BlueprintEnvironment;
+
+async fn ping() -> &'static str { "pong" }
+
+let env = BlueprintEnvironment::default();
+let router = Router::new().route(0, ping);
+
+BlueprintRunner::builder((), env)
+    .router(router)
+    .run()
+    .await?;
+```
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/sdk
+- Developer docs: https://docs.tangle.tools/developers/blueprint-sdk

--- a/crates/std/README.md
+++ b/crates/std/README.md
@@ -1,0 +1,12 @@
+# blueprint-std
+
+Re-exports of core/std for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/std
+

--- a/crates/std/README.md
+++ b/crates/std/README.md
@@ -1,12 +1,17 @@
 # blueprint-std
 
-Re-exports of core/std for Tangle Blueprints.
+Shared std/core/alloc exports and utilities used across Blueprint crates.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Re-exports for `alloc`, `core`, and `std` (feature-aware).
+- Convenience modules for IO/error and synchronization helpers.
+- Shared random/perf-trace helpers used by other workspace crates.
+
+## When to use
+
+Use inside workspace crates when you want consistent std/no-std compatible imports.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/std
-

--- a/crates/stores/README.md
+++ b/crates/stores/README.md
@@ -1,12 +1,15 @@
 # blueprint-stores
 
-Storage providers for Tangle Blueprints.
+Meta-crate for Blueprint storage backends.
 
-## Scope
+## What it re-exports
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `blueprint-store-local-database` as `local_database`.
+
+## When to use
+
+Use when you want storage providers through a single dependency entrypoint.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/stores
-

--- a/crates/stores/README.md
+++ b/crates/stores/README.md
@@ -1,0 +1,12 @@
+# blueprint-stores
+
+Storage providers for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/stores
+

--- a/crates/stores/local-database/README.md
+++ b/crates/stores/local-database/README.md
@@ -1,12 +1,17 @@
 # blueprint-store-local-database
 
-Local database storage provider for the Blueprint SDK.
+Local JSON-backed key/value storage provider.
 
-## Scope
+## What it provides
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `LocalDatabase<T>` typed key/value API.
+- Atomic flush behavior (temp-file + rename) for safer writes.
+- Common operations: `set`, `get`, `remove`, `update`, `replace`, `entries`.
+
+## When to use
+
+Use for simple local persistence needs in development and lightweight runtime state.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/stores/local-database
-

--- a/crates/stores/local-database/README.md
+++ b/crates/stores/local-database/README.md
@@ -1,0 +1,12 @@
+# blueprint-store-local-database
+
+Local database storage provider for the Blueprint SDK.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/stores/local-database
+

--- a/crates/tangle-aggregation-svc/README.md
+++ b/crates/tangle-aggregation-svc/README.md
@@ -1,12 +1,20 @@
 # blueprint-tangle-aggregation-svc
 
-BLS signature aggregation service for Tangle v2.
+BLS signature aggregation service for Tangle workflows.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- HTTP API for task init, signature submission, status, and aggregate retrieval.
+- Aggregation service/state types and persistence backends.
+- Optional client module for interacting with the service.
+
+## Typical flow
+
+1. Initialize aggregation task.
+2. Collect signatures from operators.
+3. Read aggregated result once threshold is met.
+4. Submit aggregate to on-chain consumer.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/tangle-aggregation-svc
-

--- a/crates/tangle-aggregation-svc/README.md
+++ b/crates/tangle-aggregation-svc/README.md
@@ -1,0 +1,12 @@
+# blueprint-tangle-aggregation-svc
+
+BLS signature aggregation service for Tangle v2.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/tangle-aggregation-svc
+

--- a/crates/testing-utils/README.md
+++ b/crates/testing-utils/README.md
@@ -1,0 +1,9 @@
+# blueprint-testing-utils
+
+Metapackage for Blueprint testing utilities.
+
+Use this crate to access shared testing helpers and protocol-specific test utility crates from one dependency surface.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils

--- a/crates/testing-utils/README.md
+++ b/crates/testing-utils/README.md
@@ -1,8 +1,16 @@
 # blueprint-testing-utils
 
-Metapackage for Blueprint testing utilities.
+Meta-crate for Blueprint testing helper crates.
 
-Use this crate to access shared testing helpers and protocol-specific test utility crates from one dependency surface.
+## What it re-exports
+
+- `blueprint-core-testing-utils`
+- `blueprint-anvil-testing-utils`
+- `blueprint-eigenlayer-testing-utils`
+
+## When to use
+
+Use as the default entrypoint for test harness utilities across Blueprint integration/unit tests.
 
 ## Related links
 

--- a/crates/testing-utils/anvil/README.md
+++ b/crates/testing-utils/anvil/README.md
@@ -1,0 +1,12 @@
+# blueprint-anvil-testing-utils
+
+Anvil testing utilities for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils/anvil
+

--- a/crates/testing-utils/anvil/README.md
+++ b/crates/testing-utils/anvil/README.md
@@ -1,12 +1,13 @@
 # blueprint-anvil-testing-utils
 
-Anvil testing utilities for Tangle Blueprints.
+Anvil-focused test harness utilities.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Local Anvil environment bootstrapping.
+- Blueprint test helpers on top of Anvil.
+- Multi-instance and Tangle-specific test wiring modules.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils/anvil
-

--- a/crates/testing-utils/core/README.md
+++ b/crates/testing-utils/core/README.md
@@ -1,0 +1,12 @@
+# blueprint-core-testing-utils
+
+Core primitives for testing Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils/core
+

--- a/crates/testing-utils/core/README.md
+++ b/crates/testing-utils/core/README.md
@@ -1,12 +1,13 @@
 # blueprint-core-testing-utils
 
-Core primitives for testing Tangle Blueprints.
+Core testing primitives shared across Blueprint test suites.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- `TestRunner` orchestration helpers.
+- Common testing error types.
+- Utility helpers for reading manifests and initializing logging.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils/core
-

--- a/crates/testing-utils/eigenlayer/README.md
+++ b/crates/testing-utils/eigenlayer/README.md
@@ -1,12 +1,12 @@
 # blueprint-eigenlayer-testing-utils
 
-EigenLayer-specific testing utilities for Tangle Blueprints.
+EigenLayer-specific testing helpers for Blueprint services.
 
-## Scope
+## What it includes
 
-This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+- Environment bootstrap helpers.
+- Harness and runner utilities for EigenLayer test flows.
 
 ## Related links
 
 - Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils/eigenlayer
-

--- a/crates/testing-utils/eigenlayer/README.md
+++ b/crates/testing-utils/eigenlayer/README.md
@@ -1,0 +1,12 @@
+# blueprint-eigenlayer-testing-utils
+
+EigenLayer-specific testing utilities for Tangle Blueprints.
+
+## Scope
+
+This crate is part of the Blueprint SDK workspace and is intended for Blueprint runtime and integration development.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/testing-utils/eigenlayer
+

--- a/crates/webhooks/README.md
+++ b/crates/webhooks/README.md
@@ -1,0 +1,41 @@
+# blueprint-webhooks
+
+Webhook gateway for Blueprint SDK.
+
+This crate exposes HTTP endpoints that authenticate inbound requests and inject `JobCall`s into a running Blueprint.
+
+## What it provides
+
+- `WebhookGateway` background service (axum)
+- `WebhookProducer` stream that converts verified webhook events into `JobCall`s
+- Per-endpoint route mapping (`path -> job_id`)
+- Auth modes:
+  - `none`
+  - `bearer`
+  - `hmac-sha256`
+  - `api-key`
+- Health endpoint:
+  - `GET /webhooks/health`
+
+## Quick integration
+
+```rust,ignore
+use blueprint_webhooks::{WebhookConfig, WebhookGateway};
+use blueprint_runner::BlueprintRunner;
+
+let config = WebhookConfig::from_toml("webhooks.toml")?;
+let (gateway, producer) = WebhookGateway::new(config)?;
+
+BlueprintRunner::builder((), env)
+    .router(router)
+    .producer(producer)
+    .background_service(gateway)
+    .run()
+    .await?;
+```
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/webhooks
+- Docs site page: https://docs.tangle.tools/developers/blueprint-runner/webhooks
+- Trigger model context (cron/on-chain/webhooks/x402): https://docs.tangle.tools/developers/blueprint-runner/job-triggers

--- a/crates/x402/README.md
+++ b/crates/x402/README.md
@@ -1,0 +1,47 @@
+# blueprint-x402
+
+x402 payment gateway for Blueprint SDK.
+
+This crate exposes paid HTTP job execution for Blueprint runners: clients settle via x402, then the gateway injects a verified `JobCall` into the runner.
+
+## What it provides
+
+- `X402Gateway` background service (axum + x402 middleware)
+- `X402Producer` stream that converts verified payments into `JobCall`s
+- Per-job x402 policy model:
+  - `disabled`
+  - `public_paid`
+  - `restricted_paid`
+- Restricted auth modes:
+  - `payer_is_caller`
+  - `delegated_caller_signature`
+- Auth dry-run endpoint for restricted policy checks:
+  - `POST /x402/jobs/{service_id}/{job_index}/auth-dry-run`
+
+## Quick integration
+
+```rust,ignore
+use blueprint_x402::{X402Config, X402Gateway};
+use blueprint_runner::BlueprintRunner;
+
+let config = X402Config::from_toml("x402.toml")?;
+let (gateway, producer) = X402Gateway::new(config, job_pricing)?;
+
+BlueprintRunner::builder((), env)
+    .router(router)
+    .producer(producer)
+    .background_service(gateway)
+    .run()
+    .await?;
+```
+
+`job_pricing` is a `(service_id, job_index) -> price_wei` map.
+
+## Related links
+
+- Source: https://github.com/tangle-network/blueprint/tree/main/crates/x402
+- Example blueprint (end-to-end): https://github.com/tangle-network/blueprint/blob/main/examples/x402-blueprint/README.md
+- Example x402 config: https://github.com/tangle-network/blueprint/blob/main/examples/x402-blueprint/config/x402.toml
+- Delegated auth dry-run helper script: https://github.com/tangle-network/blueprint/blob/main/scripts/x402-auth-dry-run.sh
+- Docs site page: https://docs.tangle.tools/developers/blueprint-runner/x402
+- Trigger model context (cron/on-chain/webhooks/x402): https://docs.tangle.tools/developers/blueprint-runner/job-triggers


### PR DESCRIPTION
## Summary
This PR improves crate discoverability and developer onboarding by standardizing README coverage across the `crates/` workspace.

### What changed
- Added README files for all crate directories that previously lacked one.
- Added dedicated, higher-detail READMEs for key runtime surfaces:
  - `crates/sdk`
  - `crates/runner`
  - `crates/router`
  - `crates/auth`
  - `crates/qos`
  - `crates/producers-extra`
  - `crates/manager`
  - `crates/x402`
  - `crates/webhooks`
- Updated `crates/README.md` into a clearer category index for runtime/integration/ops crates.

### README standards applied
- Succinct purpose statement up top.
- Clear scope and intended usage.
- Stable links to source and relevant docs pages.
- Example snippets on core crates where they help onboarding.
- Avoided flaky external doc links in bulk (kept links stable and CI-friendly).

## Validation
- Verified every crate directory now has a `README.md`.
- Ran link validation over all crate READMEs:
  - `lychee --no-progress 'crates/**/README.md'`
  - Result: `88 OK, 0 errors`

## Notes
- This PR is docs-only in `crates/**/README.md` plus `crates/README.md`.
- No runtime logic changes are included.
