### PR TITLE
feat(manager): enforce tee intent in tangle and remote provisioning

### DIFF
--- a/crates/blueprint-remote-providers/src/infra/mapper.rs
+++ b/crates/blueprint-remote-providers/src/infra/mapper.rs
@@ -11,6 +11,19 @@ impl InstanceTypeMapper {
         spec: &ResourceSpec,
         provider: &CloudProvider,
     ) -> InstanceSelection {
+        Self::map_to_instance_type_with_requirements(spec, provider, false)
+    }
+
+    /// Map resource spec to instance type while honoring deployment requirements.
+    pub fn map_to_instance_type_with_requirements(
+        spec: &ResourceSpec,
+        provider: &CloudProvider,
+        require_tee: bool,
+    ) -> InstanceSelection {
+        if require_tee {
+            return Self::map_tee_instance(spec, provider);
+        }
+
         match provider {
             CloudProvider::AWS => Self::map_aws_instance(spec),
             CloudProvider::GCP => Self::map_gcp_instance(spec),
@@ -18,6 +31,58 @@ impl InstanceTypeMapper {
             CloudProvider::DigitalOcean => Self::map_do_instance(spec),
             CloudProvider::Vultr => Self::map_vultr_instance(spec),
             _ => Self::map_generic_instance(spec),
+        }
+    }
+
+    fn map_tee_instance(spec: &ResourceSpec, provider: &CloudProvider) -> InstanceSelection {
+        let instance_type = match provider {
+            CloudProvider::AWS => Self::map_aws_tee_instance_type(spec).to_string(),
+            CloudProvider::GCP => Self::map_gcp_tee_instance_type(spec).to_string(),
+            CloudProvider::Azure => Self::map_azure_tee_instance_type(spec).to_string(),
+            // Non-confidential providers must already be filtered by manager/provisioner.
+            _ => Self::map_generic_instance(spec).instance_type,
+        };
+
+        InstanceSelection {
+            instance_type: instance_type.clone(),
+            // Confidential-compute SKUs are generally not spot-capable in managed flows.
+            spot_capable: false,
+            estimated_hourly_cost: match provider {
+                CloudProvider::AWS => Self::estimate_aws_cost(&instance_type),
+                CloudProvider::GCP => Self::estimate_gcp_cost(&instance_type),
+                CloudProvider::Azure => Self::estimate_azure_cost(&instance_type),
+                _ => Self::map_generic_instance(spec).estimated_hourly_cost,
+            },
+        }
+    }
+
+    fn map_aws_tee_instance_type(spec: &ResourceSpec) -> &'static str {
+        match (spec.cpu, spec.memory_gb, spec.gpu_count) {
+            (_, _, Some(_)) => "g5.xlarge",
+            (cpu, mem, _) if cpu <= 2.0 && mem <= 8.0 => "m6i.large",
+            (cpu, mem, _) if cpu <= 4.0 && mem <= 16.0 => "m6i.xlarge",
+            (cpu, mem, _) if cpu <= 8.0 && mem <= 32.0 => "m6i.2xlarge",
+            _ => "c6i.4xlarge",
+        }
+    }
+
+    fn map_gcp_tee_instance_type(spec: &ResourceSpec) -> &'static str {
+        match (spec.cpu, spec.memory_gb, spec.gpu_count) {
+            (_, _, Some(_)) => "n2d-standard-8",
+            (cpu, mem, _) if cpu <= 2.0 && mem <= 8.0 => "n2d-standard-2",
+            (cpu, mem, _) if cpu <= 4.0 && mem <= 16.0 => "n2d-standard-4",
+            (cpu, mem, _) if cpu <= 8.0 && mem <= 32.0 => "n2d-standard-8",
+            _ => "n2d-standard-16",
+        }
+    }
+
+    fn map_azure_tee_instance_type(spec: &ResourceSpec) -> &'static str {
+        match (spec.cpu, spec.memory_gb, spec.gpu_count) {
+            (_, _, Some(_)) => "Standard_DC8as_v5",
+            (cpu, mem, _) if cpu <= 2.0 && mem <= 8.0 => "Standard_DC2as_v5",
+            (cpu, mem, _) if cpu <= 4.0 && mem <= 16.0 => "Standard_DC4as_v5",
+            (cpu, mem, _) if cpu <= 8.0 && mem <= 32.0 => "Standard_DC8as_v5",
+            _ => "Standard_DC16as_v5",
         }
     }
 
@@ -304,5 +369,40 @@ mod tests {
         assert_eq!(selection.instance_type, "t3.micro");
         assert!(selection.spot_capable);
         assert!(selection.estimated_hourly_cost < 0.02); // Should be cheap
+    }
+
+    #[test]
+    fn test_tee_mapping_prefers_confidential_families() {
+        let spec = ResourceSpec {
+            cpu: 4.0,
+            memory_gb: 16.0,
+            storage_gb: 100.0,
+            gpu_count: None,
+            allow_spot: true,
+            qos: Default::default(),
+        };
+
+        let aws = InstanceTypeMapper::map_to_instance_type_with_requirements(
+            &spec,
+            &CloudProvider::AWS,
+            true,
+        );
+        let gcp = InstanceTypeMapper::map_to_instance_type_with_requirements(
+            &spec,
+            &CloudProvider::GCP,
+            true,
+        );
+        let azure = InstanceTypeMapper::map_to_instance_type_with_requirements(
+            &spec,
+            &CloudProvider::Azure,
+            true,
+        );
+
+        assert_eq!(aws.instance_type, "m6i.xlarge");
+        assert_eq!(gcp.instance_type, "n2d-standard-4");
+        assert_eq!(azure.instance_type, "Standard_DC4as_v5");
+        assert!(!aws.spot_capable);
+        assert!(!gcp.spot_capable);
+        assert!(!azure.spot_capable);
     }
 }

