### PR TITLE
feat(manager): consolidate remote TEE follow-up hardening

### DIFF
--- a/crates/blueprint-remote-providers/src/infra/provisioner.rs
+++ b/crates/blueprint-remote-providers/src/infra/provisioner.rs
@@ -196,9 +196,20 @@ impl CloudProvisioner {
                     tokio::time::sleep(blueprint_std::time::Duration::from_secs(5)).await;
                     retries += 1;
                 }
-                Err(_) => {
-                    // Instance not found - considered terminated
-                    return Ok(());
+                Err(e) => {
+                    if is_not_found_error(&e) {
+                        info!(
+                            "Instance {} no longer found after termination request",
+                            instance_id
+                        );
+                        return Ok(());
+                    }
+                    warn!(
+                        "Failed to verify termination status for {}: {}",
+                        instance_id, e
+                    );
+                    tokio::time::sleep(blueprint_std::time::Duration::from_secs(5)).await;
+                    retries += 1;
                 }
             }
         }
@@ -249,33 +260,26 @@ impl CloudProvisioner {
         resource_spec: &ResourceSpec,
         env_vars: std::collections::HashMap<String, String>,
     ) -> Result<crate::infra::traits::BlueprintDeploymentResult> {
-        use crate::core::deployment_target::DeploymentTarget;
+        let provider = self.resolve_single_provider()?;
+        self.deploy_with_target_for_provider(
+            provider,
+            target,
+            blueprint_image,
+            resource_spec,
+            env_vars,
+        )
+        .await
+    }
 
-        // Determine provider based on target
-        let provider = match target {
-            DeploymentTarget::GenericKubernetes { .. } => {
-                // For generic K8s, we need a provider that supports kubectl
-                // Use the first available provider that has K8s support
-                self.providers.keys().next().ok_or_else(|| {
-                    Error::Other("No providers configured for Kubernetes deployment".into())
-                })?
-            }
-            DeploymentTarget::ManagedKubernetes { .. } => {
-                // For managed K8s, determine provider from cluster context
-                // Use first available provider for managed K8s
-                self.providers.keys().next().ok_or_else(|| {
-                    Error::Other("No providers configured for managed Kubernetes".into())
-                })?
-            }
-            _ => {
-                // For other targets, use first available provider
-                self.providers
-                    .keys()
-                    .next()
-                    .ok_or_else(|| Error::Other("No providers configured".into()))?
-            }
-        };
-
+    /// Deploy a Blueprint to a specific provider with a specific target.
+    pub async fn deploy_with_target_for_provider(
+        &self,
+        provider: &CloudProvider,
+        target: &crate::core::deployment_target::DeploymentTarget,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: std::collections::HashMap<String, String>,
+    ) -> Result<crate::infra::traits::BlueprintDeploymentResult> {
         let adapter = self
             .providers
             .get(provider)
@@ -284,6 +288,19 @@ impl CloudProvisioner {
         adapter
             .deploy_blueprint_with_target(target, blueprint_image, resource_spec, env_vars)
             .await
+    }
+
+    fn resolve_single_provider(&self) -> Result<&CloudProvider> {
+        let mut providers = self.providers.keys();
+        let provider = providers
+            .next()
+            .ok_or_else(|| Error::Other("No providers configured".into()))?;
+        if providers.next().is_some() {
+            return Err(Error::ConfigurationError(
+                "Multiple providers configured; select one explicitly".into(),
+            ));
+        }
+        Ok(provider)
     }
 
     /// Get the status of an instance using the appropriate adapter (alias for compatibility)
@@ -354,6 +371,23 @@ impl CloudProvisioner {
         let instance_selection = InstanceTypeMapper::map_to_instance_type(resource_spec, provider);
         Ok(instance_selection.instance_type)
     }
+}
+
+fn is_not_found_error(error: &Error) -> bool {
+    let message = match error {
+        Error::ConfigurationError(message)
+        | Error::NetworkError(message)
+        | Error::SerializationError(message)
+        | Error::HttpError(message)
+        | Error::Other(message) => message.as_str(),
+        #[cfg(feature = "kubernetes")]
+        Error::Kube(err) => return err.to_string().contains("NotFound"),
+        _ => return false,
+    };
+
+    message.contains("404")
+        || message.to_ascii_lowercase().contains("not found")
+        || message.to_ascii_lowercase().contains("does not exist")
 }
 
 #[cfg(test)]

