### PR TITLE
feat(manager): close tee container-source audit gaps

### DIFF
--- a/cli/src/command/eigenlayer/register.rs
+++ b/cli/src/command/eigenlayer/register.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 ///
 /// * `config_path` - Path to the JSON configuration file containing AVS details
 /// * `keystore_uri` - URI for the keystore containing operator keys
-/// * `runtime_target` - Optional runtime target (native, hypervisor, container). Defaults to hypervisor.
+/// * `runtime_target` - Optional runtime target (native, hypervisor, container, tee). Defaults to hypervisor.
 /// * `verify` - Whether to perform on-chain verification after registration
 ///
 /// # Errors

--- a/crates/eigenlayer-extra/src/registration.rs
+++ b/crates/eigenlayer-extra/src/registration.rs
@@ -31,6 +31,7 @@ pub enum RegistrationStatus {
 /// - Native: Direct process execution (blueprint_path)
 /// - Hypervisor: VM-based isolation (blueprint_path)
 /// - Container: Docker/Kata containers (container_image)
+/// - Tee: TEE-gated container runtime (container_image + manager tee prerequisites)
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
 pub enum RuntimeTarget {
@@ -43,6 +44,9 @@ pub enum RuntimeTarget {
     /// Container runtime (Docker/Kata)
     /// Requires container_image field in config
     Container,
+    /// TEE runtime (strict container sandbox requirements + tee capability gate)
+    /// Requires container_image field in config
+    Tee,
 }
 
 impl Default for RuntimeTarget {
@@ -58,6 +62,7 @@ impl std::fmt::Display for RuntimeTarget {
             Self::Native => write!(f, "native"),
             Self::Hypervisor => write!(f, "hypervisor"),
             Self::Container => write!(f, "container"),
+            Self::Tee => write!(f, "tee"),
         }
     }
 }
@@ -70,8 +75,9 @@ impl std::str::FromStr for RuntimeTarget {
             "native" => Ok(Self::Native),
             "hypervisor" | "vm" => Ok(Self::Hypervisor),
             "container" | "docker" | "kata" => Ok(Self::Container),
+            "tee" | "confidential" | "confidential-container" => Ok(Self::Tee),
             _ => Err(format!(
-                "Invalid runtime target: '{s}'. Valid options: 'native', 'hypervisor', 'container'"
+                "Invalid runtime target: '{s}'. Valid options: 'native', 'hypervisor', 'container', 'tee'"
             )),
         }
     }
@@ -189,7 +195,10 @@ impl AvsRegistrationConfig {
         }
 
         // Pre-compiled binaries not yet supported for Native/Hypervisor runtimes