--- a/crates/blueprint-remote-providers/src/infra/provisioner.rs
+++ b/crates/blueprint-remote-providers/src/infra/provisioner.rs
@@ -101,14 +101,44 @@ impl CloudProvisioner {
         resource_spec: &ResourceSpec,
         region: &str,
     ) -> Result<ProvisionedInstance> {
+        self.provision_with_requirements(provider, resource_spec, region, false)
+            .await
+    }
+
+    /// Provision infrastructure with explicit deployment requirements.
+    pub async fn provision_with_requirements(
+        &self,
+        provider: CloudProvider,
+        resource_spec: &ResourceSpec,
+        region: &str,
+        require_tee: bool,
+    ) -> Result<ProvisionedInstance> {
         let adapter = self
             .providers
             .get(&provider)
             .ok_or_else(|| Error::ProviderNotConfigured(provider.clone()))?;
 
+        if require_tee
+            && !matches!(
+                provider,
+                CloudProvider::AWS | CloudProvider::GCP | CloudProvider::Azure
+            )
+        {
+            return Err(Error::ConfigurationError(format!(
+                "Provider {provider:?} does not support confidential-compute provisioning"
+            )));
+        }
+
         // Map resources to appropriate instance type
-        // Map resource spec to instance type
-        let instance_selection = InstanceTypeMapper::map_to_instance_type(resource_spec, &provider);
+        let instance_selection = InstanceTypeMapper::map_to_instance_type_with_requirements(
+            resource_spec,
+            &provider,
+            require_tee,
+        );
+        info!(
+            "Provisioning {} instance type {} (tee_required={})",
+            provider, instance_selection.instance_type, require_tee
+        );
 
         // Retry with exponential backoff
         let mut attempt = 0;

--- a/crates/blueprint-remote-providers/src/providers/aws/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/aws/adapter.rs
@@ -82,7 +82,7 @@ impl AwsAdapter {
 impl CloudProviderAdapter for AwsAdapter {
     async fn provision_instance(
         &self,
-        _instance_type: &str,
+        instance_type: &str,
         region: &str,
     ) -> Result<ProvisionedInstance> {
         let spec = ResourceSpec {
@@ -99,6 +99,7 @@ impl CloudProviderAdapter for AwsAdapter {
 
         let mut custom_config = HashMap::new();
         custom_config.insert("security_group_ids".to_string(), security_group);
+        custom_config.insert("instance_type".to_string(), instance_type.to_string());
 
         let config = ProvisioningConfig {
             name: format!("blueprint-{}", uuid::Uuid::new_v4()),

--- a/crates/blueprint-remote-providers/src/providers/aws/provisioner.rs
+++ b/crates/blueprint-remote-providers/src/providers/aws/provisioner.rs
@@ -38,7 +38,10 @@ impl AwsProvisioner {
         config: &ProvisioningConfig,
     ) -> Result<ProvisionedInfrastructure> {
         // Map requirements to instance type
-        let instance_selection = AwsInstanceMapper::map(spec);
+        let mut instance_selection = AwsInstanceMapper::map(spec);
+        if let Some(override_type) = config.custom_config.get("instance_type") {
+            instance_selection.instance_type = override_type.clone();
+        }
 
         // Run EC2 instance
         let result = self

--- a/crates/blueprint-remote-providers/src/providers/azure/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/azure/adapter.rs
@@ -33,7 +33,7 @@ impl AzureAdapter {
 impl CloudProviderAdapter for AzureAdapter {
     async fn provision_instance(
         &self,
-        _instance_type: &str,
+        instance_type: &str,
         region: &str,
     ) -> Result<ProvisionedInstance> {
         let spec = ResourceSpec {
@@ -53,7 +53,11 @@ impl CloudProviderAdapter for AzureAdapter {
             ssh_key_name: std::env::var("AZURE_SSH_KEY_NAME").ok(),
             ami_id: None,
             machine_image: None,
-            custom_config: HashMap::new(),
+            custom_config: {
+                let mut config = HashMap::new();
+                config.insert("vm_size".to_string(), instance_type.to_string());
+                config
+            },
         };
 
         let mut provisioner = self.provisioner.lock().await;

--- a/crates/blueprint-remote-providers/src/providers/azure/provisioner.rs
+++ b/crates/blueprint-remote-providers/src/providers/azure/provisioner.rs
@@ -128,7 +128,11 @@ impl AzureProvisioner {
             .await?;
 
         // Determine VM size based on spec
-        let vm_size = self.select_vm_size(spec);
+        let vm_size = config
+            .custom_config
+            .get("vm_size")
+            .cloned()
+            .unwrap_or_else(|| self.select_vm_size(spec).to_string());
 
         // Create VM
         let vm_body = serde_json::json!({
@@ -200,7 +204,7 @@ impl AzureProvisioner {
         let public_ip = self.wait_for_vm(&vm_name, &token).await?;
 
         let mut metadata = std::collections::HashMap::new();
-        metadata.insert("vm_size".to_string(), vm_size.to_string());
+        metadata.insert("vm_size".to_string(), vm_size.clone());
         metadata.insert("location".to_string(), location.to_string());
         metadata.insert("os".to_string(), "Ubuntu 22.04 LTS".to_string());
 
@@ -213,7 +217,7 @@ impl AzureProvisioner {
             public_ip: Some(public_ip),
             private_ip: None,
             region: location.to_string(),
-            instance_type: vm_size.to_string(),
+            instance_type: vm_size,
             metadata,
         })
     }

--- a/crates/blueprint-remote-providers/src/providers/gcp/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/gcp/adapter.rs
@@ -159,7 +159,7 @@ impl GcpAdapter {
 impl CloudProviderAdapter for GcpAdapter {
     async fn provision_instance(
         &self,
-        _instance_type: &str,
+        instance_type: &str,
         region: &str,
     ) -> Result<ProvisionedInstance> {
         let spec = ResourceSpec {
@@ -188,6 +188,7 @@ impl CloudProviderAdapter for GcpAdapter {
                     // In production, read SSH public key from file
                     config.insert("ssh_public_key".to_string(), "".to_string());
                 }
+                config.insert("instance_type".to_string(), instance_type.to_string());
                 config
             },
         };

--- a/crates/blueprint-remote-providers/src/providers/gcp/mod.rs
+++ b/crates/blueprint-remote-providers/src/providers/gcp/mod.rs
@@ -88,7 +88,16 @@ impl GcpProvisioner {
         spec: &ResourceSpec,
         config: &ProvisioningConfig,
     ) -> Result<ProvisionedInfrastructure> {
-        let instance_selection = Self::map_instance(spec);
+        let instance_selection =
+            if let Some(override_type) = config.custom_config.get("instance_type") {
+                InstanceSelection {
+                    instance_type: override_type.clone(),
+                    spot_capable: false,
+                    estimated_hourly_cost: None,
+                }
+            } else {
+                Self::map_instance(spec)
+            };
         let zone = format!("{}-a", config.region); // e.g., us-central1-a
 
         info!(

--- a/crates/manager/src/executor/remote_provider_integration.rs
+++ b/crates/manager/src/executor/remote_provider_integration.rs
@@ -13,6 +13,25 @@ use blueprint_remote_providers::{
 };
 use blueprint_std::sync::Arc;
 
+fn env_bool(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn supports_tee(provider: &CloudProvider) -> bool {
+    matches!(
+        provider,
+        CloudProvider::AWS | CloudProvider::GCP | CloudProvider::Azure
+    )
+}
+
 /// Remote provider manager that handles cloud deployments
 pub struct RemoteProviderManager {
     provisioner: Arc<CloudProvisioner>,
@@ -69,9 +88,12 @@ impl RemoteProviderManager {
 
         // Use provided resources or default
         let resource_spec = resource_requirements.unwrap_or_else(ResourceSpec::minimal);
+        let tee_required = env_bool("BLUEPRINT_REMOTE_TEE_REQUIRED");
 
         // Use intelligent provider selection based on resource requirements
-        let provider = if resource_spec.gpu_count.is_some() {
+        let provider = if tee_required {
+            CloudProvider::AWS
+        } else if resource_spec.gpu_count.is_some() {
             // GPU workloads prefer GCP or AWS
             CloudProvider::GCP
         } else if resource_spec.cpu > 8.0 {
@@ -95,9 +117,17 @@ impl RemoteProviderManager {
             _ => "default",
         };
 
+        if tee_required && !supports_tee(&provider) {
+            error!(
+                "TEE is required but selected provider {} does not support confidential compute",
+                provider
+            );
+            return Ok(());
+        }
+
         match self
             .provisioner
-            .provision(provider.clone(), &resource_spec, region)
+            .provision_with_requirements(provider.clone(), &resource_spec, region, tee_required)
             .await
         {
             Ok(instance) => {

--- a/crates/manager/src/protocol/tangle/event_handler.rs
+++ b/crates/manager/src/protocol/tangle/event_handler.rs
@@ -37,6 +37,7 @@ pub struct BlueprintMetadata {
     pub service_id: u64,
     pub name: String,
     pub sources: Vec<BlueprintSource>,
+    pub tee_required: bool,
     pub registration_mode: bool,
     pub registration_capture_only: bool,
 }
@@ -101,10 +102,19 @@ fn source_priority(source: &BlueprintSource, preferred_source: SourceType) -> u8
     }
 }
 
-fn ordered_source_indices(sources: &[BlueprintSource], preferred_source: SourceType) -> Vec<usize> {
+fn supports_tee(source: &BlueprintSource) -> bool {
+    matches!(source, BlueprintSource::Container(_))
+}
+
+fn ordered_source_indices(
+    sources: &[BlueprintSource],
+    preferred_source: SourceType,
+    require_tee: bool,
+) -> Vec<usize> {
     let mut indexed: Vec<(usize, u8)> = sources
         .iter()
         .enumerate()
+        .filter(|(_, source)| !require_tee || supports_tee(source))
         .map(|(idx, source)| (idx, source_priority(source, preferred_source)))
         .collect();
     indexed.sort_by_key(|(idx, priority)| (*priority, *idx));
@@ -346,7 +356,17 @@ impl TangleEventHandler {
             );
         }
 
-        let ordered_source_idxs = ordered_source_indices(&metadata.sources, ctx.preferred_source);
+        let ordered_source_idxs = ordered_source_indices(
+            &metadata.sources,
+            ctx.preferred_source,
+            metadata.tee_required,
+        );
+        if metadata.tee_required && ordered_source_idxs.is_empty() {
+            return Err(Error::TeeRuntimeUnavailable {
+                reason: "Blueprint requires TEE execution but exposes no container source"
+                    .to_string(),
+            });
+        }
         let ordered_source_labels: Vec<&str> = ordered_source_idxs
             .iter()
             .map(|idx| source_kind_label(&metadata.sources[*idx]))
@@ -354,6 +374,7 @@ impl TangleEventHandler {
         info!(
             blueprint_id = metadata.blueprint_id,
             service_id = metadata.service_id,
+            tee_required = metadata.tee_required,
             preferred_source = %ctx.preferred_source,
             source_order = ?ordered_source_labels,
             "Resolved deterministic source fallback ordering"
@@ -398,6 +419,7 @@ impl TangleEventHandler {
                     service_idx,
                     env_vars,
                     args,
+                    metadata.tee_required,
                     &service_label,
                     &cache_dir,
                     &runtime_dir,
@@ -449,7 +471,7 @@ impl TangleEventHandler {
 
         // Fallback: when preferred_source is Native and all on-chain sources failed,
         // try building from local cargo workspace if BLUEPRINT_CARGO_BIN is set.
-        if ctx.preferred_source == SourceType::Native {
+        if ctx.preferred_source == SourceType::Native && !metadata.tee_required {
             if let Ok(cargo_bin) = std::env::var("BLUEPRINT_CARGO_BIN") {
                 let base_path = std::env::current_dir()
                     .map(|p| p.display().to_string())
@@ -490,6 +512,7 @@ impl TangleEventHandler {
                         service_idx,
                         env_vars,
                         args,
+                        false,
                         &service_label,
                         &cache_dir,
                         &runtime_dir,
@@ -653,7 +676,7 @@ mod tests {
             remote_source(),
             github_source(),
         ];
-        let ordered = ordered_source_indices(&sources, SourceType::Native);
+        let ordered = ordered_source_indices(&sources, SourceType::Native, false);
         assert_eq!(ordered, vec![2, 3, 1, 0]);
     }
 
@@ -665,7 +688,7 @@ mod tests {
             remote_source(),
             github_source(),
         ];
-        let ordered = ordered_source_indices(&sources, SourceType::Container);
+        let ordered = ordered_source_indices(&sources, SourceType::Container, false);
         assert_eq!(ordered, vec![1, 2, 3, 0]);
     }
 
@@ -677,9 +700,28 @@ mod tests {
             remote_source(),
             container_source(),
         ];
-        let first = ordered_source_indices(&sources, SourceType::Wasm);
-        let second = ordered_source_indices(&sources, SourceType::Wasm);
+        let first = ordered_source_indices(&sources, SourceType::Wasm, false);
+        let second = ordered_source_indices(&sources, SourceType::Wasm, false);
         assert_eq!(first, second);
         assert_eq!(first, vec![0, 2, 3, 1]);
+    }
+
+    #[test]
+    fn tee_required_filters_to_container_sources_only() {
+        let sources = vec![
+            test_source(),
+            container_source(),
+            remote_source(),
+            github_source(),
+        ];
+        let ordered = ordered_source_indices(&sources, SourceType::Native, true);
+        assert_eq!(ordered, vec![1]);
+    }
+
+    #[test]
+    fn tee_required_without_container_sources_returns_empty_order() {
+        let sources = vec![test_source(), remote_source(), github_source()];
+        let ordered = ordered_source_indices(&sources, SourceType::Container, true);
+        assert!(ordered.is_empty());
     }
 }

--- a/crates/manager/src/protocol/tangle/metadata.rs
+++ b/crates/manager/src/protocol/tangle/metadata.rs
@@ -17,8 +17,10 @@ use crate::sources::types::{
 use blueprint_client_tangle::contracts::ITangleTypes;
 use serde::Deserialize;
 use serde_json;
+use serde_json::Value;
 type OnChainBlueprintSource = <ITangleTypes::BlueprintSource as SolType>::RustType;
 type OnChainBlueprintBinary = <ITangleTypes::BlueprintBinary as SolType>::RustType;
+type OnChainBlueprintMetadata = <ITangleTypes::BlueprintMetadata as SolType>::RustType;
 type OnChainImageRegistrySource = <ITangleTypes::ImageRegistrySource as SolType>::RustType;
 type OnChainTestingSource = <ITangleTypes::TestingSource as SolType>::RustType;
 type OnChainNativeSource = <ITangleTypes::NativeSource as SolType>::RustType;
@@ -54,7 +56,7 @@ impl OnChainMetadataProvider {
         service_id: u64,
         registration_mode: bool,
     ) -> Result<Option<ManagerBlueprintMetadata>> {
-        let Some((blueprint_name, sources)) =
+        let Some((blueprint_name, sources, tee_required)) =
             Self::load_blueprint_sources(client, blueprint_id).await?
         else {
             return Ok(None);
@@ -65,6 +67,7 @@ impl OnChainMetadataProvider {
             service_id,
             name: blueprint_name,
             sources,
+            tee_required,
             registration_mode,
             registration_capture_only: false,
         }))
@@ -73,7 +76,7 @@ impl OnChainMetadataProvider {
     async fn load_blueprint_sources(
         client: &TangleProtocolClient,
         blueprint_id: u64,
-    ) -> Result<Option<(String, Vec<ManagerBlueprintSource>)>> {
+    ) -> Result<Option<(String, Vec<ManagerBlueprintSource>, bool)>> {
         let inner = client.client();
         let definition = match inner.get_blueprint_definition(blueprint_id).await {
             Ok(definition) => definition,
@@ -87,6 +90,7 @@ impl OnChainMetadataProvider {
         };
 
         let blueprint_name = definition.metadata.name.clone().to_string();
+        let tee_required = Self::resolve_tee_required(&definition.metadata);
         let onchain_sources = definition.sources;
 
         let sources = Self::convert_sources(&onchain_sources);
@@ -99,7 +103,89 @@ impl OnChainMetadataProvider {
             return Ok(None);
         }
 
-        Ok(Some((blueprint_name, sources)))
+        Ok(Some((blueprint_name, sources, tee_required)))
+    }
+
+    fn resolve_tee_required(metadata: &OnChainBlueprintMetadata) -> bool {
+        for raw in [
+            metadata.profilingData.as_str(),
+            metadata.description.as_str(),
+            metadata.category.as_str(),
+        ] {
+            if let Some(tee_required) = Self::parse_tee_required_hint(raw) {
+                return tee_required;
+            }
+        }
+
+        false
+    }
+
+    fn parse_tee_required_hint(raw: &str) -> Option<bool> {
+        let trimmed = raw.trim();
+        if trimmed.is_empty() {
+            return None;
+        }
+
+        if trimmed.starts_with('{') {
+            let value: Value = serde_json::from_str(trimmed).ok()?;
+            return Self::extract_tee_required_from_value(&value);
+        }
+
+        Self::parse_runtime_profile_mode(trimmed)
+    }
+
+    fn extract_tee_required_from_value(value: &Value) -> Option<bool> {
+        if let Some(tee_required) = value.get("tee_required").and_then(Value::as_bool) {
+            return Some(tee_required);
+        }
+        if let Some(tee_required) = value.get("teeRequired").and_then(Value::as_bool) {
+            return Some(tee_required);
+        }
+
+        for key in [
+            "runtime_profile",
+            "runtimeProfile",
+            "deployment_profile",
+            "deploymentProfile",
+        ] {
+            if let Some(profile) = value.get(key) {
+                if let Some(tee_required) = Self::extract_tee_required_from_value(profile) {
+                    return Some(tee_required);
+                }
+                if let Some(mode) = profile.as_str() {
+                    if let Some(tee_required) = Self::parse_runtime_profile_mode(mode) {
+                        return Some(tee_required);
+                    }
+                }
+            }
+        }
+
+        if let Some(mode) = value.get("mode").and_then(Value::as_str) {
+            if let Some(tee_required) = Self::parse_runtime_profile_mode(mode) {
+                return Some(tee_required);
+            }
+        }
+        if let Some(mode) = value.get("runtime").and_then(Value::as_str) {
+            if let Some(tee_required) = Self::parse_runtime_profile_mode(mode) {
+                return Some(tee_required);
+            }
+        }
+
+        None
+    }
+
+    fn parse_runtime_profile_mode(mode: &str) -> Option<bool> {
+        let normalized = mode.trim().to_ascii_lowercase();
+        match normalized.as_str() {
+            "tee"
+            | "trusted_execution"
+            | "trusted-execution"
+            | "confidential"
+            | "confidential_compute"
+            | "confidential-compute" => Some(true),
+            "native" | "container" | "wasm" | "none" | "disabled" => Some(false),
+            _ => None,
+        }
     }
 
     fn convert_sources(sources: &[OnChainBlueprintSource]) -> Vec<ManagerBlueprintSource> {
@@ -623,5 +709,40 @@ mod tests {
             converted.is_empty(),
             "container source with registry scheme should be rejected"
         );
+    }
+
+    #[test]
+    fn parse_tee_required_from_top_level_bool() {
+        let payload = r#"{"tee_required":true}"#;
+        let parsed = OnChainMetadataProvider::parse_tee_required_hint(payload);
+        assert_eq!(parsed, Some(true));
+    }
+
+    #[test]
+    fn parse_tee_required_from_runtime_profile_object() {
+        let payload = r#"{"runtime_profile":{"tee_required":false}}"#;
+        let parsed = OnChainMetadataProvider::parse_tee_required_hint(payload);
+        assert_eq!(parsed, Some(false));
+    }
+
+    #[test]
+    fn parse_tee_required_from_runtime_profile_mode() {
+        let payload = r#"{"runtimeProfile":"tee"}"#;
+        let parsed = OnChainMetadataProvider::parse_tee_required_hint(payload);
+        assert_eq!(parsed, Some(true));
+    }
+
+    #[test]
+    fn parse_tee_required_from_plain_mode_string() {
+        let parsed = OnChainMetadataProvider::parse_tee_required_hint("native");
+        assert_eq!(parsed, Some(false));
+    }
+
+    #[test]
+    fn parse_tee_required_ignores_unrelated_or_non_json_payloads() {
+        let parsed = OnChainMetadataProvider::parse_tee_required_hint(
+            "[PROFILING_DATA_V1]H4sIAAAAAAAA/2NgYGBgBGIOAwA6rY+4BQAAAA==",
+        );
+        assert_eq!(parsed, None);
     }
 }

--- a/crates/manager/src/remote/integration_test.rs
+++ b/crates/manager/src/remote/integration_test.rs
@@ -13,6 +13,7 @@ async fn test_provider_selection_integration() -> Result<(), Box<dyn std::error:
         storage_gb: 100.0,
         gpu_count: Some(1),
         allow_spot: false,
+        tee_required: false,
     };
 
     let provider = selector.select_provider(&gpu_spec)?;
@@ -29,6 +30,7 @@ async fn test_provider_selection_integration() -> Result<(), Box<dyn std::error:
         storage_gb: 200.0,
         gpu_count: None,
         allow_spot: false,
+        tee_required: false,
     };
 
     let provider = selector.select_provider(&cpu_spec)?;
@@ -45,6 +47,7 @@ async fn test_provider_selection_integration() -> Result<(), Box<dyn std::error:
         storage_gb: 20.0,
         gpu_count: None,
         allow_spot: true,
+        tee_required: false,
     };
 
     let provider = selector.select_provider(&cost_spec)?;
@@ -64,6 +67,8 @@ async fn test_remote_deployment_service_integration() -> Result<(), Box<dyn std:
         max_hourly_cost: Some(10.0),
         prefer_spot: true,
         auto_terminate_hours: Some(2),
+        tee_required: false,
+        tee_backend: None,
     };
 
     let service = RemoteDeploymentService::new(policy).await?;
@@ -88,6 +93,7 @@ async fn test_custom_provider_preferences() -> Result<(), Box<dyn std::error::Er
         cpu_intensive: vec![CloudProvider::DigitalOcean, CloudProvider::GCP],
         memory_intensive: vec![CloudProvider::Azure, CloudProvider::Vultr],
         cost_optimized: vec![CloudProvider::DigitalOcean, CloudProvider::Vultr],
+        tee_capable: vec![CloudProvider::Azure, CloudProvider::AWS],
     };
 
     let selector = ProviderSelector::new(custom_preferences);
@@ -99,6 +105,7 @@ async fn test_custom_provider_preferences() -> Result<(), Box<dyn std::error::Er
         storage_gb: 100.0,
         gpu_count: Some(1),
         allow_spot: false,
+        tee_required: false,
     };
 
     let provider = selector.select_provider(&gpu_spec)?;
@@ -121,6 +128,7 @@ async fn test_fallback_providers() -> Result<(), Box<dyn std::error::Error>> {
         storage_gb: 100.0,
         gpu_count: Some(1),
         allow_spot: false,
+        tee_required: false,
     };
 
     let fallbacks = selector.get_fallback_providers(&gpu_spec);

--- a/crates/manager/src/remote/provider_selector.rs
+++ b/crates/manager/src/remote/provider_selector.rs
@@ -16,6 +16,13 @@ pub enum CloudProvider {
     Generic,
 }
 
+impl CloudProvider {
+    #[must_use]
+    pub fn supports_tee(self) -> bool {
+        matches!(self, Self::AWS | Self::GCP | Self::Azure)
+    }
+}
+
 impl std::fmt::Display for CloudProvider {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
@@ -37,6 +44,8 @@ pub struct ResourceSpec {
     pub storage_gb: f32,
     pub gpu_count: Option<u32>,
     pub allow_spot: bool,
+    #[serde(default)]
+    pub tee_required: bool,
 }
 
 /// Deployment target options.
@@ -64,6 +73,8 @@ pub struct ProviderPreferences {
     pub memory_intensive: Vec<CloudProvider>,
     /// Providers for cost-optimized workloads
     pub cost_optimized: Vec<CloudProvider>,
+    /// Providers that can satisfy TEE requirements
+    pub tee_capable: Vec<CloudProvider>,
 }
 
 impl Default for ProviderPreferences {
@@ -77,6 +88,7 @@ impl Default for ProviderPreferences {
             ],
             memory_intensive: vec![CloudProvider::AWS, CloudProvider::GCP],
             cost_optimized: vec![CloudProvider::Vultr, CloudProvider::DigitalOcean],
+            tee_capable: vec![CloudProvider::AWS, CloudProvider::GCP, CloudProvider::Azure],
         }
     }
 }
@@ -129,7 +141,10 @@ impl ProviderSelector {
 
     /// Select cloud provider based on resource requirements.
     pub fn select_provider(&self, requirements: &ResourceSpec) -> Result<CloudProvider> {
-        let candidates = if requirements.gpu_count.is_some() {
+        let candidates = if requirements.tee_required {
+            info!("TEE required, selecting from TEE-capable providers");
+            &self.preferences.tee_capable
+        } else if requirements.gpu_count.is_some() {
             info!("GPU required, selecting from GPU providers");
             &self.preferences.gpu_providers
         } else if requirements.cpu > 8.0 {
@@ -168,6 +183,15 @@ impl ProviderSelector {
     pub fn get_fallback_providers(&self, requirements: &ResourceSpec) -> Vec<CloudProvider> {
         let mut fallbacks = Vec::new();
 
+        if requirements.tee_required {
+            fallbacks.extend(&self.preferences.tee_capable);
+            let primary = self.select_provider(requirements).ok();
+            fallbacks.retain(|p| Some(*p) != primary);
+            fallbacks.dedup();
+            info!("TEE fallback providers: {:?}", fallbacks);
+            return fallbacks;
+        }
+
         // Add all other provider categories as fallbacks
         if requirements.gpu_count.is_some() {
             // For GPU workloads, fallback to CPU-intensive providers
@@ -202,6 +226,7 @@ mod tests {
             storage_gb: 100.0,
             gpu_count: Some(1),
             allow_spot: false,
+            tee_required: false,
         };
 
         let provider = selector.select_provider(&requirements).unwrap();
@@ -218,6 +243,7 @@ mod tests {
             storage_gb: 200.0,
             gpu_count: None,
             allow_spot: false,
+            tee_required: false,
         };
 
         let provider = selector.select_provider(&requirements).unwrap();
@@ -234,6 +260,7 @@ mod tests {
             storage_gb: 20.0,
             gpu_count: None,
             allow_spot: true,
+            tee_required: false,
         };
 
         let provider = selector.select_provider(&requirements).unwrap();
@@ -250,6 +277,7 @@ mod tests {
             storage_gb: 100.0,
             gpu_count: Some(1),
             allow_spot: false,
+            tee_required: false,
         };
 
         let fallbacks = selector.get_fallback_providers(&requirements);
@@ -258,5 +286,22 @@ mod tests {
         assert!(fallbacks.contains(&CloudProvider::DigitalOcean));
         // Should not include the primary selection (GCP)
         assert!(!fallbacks.contains(&CloudProvider::GCP));
+    }
+
+    #[test]
+    fn test_tee_provider_selection() {
+        let selector = ProviderSelector::with_defaults();
+        let requirements = ResourceSpec {
+            cpu: 2.0,
+            memory_gb: 8.0,
+            storage_gb: 40.0,
+            gpu_count: None,
+            allow_spot: false,
+            tee_required: true,
+        };
+
+        let provider = selector.select_provider(&requirements).unwrap();
+        assert_eq!(provider, CloudProvider::AWS);
+        assert!(provider.supports_tee());
     }
 }

--- a/crates/manager/src/remote/service.rs
+++ b/crates/manager/src/remote/service.rs
@@ -25,6 +25,8 @@ pub struct RemoteDeploymentPolicy {
     pub max_hourly_cost: Option<f32>,
     pub prefer_spot: bool,
     pub auto_terminate_hours: Option<u32>,
+    pub tee_required: bool,
+    pub tee_backend: Option<String>,
 }
 
 impl Default for RemoteDeploymentPolicy {
@@ -34,8 +36,31 @@ impl Default for RemoteDeploymentPolicy {
             max_hourly_cost: Some(5.0),
             prefer_spot: true,
             auto_terminate_hours: Some(24),
+            tee_required: env_bool("BLUEPRINT_REMOTE_TEE_REQUIRED"),
+            tee_backend: std::env::var("TEE_BACKEND")
+                .ok()
+                .and_then(|value| parse_tee_backend(&value)),
         }
     }
+}
+
+fn env_bool(name: &str) -> bool {
+    std::env::var(name)
+        .ok()
+        .map(|value| {
+            matches!(
+                value.trim().to_ascii_lowercase().as_str(),
+                "1" | "true" | "yes"
+            )
+        })
+        .unwrap_or(false)
+}
+
+fn parse_tee_backend(raw: &str) -> Option<String> {
+    raw.split(',').find_map(|entry| {
+        let trimmed = entry.trim();
+        (!trimmed.is_empty()).then(|| trimmed.to_string())
+    })
 }
 
 /// Remote deployment service for Blueprint Manager.
@@ -270,9 +295,16 @@ impl RemoteDeploymentService {
         info!("🚀 Deploying to cloud provider: {:?}", provider);
         info!("   Service: {}", service_name);
         info!(
-            "   Resources: {:.1} CPU, {:.0} GB RAM",
-            resource_spec.cpu, resource_spec.memory_gb
+            "   Resources: {:.1} CPU, {:.0} GB RAM (tee_required={})",
+            resource_spec.cpu, resource_spec.memory_gb, resource_spec.tee_required
         );
+
+        if resource_spec.tee_required && !provider.supports_tee() {
+            return Err(Error::TeePrerequisiteMissing {
+                prerequisite: format!("{provider} confidential-compute support"),
+                hint: "Select AWS, GCP, or Azure when tee_required=true".to_string(),
+            });
+        }
 
         #[cfg(feature = "remote-providers")]
         {
@@ -305,10 +337,11 @@ impl RemoteDeploymentService {
 
             // Provision the actual instance using the remote providers resource spec directly
             let instance = provisioner
-                .provision(
+                .provision_with_requirements(
                     convert_provider(provider),
                     &convert_resource_spec(&resource_spec),
                     &region,
+                    resource_spec.tee_required,
                 )
                 .await
                 .map_err(|e| Error::Other(format!("Failed to provision instance: {}", e)))?;
@@ -331,6 +364,22 @@ impl RemoteDeploymentService {
             let encoded_args = arguments.encode(false);
             for (i, arg) in encoded_args.iter().enumerate() {
                 env_map.insert(format!("ARG_{}", i), arg.clone());
+            }
+
+            if resource_spec.tee_required {
+                let backend = self
+                    .policy
+                    .tee_backend
+                    .clone()
+                    .or_else(|| provider_default_tee_backend(provider).map(str::to_string))
+                    .ok_or_else(|| Error::TeePrerequisiteMissing {
+                        prerequisite: "TEE_BACKEND".to_string(),
+                        hint: format!(
+                            "Set TEE_BACKEND or use a provider with a known default backend. provider={provider}"
+                        ),
+                    })?;
+                env_map.insert("TEE_REQUIRED".to_string(), "true".to_string());
+                env_map.entry("TEE_BACKEND".to_string()).or_insert(backend);
             }
 
             // Deploy blueprint using the adapter's deploy_blueprint_with_target
@@ -547,6 +596,7 @@ impl RemoteDeploymentService {
             storage_gb: (limits.storage_space as f32) / (1024.0 * 1024.0 * 1024.0), // Convert bytes to GB
             gpu_count: limits.gpu_count.map(u32::from), // Use actual GPU count if specified
             allow_spot: self.policy.prefer_spot,
+            tee_required: self.policy.tee_required,
         })
     }
 
@@ -812,7 +862,7 @@ impl RemoteDeploymentService {
 fn convert_resource_spec(
     spec: &ResourceSpec,
 ) -> blueprint_remote_providers::resources::ResourceSpec {
-    // Direct conversion since both structs now have the same flat structure
+    // Remote provider spec does not carry TEE policy; TEE policy is passed separately.
     blueprint_remote_providers::resources::ResourceSpec {
         cpu: spec.cpu,
         memory_gb: spec.memory_gb,
@@ -852,5 +902,14 @@ fn convert_provider(
             // For now mapping to DigitalOcean as placeholder or we should handle it.
             blueprint_remote_providers::CloudProvider::DigitalOcean
         }
+    }
+}
+
+fn provider_default_tee_backend(provider: CloudProvider) -> Option<&'static str> {
+    match provider {
+        CloudProvider::AWS => Some("aws-nitro"),
+        CloudProvider::GCP => Some("gcp-confidential"),
+        CloudProvider::Azure => Some("azure-skr"),
+        _ => None,
     }
 }

--- a/crates/manager/src/sources/container.rs
+++ b/crates/manager/src/sources/container.rs
@@ -70,6 +70,7 @@ impl BlueprintSourceHandler for ContainerSource {
         _id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
+        require_tee: bool,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,
@@ -83,7 +84,7 @@ impl BlueprintSourceHandler for ContainerSource {
             image.to_string_lossy().to_string(),
             env,
             args,
-            false,
+            require_tee,
             false,
         )
         .await

--- a/crates/manager/src/sources/github.rs
+++ b/crates/manager/src/sources/github.rs
@@ -208,6 +208,7 @@ impl BlueprintSourceHandler for GithubBinaryFetcher {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
+        _require_tee: bool,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -30,6 +30,7 @@ pub trait BlueprintSourceHandler: Send + Sync {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
+        require_tee: bool,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/crates/manager/src/sources/remote.rs
+++ b/crates/manager/src/sources/remote.rs
@@ -384,6 +384,7 @@ impl BlueprintSourceHandler for RemoteBinaryFetcher {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
+        _require_tee: bool,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/crates/manager/src/sources/testing.rs
+++ b/crates/manager/src/sources/testing.rs
@@ -146,6 +146,7 @@ impl BlueprintSourceHandler for TestSourceFetcher {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
+        _require_tee: bool,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/docs/operator-remote-deployment-guide.md
+++ b/docs/operator-remote-deployment-guide.md
@@ -142,6 +142,31 @@ cargo tangle blueprint deploy \
     --package my-blueprint
 ```
 
+### 5. Enable TEE-Required Remote Deployments
+
+When you want fail-closed confidential-compute placement, run the manager with:
+
+```bash
+export BLUEPRINT_REMOTE_TEE_REQUIRED=true
+```
+
+Optional backend override (otherwise provider defaults are used):
+
+```bash
+export TEE_BACKEND=aws-nitro
+# or: gcp-confidential
+# or: azure-skr
+```
+
+Operator behavior in this mode:
+- Provider selection is restricted to TEE-capable providers (`AWS`, `GCP`, `Azure`).
+- Non-TEE providers are rejected instead of used as fallback.
+- Deployment injects `TEE_REQUIRED=true` and `TEE_BACKEND` into runtime env vars.
+
+Current verification boundary:
+- This ensures TEE intent and confidential-capable provisioning selection.
+- Full cryptographic attestation proof/verification still requires additional policy tooling.
+
 ## Advanced Configuration
 
 ### Lightweight Manager Mode

--- a/docs/rfcs/RFC-002-cloud-key-tee-autopilot.md
+++ b/docs/rfcs/RFC-002-cloud-key-tee-autopilot.md
@@ -1,0 +1,112 @@
+# RFC-002: Cloud-Key TEE Autopilot for Blueprint Remote Deployments
+
+## Summary
+
+This RFC defines a practical path where operators can run TEE-targeted deployments with cloud credentials and a small manager policy surface, without per-deployment manual provider tuning.
+
+In this phase we focus on:
+- explicit `tee_required` deployment intent in remote manager policy,
+- fail-closed provider selection,
+- confidential-capable instance family selection,
+- deterministic `TEE_BACKEND` injection for runtime bootstrapping.
+
+## Problem
+
+Remote deployment flows currently select providers and instance types by CPU/memory heuristics only. They do not model confidential-compute intent, and selected instance types are not consistently honored by provider adapters.
+
+This makes "cloud API keys are sufficient" unreliable for TEE deployment outcomes.
+
+## Goals
+
+1. Operators can set one manager-level TEE policy (`tee_required=true`) and avoid accidental non-TEE placement.
+2. Manager/provider orchestration only chooses TEE-capable providers when TEE is required.
+3. Provisioning requests use confidential-capable machine families for AWS/GCP/Azure.
+4. Runtime receives explicit TEE backend intent (`TEE_BACKEND`) without manual per-service wiring.
+
+## Non-Goals (This Phase)
+
+- Cryptographic attestation verification at cloud-provisioning boundary.
+- On-chain attestation commitments.
+- Provider-specific evidence policy validation and measurement allowlists.
+
+## Design
+
+### 1) Manager Policy
+
+`RemoteDeploymentPolicy` gets:
+- `tee_required: bool`
+- `tee_backend: Option<String>`
+
+Defaults:
+- `tee_required` from `BLUEPRINT_REMOTE_TEE_REQUIRED`
+- `tee_backend` from `TEE_BACKEND` (first non-empty entry in comma-separated list)
+
+### 2) Fail-Closed Provider Selection
+
+`ProviderSelector` now models `tee_required` in `ResourceSpec` and a `tee_capable` preference list.
+
+When `tee_required=true`, candidate providers are restricted to:
+- AWS
+- GCP
+- Azure
+
+No fallback to non-TEE providers is allowed.
+
+### 3) TEE-Aware Instance Mapping
+
+`blueprint-remote-providers` gains `map_to_instance_type_with_requirements(..., require_tee)`.
+
+For `require_tee=true`, mapper chooses confidential-capable families:
+- AWS: `m6i/c6i/g5` family selection by size class
+- GCP: `n2d-standard-*`
+- Azure: `Standard_DC*as_v5`
+
+### 4) Provisioning API
+
+`CloudProvisioner` adds:
+- `provision_with_requirements(provider, spec, region, require_tee)`
+
+Behavior:
+- rejects non-TEE-capable providers when `require_tee=true`,
+- uses TEE-aware instance mapping,
+- preserves existing `provision(...)` as non-TEE default.
+
+### 5) Adapter Honor-Instance-Type Fix
+
+AWS/GCP/Azure adapters and provisioners are updated so the selected instance type is actually applied during provisioning.
+
+Without this, TEE-aware mapping has no operational effect.
+
+### 6) Runtime Backend Injection
+
+For TEE-required deployments, manager injects:
+- `TEE_REQUIRED=true`
+- `TEE_BACKEND=<policy override or provider default>`
+
+Provider defaults:
+- AWS -> `aws-nitro`
+- GCP -> `gcp-confidential`
+- Azure -> `azure-skr`
+
+## Operator Experience (ELI5)
+
+1. Export cloud credentials for one TEE-capable provider (AWS/GCP/Azure).
+2. Set `BLUEPRINT_REMOTE_TEE_REQUIRED=true` on manager.
+3. Optionally set `TEE_BACKEND` globally.
+4. Deploy normally.
+
+Manager will fail instead of silently picking non-TEE providers.
+
+## Remaining Gaps
+
+To make "cloud keys are fully sufficient" a complete security claim, we still need:
+- cryptographic attestation verification in-manager,
+- policy engine for expected measurements/signers,
+- attestation proof recording (on-chain or verifiable audit log),
+- operator preflight checks that verify provider prerequisites before deployment.
+
+## Rollout
+
+- Land changes behind existing remote-provider flow (no protocol-specific branching).
+- Keep defaults backward-compatible (`tee_required=false`).
+- Add operator documentation and test coverage for TEE provider/instance selection.


### PR DESCRIPTION
## Summary
- close the Tangle manager TEE intent gap by plumbing `tee_required` from on-chain metadata to source spawn and container launch
- enforce fail-closed source selection when TEE is required (no native/testing fallback)
- add remote deployment TEE policy (`tee_required` + optional `tee_backend`) and restrict selection to TEE-capable providers
- add TEE-aware instance mapping/provisioning path in `blueprint-remote-providers`
- ensure AWS/GCP/Azure adapters honor selected instance types so confidential-capable SKUs are actually requested
- add RFC draft and operator docs for cloud-key TEE autopilot behavior

## Implementation Details
- Tangle metadata parsing now supports `tee_required`, `teeRequired`, and runtime profile mode hints
- `BlueprintSourceHandler::spawn(..., require_tee)` is now honored by all source handlers; container source forwards it to runtime launch
- remote provider selection gains a `tee_capable` preference set and `tee_required` in resource requirements
- `CloudProvisioner::provision_with_requirements(..., require_tee)` performs provider gating + TEE-aware instance selection
- default backend inference for remote policy:
  - AWS -> `aws-nitro`
  - GCP -> `gcp-confidential`
  - Azure -> `azure-skr`

## Verification
- `cargo test -p blueprint-remote-providers mapper::tests::test_tee_mapping_prefers_confidential_families -- --nocapture`
- `cargo test -p blueprint-manager remote::integration_test --features remote-providers -- --nocapture`
- `cargo check -p blueprint-manager --all-features`
- `cargo test -p blueprint-manager parse_tee_required -- --nocapture`

## Docs
- added `docs/rfcs/RFC-002-cloud-key-tee-autopilot.md`
- updated `docs/operator-remote-deployment-guide.md` with TEE-required remote deployment configuration