--- a/crates/blueprint-remote-providers/src/providers/aws/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/aws/adapter.rs
@@ -213,6 +213,24 @@ impl CloudProviderAdapter for AwsAdapter {
             )),
         }
     }
+
+    async fn deploy_blueprint(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
+        use crate::shared::{SharedSshDeployment, SshDeploymentConfig};
+        SharedSshDeployment::deploy_to_instance(
+            instance,
+            blueprint_image,
+            resource_spec,
+            env_vars,
+            SshDeploymentConfig::aws(),
+        )
+        .await
+    }
 }
 
 impl AwsAdapter {
@@ -223,20 +241,10 @@ impl AwsAdapter {
         resource_spec: &ResourceSpec,
         env_vars: HashMap<String, String>,
     ) -> Result<BlueprintDeploymentResult> {
-        use crate::shared::{SharedSshDeployment, SshDeploymentConfig};
-
         // Get or provision EC2 instance
         let instance = self.provision_instance("t3.medium", "us-east-1").await?;
-
-        // Use shared SSH deployment with AWS configuration
-        SharedSshDeployment::deploy_to_instance(
-            &instance,
-            blueprint_image,
-            resource_spec,
-            env_vars,
-            SshDeploymentConfig::aws(),
-        )
-        .await
+        self.deploy_blueprint(&instance, blueprint_image, resource_spec, env_vars)
+            .await
     }
 
     /// Deploy to AWS EKS cluster

--- a/crates/blueprint-remote-providers/src/providers/azure/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/azure/adapter.rs
@@ -208,6 +208,17 @@ impl CloudProviderAdapter for AzureAdapter {
         }
     }
 