-        if self.blueprint_path.is_file() && self.runtime_target != RuntimeTarget::Container {
+        if self.blueprint_path.is_file()
+            && self.runtime_target != RuntimeTarget::Container
+            && self.runtime_target != RuntimeTarget::Tee
+        {
             return Err(format!(
                 "Pre-compiled binaries are not yet supported for {:?} runtime. \
                 Please use one of these options:\n\
@@ -221,39 +230,42 @@ impl AvsRegistrationConfig {
                 }
             }
             RuntimeTarget::Container => {
-                // Container runtime requires container_image field
-                if self.container_image.is_none() {
-                    return Err(
-                        "Container runtime requires 'container_image' field in config. \
-                        Example: \"ghcr.io/my-org/my-avs:latest\""
-                            .to_string(),
-                    );
-                }
-
-                // Validate image format
-                if let Some(ref image) = self.container_image {
-                    if image.trim().is_empty() {
-                        return Err("Container image cannot be empty".to_string());
-                    }
-
-                    // Validate format: should be "name:tag" or "registry/name:tag"
-                    let parts: Vec<&str> = image.split(':').collect();
-                    if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
-                        return Err(format!(
-                            "Container image must be 'name:tag' or 'registry/name:tag' format (got: '{image}'). \
-                            Example: \"ghcr.io/my-org/my-avs:latest\" or \"my-image:latest\""
-                        ));
-                    }
-
-                    // Check for common mistakes
-                    if parts[0].contains("://") {
-                        return Err(
-                            "Container image should not include protocol (http:// or https://)"
-                                .to_string(),
-                        );
-                    }
-                }
+                Self::validate_container_image(self.container_image.as_deref(), "Container")?;
             }
+            RuntimeTarget::Tee => {
+                Self::validate_container_image(self.container_image.as_deref(), "TEE")?;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn validate_container_image(image: Option<&str>, runtime_label: &str) -> Result<(), String> {
+        let Some(image) = image else {
+            return Err(format!(
+                "{runtime_label} runtime requires 'container_image' field in config. \
+                Example: \"ghcr.io/my-org/my-avs:latest\""
+            ));
+        };
+
+        if image.trim().is_empty() {
+            return Err("Container image cannot be empty".to_string());
+        }
+
+        // Validate format: should be "name:tag" or "registry/name:tag"
+        let parts: Vec<&str> = image.split(':').collect();
+        if parts.len() != 2 || parts[0].is_empty() || parts[1].is_empty() {
+            return Err(format!(
+                "Container image must be 'name:tag' or 'registry/name:tag' format (got: '{image}'). \
+                Example: \"ghcr.io/my-org/my-avs:latest\" or \"my-image:latest\""
+            ));
+        }
+
+        // Check for common mistakes
+        if parts[0].contains("://") {
+            return Err(
+                "Container image should not include protocol (http:// or https://)".to_string(),
+            );
         }
 
         Ok(())
@@ -628,6 +640,45 @@ mod tests {
 
         let result = config.validate();
         assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_runtime_target_parses_tee() {
+        let parsed: RuntimeTarget = "tee".parse().expect("tee runtime should parse");
+        assert_eq!(parsed, RuntimeTarget::Tee);
+        assert_eq!(parsed.to_string(), "tee");
+    }
+
+    #[test]
+    fn test_validation_tee_requires_container_image() {
+        let temp_dir = tempfile::tempdir().unwrap();
+        let blueprint_path = temp_dir.path().join("test_blueprint");
+        std::fs::create_dir_all(&blueprint_path).unwrap();
+
+        let config = AvsRegistrationConfig {
+            service_manager: Address::ZERO,
+            registry_coordinator: Address::ZERO,
+            operator_state_retriever: Address::ZERO,
+            strategy_manager: Address::ZERO,
+            delegation_manager: Address::ZERO,
+            avs_directory: Address::ZERO,
+            rewards_coordinator: Address::ZERO,
+            permission_controller: Address::ZERO,
+            allocation_manager: Address::ZERO,
+            strategy_address: Address::ZERO,
+            stake_registry: Address::ZERO,
+            blueprint_path,
+            runtime_target: RuntimeTarget::Tee,
+            allocation_delay: 0,
+            deposit_amount: 1000,
+            stake_amount: 100,
+            operator_sets: vec![0],
+            container_image: None,
+        };
+
+        let result = config.validate();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("container_image"));
     }
 
     #[test]

--- a/crates/manager/src/error.rs
+++ b/crates/manager/src/error.rs
@@ -50,6 +50,11 @@ pub enum Error {
     #[error("Failed to determine the local IP: {0}")]
     LocalIp(#[from] local_ip_address::Error),
 
+    #[error("TEE runtime is not available: {reason}")]
+    TeeRuntimeUnavailable { reason: String },
+    #[error("TEE runtime prerequisite missing: {prerequisite}. {hint}")]
+    TeePrerequisiteMissing { prerequisite: String, hint: String },
+
     #[error("Failed to get initial block hash")]
     InitialBlock,
     #[error("Finality Notification stream died")]

--- a/crates/manager/src/protocol/eigenlayer/event_handler.rs
+++ b/crates/manager/src/protocol/eigenlayer/event_handler.rs
@@ -113,6 +113,25 @@ fn format_address(addr: &alloy_primitives::Address) -> String {
     format!("{:x}", addr)
 }
 
+#[cfg(feature = "tee")]
+fn parse_tee_backend(env_value: Option<String>) -> Result<String> {
+    let backend = env_value
+        .map(|value| value.trim().to_string())
+        .unwrap_or_default();
+    if backend.is_empty() {
+        return Err(Error::TeePrerequisiteMissing {
+            prerequisite: "TEE_BACKEND".to_string(),
+            hint: "Set TEE_BACKEND (for example: direct,aws-nitro,gcp-confidential) before selecting runtime_target='tee'".to_string(),
+        });
+    }
+    Ok(backend)
+}
+
+#[cfg(feature = "tee")]
+fn resolve_tee_backend() -> Result<String> {
+    parse_tee_backend(std::env::var("TEE_BACKEND").ok())
+}
+
 impl EigenlayerEventHandler {
     /// Create a new EigenLayer event handler
     #[must_use]
@@ -382,9 +401,19 @@ impl EigenlayerEventHandler {
         })?;
 
         // Spawn the blueprint process using the runtime target from registration config
-        let mut service = match registration.config.runtime_target {
+        let runtime_target = registration.config.runtime_target;
+        info!(
+            blueprint_id,
+            service_id,
+            runtime_target = %runtime_target,
+            "Selecting EigenLayer runtime target"
+        );
+        let mut service = match runtime_target {
             blueprint_eigenlayer_extra::RuntimeTarget::Native => {
-                info!("Using Native runtime (no sandbox) - testing only!");
+                info!(
+                    runtime_path = "native",
+                    "Using Native runtime (no sandbox) - testing only!"
+                );
                 crate::rt::service::Service::new_native(
                     ctx,
                     limits,
@@ -399,7 +428,10 @@ impl EigenlayerEventHandler {
             blueprint_eigenlayer_extra::RuntimeTarget::Hypervisor => {
                 #[cfg(feature = "vm-sandbox")]
                 {
-                    info!("Using Hypervisor runtime (cloud-hypervisor VM)");
+                    info!(
+                        runtime_path = "hypervisor",
+                        "Using Hypervisor runtime (cloud-hypervisor VM)"
+                    );
                     crate::rt::service::Service::new_vm(
                         ctx,
                         limits,
@@ -436,7 +468,7 @@ impl EigenlayerEventHandler {
                             )
                         })?;
 
-                    info!("Using Container runtime with image: {}", container_image);
+                    info!(runtime_path = "container", image = %container_image, "Using Container runtime");
                     crate::rt::service::Service::new_container(
                         ctx,
                         limits,
@@ -445,6 +477,7 @@ impl EigenlayerEventHandler {
                         container_image,
                         blueprint_env.clone(),
                         args.clone(),
+                        false,
                         false, // debug mode
                     )
                     .await?
@@ -455,6 +488,52 @@ impl EigenlayerEventHandler {
                     return Err(Error::Other(
                         "Container runtime not available. Recompile with --features containers or use 'native' for testing.".into()
                     ));
+                }
+            }
+            blueprint_eigenlayer_extra::RuntimeTarget::Tee => {
+                #[cfg(feature = "tee")]
+                {
+                    #[cfg(feature = "containers")]
+                    {
+                        let container_image =
+                            registration.config.container_image.clone().ok_or_else(|| {
+                                Error::TeePrerequisiteMissing {
+                                    prerequisite: "container_image".to_string(),
+                                    hint: "TEE runtime requires container_image in EigenLayer registration config".to_string(),
+                                }
+                            })?;
+                        let tee_backend = resolve_tee_backend()?;
+                        info!(
+                            runtime_path = "container+tee-gate",
+                            image = %container_image,
+                            tee_backend = %tee_backend,
+                            "Using TEE runtime target"
+                        );
+                        crate::rt::service::Service::new_container(
+                            ctx,
+                            limits,
+                            &runtime_dir,
+                            &service_str,
+                            container_image,
+                            blueprint_env.clone(),
+                            args.clone(),
+                            true,
+                            false, // debug mode
+                        )
+                        .await?
+                    }
+                    #[cfg(not(feature = "containers"))]
+                    {
+                        return Err(Error::TeeRuntimeUnavailable {
+                            reason: "TEE runtime requires container runtime support. Recompile with --features tee,containers".to_string(),
+                        });
+                    }
+                }
+                #[cfg(not(feature = "tee"))]
+                {
+                    return Err(Error::TeeRuntimeUnavailable {
+                        reason: "TEE runtime requested but manager was compiled without tee support. Recompile with --features tee".to_string(),
+                    });
                 }
             }
         };

--- a/crates/manager/src/protocol/tangle/event_handler.rs
+++ b/crates/manager/src/protocol/tangle/event_handler.rs
@@ -3,7 +3,7 @@ use std::sync::Arc;
 use alloy_sol_types::sol;
 use async_trait::async_trait;
 use blueprint_client_tangle::contracts::ITangle;
-use blueprint_core::info;
+use blueprint_core::{info, warn};
 use blueprint_runner::config::{BlueprintEnvironment, Protocol};
 use tokio::fs::create_dir_all;
 
@@ -59,6 +59,74 @@ pub trait BlueprintMetadataProvider: Send + Sync {
 /// Handles Tangle events and translates them into blueprint lifecycle actions.
 pub struct TangleEventHandler {
     metadata: Arc<dyn BlueprintMetadataProvider>,
+}
+
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
+enum SourceCategory {
+    Native,
+    Container,
+    Testing,
+}
+
+fn source_category(source: &BlueprintSource) -> SourceCategory {
+    match source {
+        BlueprintSource::Github(_) | BlueprintSource::Remote(_) => SourceCategory::Native,
+        BlueprintSource::Container(_) => SourceCategory::Container,
+        BlueprintSource::Testing(_) => SourceCategory::Testing,
+    }
+}
+
+fn source_kind_label(source: &BlueprintSource) -> &'static str {
+    match source {
+        BlueprintSource::Github(_) => "github",
+        BlueprintSource::Remote(_) => "remote",
+        BlueprintSource::Container(_) => "container",
+        BlueprintSource::Testing(_) => "testing",
+    }
+}
+
+fn source_priority(source: &BlueprintSource, preferred_source: SourceType) -> u8 {
+    match preferred_source {
+        SourceType::Container => match source_category(source) {
+            SourceCategory::Container => 0,
+            SourceCategory::Native => 1,
+            SourceCategory::Testing => 2,
+        },
+        // WASM is currently unsupported in manager source handling.
+        SourceType::Native | SourceType::Wasm => match source_category(source) {
+            SourceCategory::Native => 0,
+            SourceCategory::Container => 1,
+            SourceCategory::Testing => 2,
+        },
+    }
+}
+
+fn ordered_source_indices(sources: &[BlueprintSource], preferred_source: SourceType) -> Vec<usize> {
+    let mut indexed: Vec<(usize, u8)> = sources
+        .iter()
+        .enumerate()
+        .map(|(idx, source)| (idx, source_priority(source, preferred_source)))
+        .collect();
+    indexed.sort_by_key(|(idx, priority)| (*priority, *idx));
+    indexed.into_iter().map(|(idx, _)| idx).collect()
+}
+
+fn planned_runtime_path_for_source(
+    source: &BlueprintSource,
+    ctx: &BlueprintManagerContext,
+) -> &'static str {
+    match source {
+        BlueprintSource::Container(_) => "container",
+        BlueprintSource::Github(_) | BlueprintSource::Remote(_) | BlueprintSource::Testing(_) => {
+            #[cfg(feature = "vm-sandbox")]
+            {
+                if !ctx.vm_sandbox_options.no_vm {
+                    return "hypervisor";
+                }
+            }
+            "native"
+        }
+    }
 }
 
 impl TangleEventHandler {
@@ -271,7 +339,39 @@ impl TangleEventHandler {
 
         let mut last_err: Option<Error> = None;
 
-        for source in &metadata.sources {
+        if ctx.preferred_source == SourceType::Wasm {
+            warn!(
+                preferred_source = %ctx.preferred_source,
+                "WASM source preference is not yet supported; using native/container/testing fallback ordering"
+            );
+        }
+
+        let ordered_source_idxs = ordered_source_indices(&metadata.sources, ctx.preferred_source);
+        let ordered_source_labels: Vec<&str> = ordered_source_idxs
+            .iter()
+            .map(|idx| source_kind_label(&metadata.sources[*idx]))
+            .collect();
+        info!(
+            blueprint_id = metadata.blueprint_id,
+            service_id = metadata.service_id,
+            preferred_source = %ctx.preferred_source,
+            source_order = ?ordered_source_labels,
+            "Resolved deterministic source fallback ordering"
+        );
+
+        for (attempt, source_idx) in ordered_source_idxs.iter().enumerate() {
+            let source = &metadata.sources[*source_idx];
+            let source_kind = source_kind_label(source);
+            let runtime_path = planned_runtime_path_for_source(source, ctx);
+            info!(
+                blueprint_id = metadata.blueprint_id,
+                service_id = metadata.service_id,
+                attempt = attempt + 1,
+                source_index = *source_idx,
+                source_kind,
+                runtime_path,
+                "Attempting source launch"
+            );
             let mut handler = build_source_handler(
                 source,
                 metadata.blueprint_id,
@@ -307,6 +407,14 @@ impl TangleEventHandler {
                 Ok(mut service) => {
                     if let Some(health) = service.start().await? {
                         if let Err(e) = health.await {
+                            info!(
+                                blueprint_id = metadata.blueprint_id,
+                                service_id = metadata.service_id,
+                                source_kind,
+                                runtime_path,
+                                error = %e,
+                                "Source launch failed health check; trying next fallback"
+                            );
                             last_err = Some(e);
                             continue;
                         }
@@ -317,12 +425,25 @@ impl TangleEventHandler {
                         .or_default()
                         .insert(metadata.service_id, service);
                     info!(
-                        "Started Tangle blueprint {} service {}",
-                        metadata.blueprint_id, metadata.service_id
+                        blueprint_id = metadata.blueprint_id,
+                        service_id = metadata.service_id,
+                        source_kind,
+                        runtime_path,
+                        "Started Tangle blueprint service"
                     );
                     return Ok(());
                 }
-                Err(e) => last_err = Some(e),
+                Err(e) => {
+                    info!(
+                        blueprint_id = metadata.blueprint_id,
+                        service_id = metadata.service_id,
+                        source_kind,
+                        runtime_path,
+                        error = %e,
+                        "Source launch attempt failed; trying next fallback"
+                    );
+                    last_err = Some(e);
+                }
             }
         }
 
@@ -469,5 +590,96 @@ fn build_source_handler(
             blueprint_id,
             blueprint_name,
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::sources::types::{
+        BlueprintBinary, GithubFetcher, ImageRegistryFetcher, RemoteFetcher, TestFetcher,
+    };
+
+    fn test_source() -> BlueprintSource {
+        BlueprintSource::Testing(TestFetcher {
+            cargo_package: "pkg".to_string(),
+            cargo_bin: "bin".to_string(),
+            base_path: "/tmp".to_string(),
+        })
+    }
+
+    fn container_source() -> BlueprintSource {
+        BlueprintSource::Container(ImageRegistryFetcher {
+            registry: "ghcr.io".to_string(),
+            image: "tangle/demo".to_string(),
+            tag: "v1".to_string(),
+        })
+    }
+
+    fn remote_source() -> BlueprintSource {
+        BlueprintSource::Remote(RemoteFetcher {
+            dist_url: "https://example.com/dist.json".to_string(),
+            archive_url: "https://example.com/archive.tar.xz".to_string(),
+            binaries: vec![BlueprintBinary {
+                arch: "amd64".to_string(),
+                os: "linux".to_string(),
+                name: "demo".to_string(),
+                sha256: [0x11; 32],
+                blake3: None,
+            }],
+        })
+    }
+
+    fn github_source() -> BlueprintSource {
+        BlueprintSource::Github(GithubFetcher {
+            owner: "owner".to_string(),
+            repo: "repo".to_string(),
+            tag: "v1".to_string(),
+            binaries: vec![BlueprintBinary {
+                arch: "amd64".to_string(),
+                os: "linux".to_string(),
+                name: "demo".to_string(),
+                sha256: [0x22; 32],
+                blake3: None,
+            }],
+        })
+    }
+
+    #[test]
+    fn deterministic_order_prefers_native_then_container_then_testing() {
+        let sources = vec![
+            test_source(),
+            container_source(),
+            remote_source(),
+            github_source(),
+        ];
+        let ordered = ordered_source_indices(&sources, SourceType::Native);
+        assert_eq!(ordered, vec![2, 3, 1, 0]);
+    }
+
+    #[test]
+    fn deterministic_order_prefers_container_when_requested() {
+        let sources = vec![
+            test_source(),
+            container_source(),
+            remote_source(),
+            github_source(),
+        ];
+        let ordered = ordered_source_indices(&sources, SourceType::Container);
+        assert_eq!(ordered, vec![1, 2, 3, 0]);
+    }
+
+    #[test]
+    fn deterministic_order_is_stable_for_wasm_preference() {
+        let sources = vec![
+            github_source(),
+            test_source(),
+            remote_source(),
+            container_source(),
+        ];
+        let first = ordered_source_indices(&sources, SourceType::Wasm);
+        let second = ordered_source_indices(&sources, SourceType::Wasm);
+        assert_eq!(first, second);
+        assert_eq!(first, vec![0, 2, 3, 1]);
     }
 }

--- a/crates/manager/src/protocol/tangle/metadata.rs
+++ b/crates/manager/src/protocol/tangle/metadata.rs
@@ -132,10 +132,37 @@ impl OnChainMetadataProvider {
     fn convert_container_source(
         source: &OnChainImageRegistrySource,
     ) -> Option<ImageRegistryFetcher> {
-        let registry = source.registry.clone().to_string();
-        let image = source.image.clone().to_string();
-        let tag = source.tag.clone().to_string();
+        let registry = source.registry.clone().to_string().trim().to_string();
+        let image = source.image.clone().to_string().trim().to_string();
+        let tag = source.tag.clone().to_string().trim().to_string();
         if registry.is_empty() && image.is_empty() && tag.is_empty() {
+            return None;
+        }
+
+        let mut lint_issues = Vec::new();
+        if registry.is_empty() {
+            lint_issues.push("missing registry");
+        }
+        if image.is_empty() {
+            lint_issues.push("missing image");
+        }
+        if tag.is_empty() {
+            lint_issues.push("missing tag");
+        }
+        if registry.contains("://") {
+            lint_issues.push("registry must not include URL scheme");
+        }
+        if registry.chars().any(char::is_whitespace)
+            || image.chars().any(char::is_whitespace)
+            || tag.chars().any(char::is_whitespace)
+        {
+            lint_issues.push("registry/image/tag must not contain whitespace");
+        }
+        if !lint_issues.is_empty() {
+            warn!(
+                "Skipping malformed container source metadata: {}",
+                lint_issues.join(", ")
+            );
             return None;
         }
 
@@ -562,5 +589,39 @@ mod tests {
             }
             other => panic!("expected remote source, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn skips_malformed_container_source_missing_tag() {
+        let mut container: OnChainBlueprintSource = Default::default();
+        container.kind = SOURCE_KIND_CONTAINER;
+        container.container = ITangleTypes::ImageRegistrySource {
+            registry: "ghcr.io".into(),
+            image: "demo/app".into(),
+            tag: "".into(),
+        };
+
+        let converted = OnChainMetadataProvider::convert_sources(&[container]);
+        assert!(
+            converted.is_empty(),
+            "container source with missing tag should be rejected"
+        );
+    }
+
+    #[test]
+    fn skips_malformed_container_source_with_registry_scheme() {
+        let mut container: OnChainBlueprintSource = Default::default();
+        container.kind = SOURCE_KIND_CONTAINER;
+        container.container = ITangleTypes::ImageRegistrySource {
+            registry: "https://ghcr.io".into(),
+            image: "demo/app".into(),
+            tag: "v1".into(),
+        };
+
+        let converted = OnChainMetadataProvider::convert_sources(&[container]);
+        assert!(
+            converted.is_empty(),
+            "container source with registry scheme should be rejected"
+        );
     }
 }

--- a/crates/manager/src/rt/container/mod.rs
+++ b/crates/manager/src/rt/container/mod.rs
@@ -46,6 +46,7 @@ pub struct ContainerInstance {
     image: String,
     env: BlueprintEnvVars,
     args: BlueprintArgs,
+    require_tee: bool,
 
     // TODO: Debug logging for containers
     /// Whether this instance should run in debug mode
@@ -69,6 +70,7 @@ impl ContainerInstance {
         image: String,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
+        require_tee: bool,
         debug: bool,
     ) -> Result<ContainerInstance> {
         let client = ctx.containers.kube_client.clone().ok_or_else(|| {
@@ -89,6 +91,7 @@ impl ContainerInstance {
             image,
             env,
             args,
+            require_tee,
             debug,
         })
     }
@@ -117,7 +120,24 @@ impl ContainerInstance {
         self.ensure_host_service().await?;
         self.ensure_host_endpoints().await?;
 
-        let runtime = if matches!(detect_kata(self.client.clone()).await, Ok(true)) {
+        let kata_available = match detect_kata(self.client.clone()).await {
+            Ok(v) => v,
+            Err(err) => {
+                if self.require_tee {
+                    return Err(err);
+                }
+                warn!("Failed to detect kata runtime class, continuing without kata: {err}");
+                false
+            }
+        };
+        if self.require_tee && !kata_available {
+            return Err(crate::error::Error::TeePrerequisiteMissing {
+                prerequisite: "kata runtime class".to_string(),
+                hint: "TEE runtime requires Kubernetes RuntimeClass 'kata' to enforce sandbox isolation".to_string(),
+            });
+        }
+
+        let runtime = if kata_available {
             Some(String::from("kata"))
         } else {
             None

--- a/crates/manager/src/rt/service.rs
+++ b/crates/manager/src/rt/service.rs
@@ -230,6 +230,7 @@ impl Service {
         image: String,
         mut env_vars: BlueprintEnvVars,
         arguments: BlueprintArgs,
+        require_tee: bool,
         debug: bool,
     ) -> Result<Service> {
         let (bridge_base_socket, bridge_handle, alive_rx) =
@@ -237,9 +238,17 @@ impl Service {
 
         env_vars.bridge_socket_path = Some(bridge_base_socket);
 
-        let instance =
-            ContainerInstance::new(ctx, limits, service_name, image, env_vars, arguments, debug)
-                .await?;
+        let instance = ContainerInstance::new(
+            ctx,
+            limits,
+            service_name,
+            image,
+            env_vars,
+            arguments,
+            require_tee,
+            debug,
+        )
+        .await?;
 
         Ok(Self {
             runtime: Runtime::Container(instance),

--- a/crates/manager/src/sources/container.rs
+++ b/crates/manager/src/sources/container.rs
@@ -84,6 +84,7 @@ impl BlueprintSourceHandler for ContainerSource {
             env,
             args,
             false,
+            false,
         )
         .await
     }

--- a/docs/tee-container-audit-gap-closure.md
+++ b/docs/tee-container-audit-gap-closure.md
@@ -1,0 +1,14 @@
+# TEE + Container Source Audit Gap Closure (2026-03-03)
+
+This document maps security/TEE claims to concrete code paths and tests implemented in
+`feat/tee-container-audit-gap-closure`.
+
+## Claims to code + tests
+
+| Claim | Code path | Test evidence |
+| --- | --- | --- |
+| Source fallback ordering is deterministic across source types. | `crates/manager/src/protocol/tangle/event_handler.rs` (`ordered_source_indices`, `source_priority`, `ensure_service_running`) | `crates/manager/src/protocol/tangle/event_handler.rs` tests: `deterministic_order_prefers_native_then_container_then_testing`, `deterministic_order_prefers_container_when_requested`, `deterministic_order_is_stable_for_wasm_preference` |
+| Source launch decisions are observable at runtime. | `crates/manager/src/protocol/tangle/event_handler.rs` (logs for preferred source, ordered source list, per-attempt source kind/runtime path, selected source) and `crates/manager/src/protocol/eigenlayer/event_handler.rs` (runtime target + runtime path logs) | Covered by existing protocol execution tests plus compile-time checked logging callsites in the paths above |
+| TEE runtime selection fails closed with structured prerequisite errors. | `crates/manager/src/error.rs` (`TeeRuntimeUnavailable`, `TeePrerequisiteMissing`), `crates/eigenlayer-extra/src/registration.rs` (`RuntimeTarget::Tee`), `crates/manager/src/protocol/eigenlayer/event_handler.rs` (TEE runtime gate + `TEE_BACKEND` prerequisite), `crates/manager/src/rt/container/mod.rs` (requires Kata when `require_tee=true`) | `crates/eigenlayer-extra/src/registration.rs` tests: `test_runtime_target_parses_tee`, `test_validation_tee_requires_container_image` |
+| Malformed container source metadata is linted and rejected before launch. | `crates/manager/src/protocol/tangle/metadata.rs` (`convert_container_source` validation for missing fields, URL scheme, whitespace) | `crates/manager/src/protocol/tangle/metadata.rs` tests: `skips_malformed_container_source_missing_tag`, `skips_malformed_container_source_with_registry_scheme` |
+| EigenLayer runtime supports explicit `tee` target selection. | `crates/eigenlayer-extra/src/registration.rs` (`RuntimeTarget::Tee`, display/parse/validation), `crates/manager/src/protocol/eigenlayer/event_handler.rs` (`RuntimeTarget::Tee` arm) | `crates/eigenlayer-extra/src/registration.rs` tests above |


### PR DESCRIPTION
## Gaps Addressed
- Source-selection determinism tests and ordering logic across source types (native/container/testing).
- Explicit TEE capability gate with structured errors when `runtime_target=tee` is selected without prerequisites.
- Decision-point observability for source selection and runtime path in Tangle/EigenLayer handlers.
- Source metadata lint/validation for malformed container source fields.
- Docs update mapping security/TEE claims to concrete code paths/tests.

## Test Evidence
- `cargo fmt --all`
- `cargo test -p blueprint-eigenlayer-extra test_runtime_target_parses_tee`
- `cargo test -p blueprint-eigenlayer-extra test_validation_tee_requires_container_image`
- `cargo test -p blueprint-manager deterministic_order_prefers_native_then_container_then_testing`
- `cargo test -p blueprint-manager deterministic_order_prefers_container_when_requested`
- `cargo test -p blueprint-manager deterministic_order_is_stable_for_wasm_preference`
- `cargo test -p blueprint-manager skips_malformed_container_source_missing_tag`
- `cargo test -p blueprint-manager skips_malformed_container_source_with_registry_scheme`
- Pre-push hook validation passed (format/check/tests for changed crates).

## Remaining Gaps
- No additional gaps from the implementation checklist remain in this PR.

## Audit Reference
- https://gist.github.com/drewstone/d159abf2667f4c377a76d96ec16ef58c