+    async fn deploy_blueprint(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
+        self.deploy_to_existing_vm(instance, blueprint_image, resource_spec, env_vars)
+            .await
+    }
+
     async fn health_check_blueprint(&self, deployment: &BlueprintDeploymentResult) -> Result<bool> {
         if let Some(endpoint) = deployment.qos_grpc_endpoint() {
             let client = reqwest::Client::builder()
@@ -255,6 +266,17 @@ impl AzureAdapter {
         env_vars: HashMap<String, String>,
     ) -> Result<BlueprintDeploymentResult> {
         let instance = self.provision_instance("Standard_B2ms", "eastus").await?;
+        self.deploy_to_existing_vm(&instance, blueprint_image, resource_spec, env_vars)
+            .await
+    }
+
+    async fn deploy_to_existing_vm(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
         let public_ip = instance
             .public_ip
             .as_ref()

--- a/crates/blueprint-remote-providers/src/providers/digitalocean/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/digitalocean/adapter.rs
@@ -157,6 +157,24 @@ impl CloudProviderAdapter for DigitalOceanAdapter {
         }
     }
 
+    async fn deploy_blueprint(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
+        use crate::shared::{SharedSshDeployment, SshDeploymentConfig};
+        SharedSshDeployment::deploy_to_instance(
+            instance,
+            blueprint_image,
+            resource_spec,
+            env_vars,
+            SshDeploymentConfig::digitalocean(),
+        )
+        .await
+    }
+
     async fn health_check_blueprint(&self, deployment: &BlueprintDeploymentResult) -> Result<bool> {
         use crate::security::{ApiAuthentication, SecureHttpClient};
 
@@ -192,19 +210,9 @@ impl DigitalOceanAdapter {
         resource_spec: &ResourceSpec,
         env_vars: HashMap<String, String>,
     ) -> Result<BlueprintDeploymentResult> {
-        use crate::shared::{SharedSshDeployment, SshDeploymentConfig};
-
         let instance = self.provision_instance("s-2vcpu-4gb", "nyc3").await?;
-
-        // Use shared SSH deployment with DigitalOcean configuration
-        SharedSshDeployment::deploy_to_instance(
-            &instance,
-            blueprint_image,
-            resource_spec,
-            env_vars,
-            SshDeploymentConfig::digitalocean(),
-        )
-        .await
+        self.deploy_blueprint(&instance, blueprint_image, resource_spec, env_vars)
+            .await
     }
 
     /// Deploy to DOKS cluster

--- a/crates/blueprint-remote-providers/src/providers/gcp/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/gcp/adapter.rs
@@ -314,6 +314,24 @@ impl CloudProviderAdapter for GcpAdapter {
         }
     }
 
+    async fn deploy_blueprint(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
+        use crate::shared::{SharedSshDeployment, SshDeploymentConfig};
+        SharedSshDeployment::deploy_to_instance(
+            instance,
+            blueprint_image,
+            resource_spec,
+            env_vars,
+            SshDeploymentConfig::gcp(&self.project_id),
+        )
+        .await
+    }
+
     async fn health_check_blueprint(&self, deployment: &BlueprintDeploymentResult) -> Result<bool> {
         if let Some(endpoint) = deployment.qos_grpc_endpoint() {
             match reqwest::get(&format!("{endpoint}/health")).await {
@@ -369,19 +387,9 @@ impl GcpAdapter {
         resource_spec: &ResourceSpec,
         env_vars: HashMap<String, String>,
     ) -> Result<BlueprintDeploymentResult> {
-        use crate::shared::{SharedSshDeployment, SshDeploymentConfig};
-
         let instance = self.provision_instance("e2-medium", "us-central1").await?;
-
-        // Use shared SSH deployment with GCP configuration
-        SharedSshDeployment::deploy_to_instance(
-            &instance,
-            blueprint_image,
-            resource_spec,
-            env_vars,
-            SshDeploymentConfig::gcp(&self.project_id),
-        )
-        .await
+        self.deploy_blueprint(&instance, blueprint_image, resource_spec, env_vars)
+            .await
     }
 
     /// Deploy to GKE cluster

--- a/crates/blueprint-remote-providers/src/providers/gcp/mod.rs
+++ b/crates/blueprint-remote-providers/src/providers/gcp/mod.rs
@@ -221,10 +221,14 @@ impl GcpProvisioner {
         let mut metadata = HashMap::new();
         metadata.insert("zone".to_string(), zone.clone());
         metadata.insert("project_id".to_string(), self.project_id.clone());
+        metadata.insert("instance_name".to_string(), config.name.clone());
+        if let Some(numeric_id) = instance["id"].as_str() {
+            metadata.insert("instance_numeric_id".to_string(), numeric_id.to_string());
+        }
 
         Ok(ProvisionedInfrastructure {
             provider: CloudProvider::GCP,
-            instance_id: instance["id"].as_str().unwrap_or("").to_string(),
+            instance_id: config.name.clone(),
             public_ip,
             private_ip,
             region: config.region.clone(),

--- a/crates/blueprint-remote-providers/src/providers/vultr/adapter.rs
+++ b/crates/blueprint-remote-providers/src/providers/vultr/adapter.rs
@@ -154,6 +154,17 @@ impl CloudProviderAdapter for VultrAdapter {
         }
     }
 
+    async fn deploy_blueprint(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
+        self.deploy_to_existing_instance(instance, blueprint_image, resource_spec, env_vars)
+            .await
+    }
+
     async fn health_check_blueprint(&self, deployment: &BlueprintDeploymentResult) -> Result<bool> {
         if let Some(endpoint) = deployment.qos_grpc_endpoint() {
             let client = reqwest::Client::builder()
@@ -201,6 +212,17 @@ impl VultrAdapter {
         env_vars: HashMap<String, String>,
     ) -> Result<BlueprintDeploymentResult> {
         let instance = self.provision_instance("vc2-2c-4gb", "ewr").await?;
+        self.deploy_to_existing_instance(&instance, blueprint_image, resource_spec, env_vars)
+            .await
+    }
+
+    async fn deploy_to_existing_instance(
+        &self,
+        instance: &ProvisionedInstance,
+        blueprint_image: &str,
+        resource_spec: &ResourceSpec,
+        env_vars: HashMap<String, String>,
+    ) -> Result<BlueprintDeploymentResult> {
         let public_ip = instance
             .public_ip
             .as_ref()

--- a/crates/manager/src/executor/remote_provider_integration.rs
+++ b/crates/manager/src/executor/remote_provider_integration.rs
@@ -3,7 +3,7 @@
 //! Handles automatic cloud deployment when services are initiated
 
 use crate::config::BlueprintManagerContext;
-use crate::error::Result;
+use crate::error::{Error, Result};
 use blueprint_core::{error, info};
 use blueprint_remote_providers::deployment::manager_integration::{
     RemoteDeploymentRegistry, TtlManager,
@@ -44,8 +44,11 @@ impl RemoteProviderManager {
     /// Initialize from Blueprint Manager config
     pub async fn new(ctx: &BlueprintManagerContext) -> Result<Option<Self>> {
         // Check if remote providers are configured
-        let cloud_config = ctx.cloud_config();
-        if cloud_config.is_none() || !cloud_config.as_ref().unwrap().enabled {
+        if !ctx
+            .cloud_config()
+            .as_ref()
+            .is_some_and(|config| config.enabled)
+        {
             info!("Remote cloud providers not configured");
             return Ok(None);
         }
@@ -118,30 +121,22 @@ impl RemoteProviderManager {
         };
 
         if tee_required && !supports_tee(&provider) {
-            error!(
-                "TEE is required but selected provider {} does not support confidential compute",
-                provider
-            );
-            return Ok(());
+            return Err(Error::TeePrerequisiteMissing {
+                prerequisite: format!("{provider} confidential-compute support"),
+                hint: "Select AWS, GCP, or Azure when BLUEPRINT_REMOTE_TEE_REQUIRED=true"
+                    .to_string(),
+            });
         }
 
-        match self
+        let instance = self
             .provisioner
             .provision_with_requirements(provider.clone(), &resource_spec, region, tee_required)
-            .await
-        {
-            Ok(instance) => {
-                info!("Service deployed to {}: instance={}", provider, instance.id);
+            .await?;
 
-                // Register with TTL manager for automatic cleanup
-                self.ttl_manager
-                    .register_ttl(blueprint_id, service_id, 3600)
-                    .await; // 1 hour default
-            }
-            Err(e) => {
-                error!("Failed to deploy service: {}", e);
-            }
-        }
+        info!("Service deployed to {}: instance={}", provider, instance.id);
+        self.ttl_manager
+            .register_ttl(blueprint_id, service_id, 3600)
+            .await; // 1 hour default
 
         Ok(())
     }

--- a/crates/manager/src/remote/service.rs
+++ b/crates/manager/src/remote/service.rs
@@ -63,6 +63,27 @@ fn parse_tee_backend(raw: &str) -> Option<String> {
     })
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum TeeAttestationPolicy {
+    Structural,
+    Cryptographic,
+}
+
+impl TeeAttestationPolicy {
+    fn from_env() -> Self {
+        let raw = std::env::var("BLUEPRINT_REMOTE_TEE_ATTESTATION_POLICY")
+            .unwrap_or_else(|_| "structural".to_string());
+        parse_tee_attestation_policy(&raw)
+    }
+}
+
+fn parse_tee_attestation_policy(raw: &str) -> TeeAttestationPolicy {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "cryptographic" => TeeAttestationPolicy::Cryptographic,
+        _ => TeeAttestationPolicy::Structural,
+    }
+}
+
 /// Remote deployment service for Blueprint Manager.
 pub struct RemoteDeploymentService {
     /// Provider selection logic
@@ -306,13 +327,21 @@ impl RemoteDeploymentService {
             });
         }
 
+        if resource_spec.tee_required
+            && matches!(
+                TeeAttestationPolicy::from_env(),
+                TeeAttestationPolicy::Cryptographic
+            )
+        {
+            return Err(Error::TeeRuntimeUnavailable {
+                reason: "Cryptographic attestation policy requested, but current built-in provider verifiers are structural-only. Set BLUEPRINT_REMOTE_TEE_ATTESTATION_POLICY=structural or use an external cryptographic attestation verification pipeline.".to_string(),
+            });
+        }
+
         #[cfg(feature = "remote-providers")]
         {
             // Use real cloud provider SDK
             use blueprint_remote_providers::CloudProvisioner;
-            use blueprint_remote_providers::core::deployment_target::{
-                ContainerRuntime, DeploymentTarget,
-            };
 
             let provisioner = CloudProvisioner::new()
                 .await
@@ -329,11 +358,6 @@ impl RemoteDeploymentService {
             };
 
             info!("   Region: {}", region);
-
-            // Create deployment target for VM with Docker
-            let target = DeploymentTarget::VirtualMachine {
-                runtime: ContainerRuntime::Docker,
-            };
 
             // Provision the actual instance using the remote providers resource spec directly
             let instance = provisioner
@@ -382,11 +406,11 @@ impl RemoteDeploymentService {
                 env_map.entry("TEE_BACKEND".to_string()).or_insert(backend);
             }
 
-            // Deploy blueprint using the adapter's deploy_blueprint_with_target
-            // This will handle SSH deployment, Docker setup, and QoS port exposure
+            // Deploy to the provisioned instance. This must not provision a second VM.
             let deployment_result = provisioner
-                .deploy_with_target(
-                    &target,
+                .deploy_blueprint_to_instance(
+                    &convert_provider(provider),
+                    &instance,
                     &blueprint_image,
                     &convert_resource_spec(&resource_spec),
                     env_map,
@@ -410,13 +434,13 @@ impl RemoteDeploymentService {
                         if let Some(ref qos_provider) = self.qos_provider {
                             qos_provider
                                 .register_remote_instance(
-                                    instance.id.clone(),
+                                    deployment_result.instance.id.clone(),
                                     host.to_string(),
                                     port,
                                 )
                                 .await;
                             info!("✅ QoS endpoint registered: {}:{}", host, port);
-                            info!("   Instance: {}", instance.id);
+                            info!("   Instance: {}", deployment_result.instance.id);
                             info!("   Blueprint metrics will be collected from port {}", port);
                         }
 
@@ -433,7 +457,7 @@ impl RemoteDeploymentService {
 
             // Register deployment
             let deployment_info = RemoteDeploymentInfo {
-                instance_id: instance.id.clone(),
+                instance_id: deployment_result.instance.id.clone(),
                 provider,
                 service_name: service_name.to_string(),
                 blueprint_id,
@@ -442,12 +466,15 @@ impl RemoteDeploymentService {
                     .policy
                     .auto_terminate_hours
                     .map(|hours| chrono::Utc::now() + chrono::Duration::hours(hours as i64)),
-                public_ip: instance.public_ip.clone(),
+                public_ip: deployment_result.instance.public_ip.clone(),
             };
 
             {
                 let mut deployments = self.deployments.write().await;
-                deployments.insert(instance.id.clone(), deployment_info.clone());
+                deployments.insert(
+                    deployment_result.instance.id.clone(),
+                    deployment_info.clone(),
+                );
             }
 
             info!("✅ Deployment registered with TTL tracking");
@@ -524,17 +551,31 @@ impl RemoteDeploymentService {
                 env_map.insert(format!("ARG_{}", i), arg.clone());
             }
 
-            // Deploy to Kubernetes using generic adapter
-            // Note: This will use kubectl to deploy to any K8s cluster
-            let deployment_result = provisioner
-                .deploy_with_target(
-                    &target,
-                    &blueprint_image,
-                    &convert_resource_spec(&resource_spec),
-                    env_map,
-                )
-                .await
-                .map_err(|e| Error::Other(format!("Failed to deploy to Kubernetes: {}", e)))?;
+            // Deploy to Kubernetes using either an inferred provider or a single configured provider.
+            let deployment_result = if let Some(provider) =
+                infer_remote_provider_from_context(context)
+            {
+                provisioner
+                    .deploy_with_target_for_provider(
+                        &provider,
+                        &target,
+                        &blueprint_image,
+                        &convert_resource_spec(&resource_spec),
+                        env_map,
+                    )
+                    .await
+                    .map_err(|e| Error::Other(format!("Failed to deploy to Kubernetes: {}", e)))?
+            } else {
+                provisioner
+                    .deploy_with_target(
+                        &target,
+                        &blueprint_image,
+                        &convert_resource_spec(&resource_spec),
+                        env_map,
+                    )
+                    .await
+                    .map_err(|e| Error::Other(format!("Failed to deploy to Kubernetes: {}", e)))?
+            };
 
             info!(
                 "✅ Blueprint deployed to Kubernetes: {}",
@@ -911,5 +952,49 @@ fn provider_default_tee_backend(provider: CloudProvider) -> Option<&'static str>
         CloudProvider::GCP => Some("gcp-confidential"),
         CloudProvider::Azure => Some("azure-skr"),
         _ => None,
+    }
+}
+
+#[cfg(feature = "remote-providers")]
+fn infer_remote_provider_from_context(
+    context: &str,
+) -> Option<blueprint_remote_providers::CloudProvider> {
+    let context = context.to_ascii_lowercase();
+    if context.contains("aws") || context.contains("eks") {
+        return Some(blueprint_remote_providers::CloudProvider::AWS);
+    }
+    if context.contains("gcp") || context.contains("gke") || context.contains("google") {
+        return Some(blueprint_remote_providers::CloudProvider::GCP);
+    }
+    if context.contains("azure") || context.contains("aks") {
+        return Some(blueprint_remote_providers::CloudProvider::Azure);
+    }
+    if context.contains("digitalocean") || context.contains("doks") {
+        return Some(blueprint_remote_providers::CloudProvider::DigitalOcean);
+    }
+    if context.contains("vultr") || context.contains("vke") {
+        return Some(blueprint_remote_providers::CloudProvider::Vultr);
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{TeeAttestationPolicy, parse_tee_attestation_policy};
+
+    #[test]
+    fn parses_attestation_policy_modes() {
+        assert_eq!(
+            parse_tee_attestation_policy("cryptographic"),
+            TeeAttestationPolicy::Cryptographic
+        );
+        assert_eq!(
+            parse_tee_attestation_policy("STRUCTURAL"),
+            TeeAttestationPolicy::Structural
+        );
+        assert_eq!(
+            parse_tee_attestation_policy("unexpected"),
+            TeeAttestationPolicy::Structural
+        );
     }
 }

--- a/crates/manager/src/sources/github.rs
+++ b/crates/manager/src/sources/github.rs
@@ -1,4 +1,4 @@
-use super::{BlueprintArgs, BlueprintEnvVars, BlueprintSourceHandler};
+use super::{BlueprintArgs, BlueprintEnvVars, BlueprintSourceHandler, unpack_archive_safely};
 use crate::blueprint::native::get_blueprint_binary;
 use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
@@ -170,8 +170,7 @@ impl BlueprintSourceHandler for GithubBinaryFetcher {
         let tar_xz = File::open(&archive_path)?;
         let tar = XzDecoder::new(tar_xz);
         let mut archive = Archive::new(tar);
-
-        archive.unpack(cache_dir)?;
+        unpack_archive_safely(&mut archive, cache_dir)?;
 
         // sanity check that the binary actually there
         let mut binary_path = None;

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -1,9 +1,11 @@
 use crate::blueprint::native::FilteredBlueprint;
 use crate::config::{BlueprintManagerConfig, BlueprintManagerContext};
+use crate::error::{Error, Result};
 use crate::rt::ResourceLimits;
 use crate::rt::service::Service;
 use alloy_primitives::Address;
 use blueprint_runner::config::{BlueprintEnvironment, Protocol, SupportedChains};
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use url::Url;
 
@@ -13,6 +15,50 @@ pub mod github;
 pub mod remote;
 pub mod testing;
 pub mod types;
+
+fn is_safe_archive_path(path: &Path) -> bool {
+    use std::path::Component;
+    !path.is_absolute()
+        && path.components().all(|component| {
+            !matches!(
+                component,
+                Component::ParentDir | Component::RootDir | Component::Prefix(_)
+            )
+        })
+}
+
+pub(crate) fn unpack_archive_safely<R: Read>(
+    archive: &mut tar::Archive<R>,
+    destination: &Path,
+) -> Result<()> {
+    for entry in archive.entries()? {
+        let mut entry = entry?;
+        let entry_path = entry.path()?.into_owned();
+        if !is_safe_archive_path(&entry_path) {
+            return Err(Error::Other(format!(
+                "Unsafe archive entry path rejected: {}",
+                entry_path.display()
+            )));
+        }
+
+        let entry_type = entry.header().entry_type();
+        if entry_type.is_symlink() || entry_type.is_hard_link() {
+            return Err(Error::Other(format!(
+                "Archive entry type not allowed for security reasons: {}",
+                entry_path.display()
+            )));
+        }
+
+        if !entry.unpack_in(destination)? {
+            return Err(Error::Other(format!(
+                "Archive entry escaped destination: {}",
+                entry_path.display()
+            )));
+        }
+    }
+
+    Ok(())
+}
 
 #[auto_impl::auto_impl(Box)]
 #[dynosaur::dynosaur(pub(crate) DynBlueprintSource)]
@@ -268,5 +314,18 @@ impl BlueprintEnvVars {
         }
 
         env_vars
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::is_safe_archive_path;
+    use std::path::Path;
+
+    #[test]
+    fn archive_path_guard_rejects_traversal_and_absolute_paths() {
+        assert!(is_safe_archive_path(Path::new("bin/blueprint")));
+        assert!(!is_safe_archive_path(Path::new("../etc/passwd")));
+        assert!(!is_safe_archive_path(Path::new("/tmp/evil")));
     }
 }

--- a/crates/manager/src/sources/remote.rs
+++ b/crates/manager/src/sources/remote.rs
@@ -1,4 +1,4 @@
-use super::{BlueprintArgs, BlueprintEnvVars, BlueprintSourceHandler};
+use super::{BlueprintArgs, BlueprintEnvVars, BlueprintSourceHandler, unpack_archive_safely};
 use crate::blueprint::native::get_blueprint_binary;
 use crate::config::BlueprintManagerContext;
 use crate::error::{Error, Result};
@@ -284,7 +284,7 @@ impl RemoteBinaryFetcher {
         let tar_xz = File::open(&archive_path)?;
         let tar = XzDecoder::new(tar_xz);
         let mut archive = Archive::new(tar);
-        archive.unpack(cache_dir)?;
+        unpack_archive_safely(&mut archive, cache_dir)?;
 
         let mut binary_path = None;
         for entry in walkdir::WalkDir::new(cache_dir) {


### PR DESCRIPTION
## Summary
- harden source extraction by adding safe tar unpack guards and using them for GitHub/remote source handlers
- make remote provider integration fail closed for TEE-required paths and propagate provisioning errors
- remove double-provision risk in remote cloud deployment by deploying to the explicitly provisioned instance
- add explicit provider-target deployment API to the cloud provisioner and use provider inference for kubernetes contexts
- improve provider adapter behavior for deploy-to-existing-instance, tighten termination verification, and align GCP instance identity handling
- add configurable TEE attestation policy gate with default structural mode and fail-closed cryptographic placeholder

## Validation
- cargo fmt --all
- cargo check -p blueprint-remote-providers --all-features
- cargo check -p blueprint-manager --all-features
- cargo test -p blueprint-manager --all-features archive_path_guard_rejects_traversal_and_absolute_paths -- --nocapture
- cargo test -p blueprint-manager --all-features parses_attestation_policy_modes -- --nocapture
- repository pre-push hook (format + blueprint-remote-providers tests + blueprint-manager tests + audit)
