### PR TITLE
fix(tee): recover pending metadata and source-plumbing refactors

### DIFF
--- a/cli/src/command/deploy/definition.rs
+++ b/cli/src/command/deploy/definition.rs
@@ -3,7 +3,7 @@ use alloy_json_abi::Param;
 use alloy_primitives::{Address, Bytes, FixedBytes, U256};
 use alloy_sol_types::{SolType, SolValue};
 use blueprint_client_tangle::contracts::ITangleTypes;
-use blueprint_client_tangle::{TeeDeploymentProfile, inject_tee_deployment_profile};
+use blueprint_client_tangle::{ExecutionProfile, inject_execution_profile};
 use color_eyre::eyre::{Context, Result, eyre};
 use serde::{Deserialize, Serialize};
 use serde_json;
@@ -358,7 +358,7 @@ struct MetadataSpec {
     #[serde(default)]
     profiling_data: String,
     #[serde(default)]
-    deployment_profile: Option<DeploymentProfileSpec>,
+    execution_profile: Option<ExecutionProfileSpec>,
 }
 
 impl Default for MetadataSpec {
@@ -373,19 +373,19 @@ impl Default for MetadataSpec {
             website: default_website(),
             license: default_license(),
             profiling_data: String::new(),
-            deployment_profile: None,
+            execution_profile: None,
         }
     }
 }
 
 impl MetadataSpec {
     fn into_metadata(self) -> BlueprintMetadata {
-        let deployment_profile = self
-            .deployment_profile
+        let execution_profile = self
+            .execution_profile
             .as_ref()
-            .map(DeploymentProfileSpec::to_profile);
-        let profiling_data = deployment_profile
-            .map(|profile| inject_tee_deployment_profile(&self.profiling_data, profile))
+            .map(ExecutionProfileSpec::to_profile);
+        let profiling_data = execution_profile
+            .map(|profile| inject_execution_profile(&self.profiling_data, profile))
             .unwrap_or(self.profiling_data);
 
         BlueprintMetadata {
@@ -403,18 +403,15 @@ impl MetadataSpec {
 }
 
 #[derive(Debug, Deserialize, Clone)]
-struct DeploymentProfileSpec {
+struct ExecutionProfileSpec {
     #[serde(default)]
-    tee_required: bool,
-    #[serde(default)]
-    supports_tee: bool,
+    confidentiality: blueprint_client_tangle::ConfidentialityPolicy,
 }
 
-impl DeploymentProfileSpec {
-    fn to_profile(&self) -> TeeDeploymentProfile {
-        TeeDeploymentProfile {
-            tee_required: self.tee_required,
-            supports_tee: self.supports_tee || self.tee_required,
+impl ExecutionProfileSpec {
+    fn to_profile(&self) -> ExecutionProfile {
+        ExecutionProfile {
+            confidentiality: self.confidentiality,
         }
     }
 }
@@ -1488,7 +1485,7 @@ mod tests {
     }
 
     #[test]
-    fn metadata_tee_required_injects_structured_profiling_data() {
+    fn metadata_execution_profile_injects_structured_profiling_data() {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("definition.json");
         let manifest = serde_json::json!({
@@ -1496,8 +1493,8 @@ mod tests {
             "manager": "0x0000000000000000000000000000000000000001",
             "metadata": {
                 "name": "TEE Blueprint",
-                "deployment_profile": {
-                    "tee_required": true
+                "execution_profile": {
+                    "confidentiality": "tee_required"
                 }
             },
             "jobs": [
@@ -1527,29 +1524,22 @@ mod tests {
         let metadata_json: serde_json::Value = serde_json::from_str(&metadata_payload).unwrap();
         assert_eq!(
             metadata_json
-                .get("deployment_profile")
-                .and_then(|v| v.get("tee_required"))
-                .and_then(serde_json::Value::as_bool),
-            Some(true)
-        );
-        assert_eq!(
-            metadata_json
-                .get("deployment_profile")
-                .and_then(|v| v.get("supports_tee"))
-                .and_then(serde_json::Value::as_bool),
-            Some(true)
+                .get("execution_profile")
+                .and_then(|v| v.get("confidentiality"))
+                .and_then(serde_json::Value::as_str),
+            Some("tee_required")
         );
     }
 
     #[test]
-    fn metadata_deployment_profile_supports_tee_only_is_optional() {
+    fn metadata_execution_profile_accepts_standard_required() {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("definition.json");
         let manifest = serde_json::json!({
             "metadata_uri": "ipfs://cid",
             "manager": "0x0000000000000000000000000000000000000001",
             "metadata": {
-                "deployment_profile": { "supports_tee": true }
+                "execution_profile": { "confidentiality": "standard_required" }
             },
             "jobs": [
                 { "name": "square" }
@@ -1578,22 +1568,15 @@ mod tests {
         let metadata_json: serde_json::Value = serde_json::from_str(&metadata_payload).unwrap();
         assert_eq!(
             metadata_json
-                .get("deployment_profile")
-                .and_then(|v| v.get("tee_required"))
-                .and_then(serde_json::Value::as_bool),
-            Some(false)
-        );
-        assert_eq!(
-            metadata_json
-                .get("deployment_profile")
-                .and_then(|v| v.get("supports_tee"))
-                .and_then(serde_json::Value::as_bool),
-            Some(true)
+                .get("execution_profile")
+                .and_then(|v| v.get("confidentiality"))
+                .and_then(serde_json::Value::as_str),
+            Some("standard_required")
         );
     }
 
     #[test]
-    fn metadata_tee_required_wraps_legacy_profiling_blob() {
+    fn metadata_execution_profile_wraps_legacy_profiling_blob() {
         let temp_dir = tempfile::tempdir().unwrap();
         let path = temp_dir.path().join("definition.json");
         let legacy_blob = "H4sIAAAAAAAA/2NgYGBgBGIOAwA6rY+4BQAAAA==";
@@ -1602,8 +1585,8 @@ mod tests {
             "manager": "0x0000000000000000000000000000000000000001",
             "metadata": {
                 "profiling_data": legacy_blob,
-                "deployment_profile": {
-                    "tee_required": true
+                "execution_profile": {
+                    "confidentiality": "tee_required"
                 }
             },
             "jobs": [

--- a/cli/src/command/list/blueprints.rs
+++ b/cli/src/command/list/blueprints.rs
@@ -1,6 +1,6 @@
 use blueprint_client_tangle::TangleClient;
-use blueprint_client_tangle::resolve_tee_deployment_profile;
 use blueprint_client_tangle::services::BlueprintInfo;
+use blueprint_client_tangle::{ConfidentialityPolicy, resolve_execution_profile};
 use color_eyre::Result;
 use color_eyre::eyre::WrapErr;
 use dialoguer::console::style;
@@ -14,12 +14,10 @@ pub struct BlueprintListEntry {
     pub blueprint_id: u64,
     /// Basic blueprint info from listing endpoint.
     pub info: BlueprintInfo,
-    /// Whether TEE placement is mandatory.
-    pub tee_required: Option<bool>,
-    /// Whether blueprint supports TEE placement.
-    pub tee_supported: Option<bool>,
+    /// Optional confidentiality execution policy declared by the blueprint.
+    pub confidentiality_policy: Option<ConfidentialityPolicy>,
     /// Metadata parsing/fetching issue, if any.
-    pub tee_metadata_error: Option<String>,
+    pub execution_metadata_error: Option<String>,
 }
 
 /// Fetch all registered blueprints.
@@ -31,29 +29,20 @@ pub async fn list_blueprints(client: &TangleClient) -> Result<Vec<BlueprintListE
 
     let mut entries = stream::iter(blueprints)
         .map(|(blueprint_id, info)| async move {
-            let (tee_required, tee_supported, tee_metadata_error) =
+            let (confidentiality_policy, execution_metadata_error) =
                 match client.get_blueprint_definition(blueprint_id).await {
-                    Ok(definition) => match resolve_tee_deployment_profile(&definition.metadata) {
-                        Ok(profile) => (
-                            profile.map(|value| value.tee_required),
-                            profile.map(|value| value.supports_tee),
-                            None,
-                        ),
-                        Err(err) => (None, None, Some(err.to_string())),
+                    Ok(definition) => match resolve_execution_profile(&definition.metadata) {
+                        Ok(profile) => (profile.map(|value| value.confidentiality), None),
+                        Err(err) => (None, Some(err.to_string())),
                     },
-                    Err(err) => (
-                        None,
-                        None,
-                        Some(format!("failed to fetch definition: {err}")),
-                    ),
+                    Err(err) => (None, Some(format!("failed to fetch definition: {err}"))),
                 };
 
             BlueprintListEntry {
                 blueprint_id,
                 info,
-                tee_required,
-                tee_supported,
-                tee_metadata_error,
+                confidentiality_policy,
+                execution_metadata_error,
             }
         })
         .buffer_unordered(MAX_CONCURRENT_BLUEPRINT_FETCHES)
@@ -82,9 +71,8 @@ pub fn print_blueprints(blueprints: &[BlueprintListEntry]) {
         let BlueprintListEntry {
             blueprint_id,
             info,
-            tee_required,
-            tee_supported,
-            tee_metadata_error,
+            confidentiality_policy,
+            execution_metadata_error,
         } = entry;
         println!(
             "{}: {}",
@@ -105,24 +93,20 @@ pub fn print_blueprints(blueprints: &[BlueprintListEntry]) {
             info.membership
         );
         println!("{}: {:?}", style("Pricing Model").green(), info.pricing);
-        let compatibility_label = match tee_supported {
-            Some(true) => "yes",
-            Some(false) => "no",
+        let policy_label = match confidentiality_policy {
+            Some(ConfidentialityPolicy::Any) => "any",
+            Some(ConfidentialityPolicy::TeeRequired) => "tee_required",
+            Some(ConfidentialityPolicy::StandardRequired) => "standard_required",
+            Some(ConfidentialityPolicy::TeePreferred) => "tee_preferred",
             None => "unspecified",
         };
         println!(
             "{}: {}",
-            style("TEE Compatible").green(),
-            compatibility_label
+            style("Execution Confidentiality").green(),
+            policy_label
         );
-        let policy_label = match tee_required {
-            Some(true) => "required (fail closed)",
-            Some(false) => "optional",
-            None => "unspecified",
-        };
-        println!("{}: {}", style("TEE Policy").green(), policy_label);
-        if let Some(err) = tee_metadata_error {
-            println!("{}: {}", style("TEE Metadata Error").red(), err);
+        if let Some(err) = execution_metadata_error {
+            println!("{}: {}", style("Execution Metadata Error").red(), err);
         }
         println!("{}: {}", style("Active").green(), info.active);
         println!(

--- a/crates/clients/tangle/src/blueprint_metadata.rs
+++ b/crates/clients/tangle/src/blueprint_metadata.rs
@@ -1,4 +1,4 @@
-//! Helpers for reading and writing blueprint deployment metadata.
+//! Helpers for reading and writing blueprint execution metadata.
 
 use crate::contracts::ITangleTypes;
 use alloc::borrow::ToOwned;
@@ -10,14 +10,13 @@ use thiserror::Error;
 /// Schema marker for structured blueprint metadata payloads.
 pub const METADATA_SCHEMA_V1: &str = "tangle.blueprint.metadata.v1";
 
-const DEPLOYMENT_PROFILE_KEY: &str = "deployment_profile";
+const EXECUTION_PROFILE_KEY: &str = "execution_profile";
 const JOB_PROFILES_BLOB_KEY: &str = "job_profiles_b64_gzip";
-const LEGACY_PROFILING_PREFIX: &str = "[PROFILING_DATA_";
 
-/// Errors produced while parsing deployment profile metadata.
+/// Errors produced while parsing execution profile metadata.
 #[derive(Debug, Error, Clone, PartialEq, Eq)]
 #[non_exhaustive]
-pub enum TeeDeploymentProfileError {
+pub enum ExecutionProfileError {
     /// `profiling_data` is not valid JSON.
     #[error("profiling_data must be valid JSON: {message}")]
     InvalidJson {
@@ -27,161 +26,139 @@ pub enum TeeDeploymentProfileError {
     /// `profiling_data` JSON root is not an object.
     #[error("profiling_data must be a JSON object")]
     MetadataNotObject,
-    /// `deployment_profile` exists but is not an object.
-    #[error("deployment_profile must be an object")]
-    DeploymentProfileNotObject,
-    /// `deployment_profile` exists but does not match expected schema.
-    #[error("deployment_profile is invalid: {message}")]
-    InvalidDeploymentProfile {
+    /// `execution_profile` exists but is not an object.
+    #[error("execution_profile must be an object")]
+    ExecutionProfileNotObject,
+    /// `execution_profile` exists but does not match expected schema.
+    #[error("execution_profile is invalid: {message}")]
+    InvalidExecutionProfile {
         /// Human-readable schema validation detail.
         message: String,
     },
-    /// `profiling_data` is non-empty but not recognized as structured JSON or legacy payload.
-    #[error("profiling_data is not structured metadata and does not match legacy profile format")]
-    UnsupportedProfilingDataFormat,
-    /// `tee_required=true` cannot be paired with `supports_tee=false`.
-    #[error("deployment_profile is invalid: tee_required=true requires supports_tee=true")]
-    ContradictoryPolicy,
 }
 
-/// Blueprint deployment policy related to TEE placement.
-///
-/// - `tee_required=true` means manager must fail-closed when TEE is unavailable.
-/// - `supports_tee=true` means the blueprint can run in TEE mode.
-///
-/// A dual-mode blueprint (TEE and non-TEE) should set:
-/// `tee_required=false`, `supports_tee=true`.
+/// Confidentiality policy for execution.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct TeeDeploymentProfile {
-    /// Whether TEE placement is mandatory (fail-closed).
-    pub tee_required: bool,
-    /// Whether this blueprint can run on TEE-capable infrastructure.
-    pub supports_tee: bool,
+#[serde(rename_all = "snake_case")]
+pub enum ConfidentialityPolicy {
+    /// Standard and TEE placement are both valid.
+    Any,
+    /// TEE execution is mandatory (fail closed).
+    TeeRequired,
+    /// Non-TEE execution is mandatory.
+    StandardRequired,
+    /// Prefer TEE, but allow non-TEE fallback.
+    TeePreferred,
 }
 
-impl TeeDeploymentProfile {
-    /// Normalize profile invariants.
+impl Default for ConfidentialityPolicy {
+    fn default() -> Self {
+        Self::Any
+    }
+}
+
+/// Blueprint deployment policy for execution environments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub struct ExecutionProfile {
+    /// Confidentiality policy for runtime placement.
+    #[serde(default)]
+    pub confidentiality: ConfidentialityPolicy,
+}
+
+impl ExecutionProfile {
+    /// Whether execution must run in TEE.
     #[must_use]
-    pub fn normalized(self) -> Self {
-        if self.tee_required && !self.supports_tee {
-            return Self {
-                tee_required: true,
-                supports_tee: true,
-            };
-        }
-        self
+    pub fn tee_required(self) -> bool {
+        matches!(self.confidentiality, ConfidentialityPolicy::TeeRequired)
+    }
+
+    /// Whether execution may run in TEE.
+    #[must_use]
+    pub fn tee_supported(self) -> bool {
+        matches!(
+            self.confidentiality,
+            ConfidentialityPolicy::Any
+                | ConfidentialityPolicy::TeeRequired
+                | ConfidentialityPolicy::TeePreferred
+        )
+    }
+
+    /// Whether non-TEE placement is required.
+    #[must_use]
+    pub fn standard_required(self) -> bool {
+        matches!(
+            self.confidentiality,
+            ConfidentialityPolicy::StandardRequired
+        )
     }
 }
 
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct RawDeploymentProfile {
-    tee_required: Option<bool>,
-    supports_tee: Option<bool>,
+struct RawExecutionProfile {
+    confidentiality: Option<ConfidentialityPolicy>,
 }
 
-/// Resolve TEE deployment profile from on-chain metadata.
-pub fn resolve_tee_deployment_profile(
+/// Resolve execution profile from on-chain metadata.
+pub fn resolve_execution_profile(
     metadata: &ITangleTypes::BlueprintMetadata,
-) -> Result<Option<TeeDeploymentProfile>, TeeDeploymentProfileError> {
-    resolve_tee_deployment_profile_from_profiling_data(metadata.profilingData.as_str())
+) -> Result<Option<ExecutionProfile>, ExecutionProfileError> {
+    resolve_execution_profile_from_profiling_data(metadata.profilingData.as_str())
 }
 
-/// Resolve TEE deployment profile from `profiling_data` payload.
+/// Resolve execution profile from `profiling_data` payload.
 ///
-/// Tolerant path:
-/// - Returns `Ok(None)` for empty or legacy non-JSON/non-object payloads.
-/// - Returns `Err` when structured JSON metadata is present but malformed.
-pub fn resolve_tee_deployment_profile_from_profiling_data(
+/// This parser is strict by design:
+/// - empty payload => `Ok(None)`
+/// - non-empty payload must be structured JSON metadata
+pub fn resolve_execution_profile_from_profiling_data(
     profiling_data: &str,
-) -> Result<Option<TeeDeploymentProfile>, TeeDeploymentProfileError> {
-    let trimmed = profiling_data.trim();
-    if trimmed.is_empty() {
-        return Ok(None);
-    }
-    if !looks_like_structured_metadata(trimmed) {
-        return if looks_like_legacy_profile_payload(trimmed) {
-            Ok(None)
-        } else {
-            Err(TeeDeploymentProfileError::UnsupportedProfilingDataFormat)
-        };
-    }
-
-    try_resolve_tee_deployment_profile_from_profiling_data(trimmed)
-}
-
-/// Resolve TEE deployment profile from `profiling_data` payload with strict errors.
-///
-/// Strict path:
-/// - Returns `Err` for any non-empty payload that is not valid structured metadata.
-pub fn try_resolve_tee_deployment_profile_from_profiling_data(
-    profiling_data: &str,
-) -> Result<Option<TeeDeploymentProfile>, TeeDeploymentProfileError> {
+) -> Result<Option<ExecutionProfile>, ExecutionProfileError> {
     let trimmed = profiling_data.trim();
     if trimmed.is_empty() {
         return Ok(None);
     }
 
     let root: Value =
-        serde_json::from_str(trimmed).map_err(|e| TeeDeploymentProfileError::InvalidJson {
+        serde_json::from_str(trimmed).map_err(|e| ExecutionProfileError::InvalidJson {
             message: e.to_string(),
         })?;
     let Some(root_object) = root.as_object() else {
-        return Err(TeeDeploymentProfileError::MetadataNotObject);
+        return Err(ExecutionProfileError::MetadataNotObject);
     };
 
-    let Some(raw_profile_value) = root_object.get(DEPLOYMENT_PROFILE_KEY) else {
+    let Some(raw_profile_value) = root_object.get(EXECUTION_PROFILE_KEY) else {
         return Ok(None);
     };
     let Some(raw_profile_object) = raw_profile_value.as_object() else {
-        return Err(TeeDeploymentProfileError::DeploymentProfileNotObject);
+        return Err(ExecutionProfileError::ExecutionProfileNotObject);
     };
 
-    let raw_profile: RawDeploymentProfile =
+    let raw_profile: RawExecutionProfile =
         serde_json::from_value(Value::Object(raw_profile_object.clone())).map_err(|e| {
-            TeeDeploymentProfileError::InvalidDeploymentProfile {
+            ExecutionProfileError::InvalidExecutionProfile {
                 message: e.to_string(),
             }
         })?;
-    let tee_required = raw_profile.tee_required.unwrap_or(false);
-    if tee_required && matches!(raw_profile.supports_tee, Some(false)) {
-        return Err(TeeDeploymentProfileError::ContradictoryPolicy);
-    }
-    let supports_tee = raw_profile.supports_tee.unwrap_or(false);
 
-    Ok(Some(
-        TeeDeploymentProfile {
-            tee_required,
-            supports_tee,
-        }
-        .normalized(),
-    ))
+    Ok(Some(ExecutionProfile {
+        confidentiality: raw_profile.confidentiality.unwrap_or_default(),
+    }))
 }
 
-/// Resolve explicit `tee_required` deployment enforcement from metadata.
-pub fn resolve_tee_required(
+/// Resolve explicit confidentiality policy from metadata.
+pub fn resolve_confidentiality_policy(
     metadata: &ITangleTypes::BlueprintMetadata,
-) -> Result<Option<bool>, TeeDeploymentProfileError> {
-    Ok(resolve_tee_deployment_profile(metadata)?.map(|profile| profile.tee_required))
+) -> Result<Option<ConfidentialityPolicy>, ExecutionProfileError> {
+    Ok(resolve_execution_profile(metadata)?.map(|profile| profile.confidentiality))
 }
 
-/// Resolve explicit `supports_tee` capability from metadata.
-pub fn resolve_tee_support(
-    metadata: &ITangleTypes::BlueprintMetadata,
-) -> Result<Option<bool>, TeeDeploymentProfileError> {
-    Ok(resolve_tee_deployment_profile(metadata)?.map(|profile| profile.supports_tee))
-}
-
-/// Inject or update structured TEE deployment profile inside `profiling_data`.
+/// Inject or update structured execution profile inside `profiling_data`.
 ///
-/// If `profiling_data` currently contains a legacy plain blob, it is preserved
+/// If `profiling_data` currently contains a non-JSON blob, it is preserved
 /// under `job_profiles_b64_gzip`.
 #[must_use]
-pub fn inject_tee_deployment_profile(
-    profiling_data: &str,
-    profile: TeeDeploymentProfile,
-) -> String {
-    let profile = profile.normalized();
+pub fn inject_execution_profile(profiling_data: &str, profile: ExecutionProfile) -> String {
     let trimmed = profiling_data.trim();
     if trimmed.is_empty() {
         return default_metadata_payload(profile).to_string();
@@ -193,20 +170,20 @@ pub fn inject_tee_deployment_profile(
                 if schema != METADATA_SCHEMA_V1 {
                     return json!({
                         "schema": METADATA_SCHEMA_V1,
-                        DEPLOYMENT_PROFILE_KEY: profile_to_value(profile),
+                        EXECUTION_PROFILE_KEY: profile_to_value(profile),
                         JOB_PROFILES_BLOB_KEY: trimmed,
                     })
                     .to_string();
                 }
             }
-            upsert_deployment_profile(root, profile);
+            upsert_execution_profile(root, profile);
             return value.to_string();
         }
     }
 
     json!({
         "schema": METADATA_SCHEMA_V1,
-        DEPLOYMENT_PROFILE_KEY: profile_to_value(profile),
+        EXECUTION_PROFILE_KEY: profile_to_value(profile),
         JOB_PROFILES_BLOB_KEY: trimmed,
     })
     .to_string()
@@ -228,37 +205,25 @@ pub fn extract_job_profiles_blob(profiling_data: &str) -> Option<String> {
         .map(ToOwned::to_owned)
 }
 
-fn looks_like_structured_metadata(payload: &str) -> bool {
-    payload.starts_with('{')
-}
-
-fn looks_like_legacy_profile_payload(payload: &str) -> bool {
-    payload.starts_with(LEGACY_PROFILING_PREFIX) || payload.starts_with("H4sI")
-}
-
-fn default_metadata_payload(profile: TeeDeploymentProfile) -> Value {
+fn default_metadata_payload(profile: ExecutionProfile) -> Value {
     json!({
         "schema": METADATA_SCHEMA_V1,
-        DEPLOYMENT_PROFILE_KEY: profile_to_value(profile),
+        EXECUTION_PROFILE_KEY: profile_to_value(profile),
     })
 }
 
-fn profile_to_value(profile: TeeDeploymentProfile) -> Value {
+fn profile_to_value(profile: ExecutionProfile) -> Value {
     json!({
-        "tee_required": profile.tee_required,
-        "supports_tee": profile.supports_tee,
+        "confidentiality": profile.confidentiality,
     })
 }
 
-fn upsert_deployment_profile(root: &mut Map<String, Value>, profile: TeeDeploymentProfile) {
+fn upsert_execution_profile(root: &mut Map<String, Value>, profile: ExecutionProfile) {
     root.insert(
         "schema".to_string(),
         Value::String(METADATA_SCHEMA_V1.to_string()),
     );
-    root.insert(
-        DEPLOYMENT_PROFILE_KEY.to_string(),
-        profile_to_value(profile),
-    );
+    root.insert(EXECUTION_PROFILE_KEY.to_string(), profile_to_value(profile));
 }
 
 #[cfg(test)]
@@ -270,12 +235,11 @@ mod tests {
     fn resolves_required_profile() {
         let mut metadata: ITangleTypes::BlueprintMetadata = Default::default();
         metadata.profilingData =
-            r#"{"deployment_profile":{"tee_required":true,"supports_tee":true}}"#.into();
+            r#"{"execution_profile":{"confidentiality":"tee_required"}}"#.into();
         assert_eq!(
-            resolve_tee_deployment_profile(&metadata).unwrap(),
-            Some(TeeDeploymentProfile {
-                tee_required: true,
-                supports_tee: true,
+            resolve_execution_profile(&metadata).unwrap(),
+            Some(ExecutionProfile {
+                confidentiality: ConfidentialityPolicy::TeeRequired,
             })
         );
     }
@@ -284,195 +248,111 @@ mod tests {
     fn resolves_optional_profile() {
         let mut metadata: ITangleTypes::BlueprintMetadata = Default::default();
         metadata.profilingData =
-            r#"{"deployment_profile":{"tee_required":false,"supports_tee":true}}"#.into();
+            r#"{"execution_profile":{"confidentiality":"tee_preferred"}}"#.into();
         assert_eq!(
-            resolve_tee_deployment_profile(&metadata).unwrap(),
-            Some(TeeDeploymentProfile {
-                tee_required: false,
-                supports_tee: true,
+            resolve_execution_profile(&metadata).unwrap(),
+            Some(ExecutionProfile {
+                confidentiality: ConfidentialityPolicy::TeePreferred,
             })
         );
     }
 
     #[test]
-    fn ignores_non_structured_payloads() {
-        let mut metadata: ITangleTypes::BlueprintMetadata = Default::default();
-        metadata.profilingData = "[PROFILING_DATA_V1]tee".into();
-        assert_eq!(resolve_tee_deployment_profile(&metadata).unwrap(), None);
-    }
-
-    #[test]
     fn strict_parser_errors_on_non_json_payloads() {
-        let err = try_resolve_tee_deployment_profile_from_profiling_data("tee")
-            .expect_err("expected parse error");
-        assert!(matches!(err, TeeDeploymentProfileError::InvalidJson { .. }));
+        let err =
+            resolve_execution_profile_from_profiling_data("tee").expect_err("expected parse error");
+        assert!(matches!(err, ExecutionProfileError::InvalidJson { .. }));
     }
 
     #[test]
-    fn tolerant_parser_ignores_recognized_legacy_payloads() {
-        assert_eq!(
-            resolve_tee_deployment_profile_from_profiling_data("[PROFILING_DATA_V1]tee").unwrap(),
-            None
-        );
+    fn strict_parser_errors_on_non_object_json_payloads() {
+        let err =
+            resolve_execution_profile_from_profiling_data("[]").expect_err("expected type error");
+        assert!(matches!(err, ExecutionProfileError::MetadataNotObject));
     }
 
     #[test]
-    fn tolerant_parser_errors_on_unknown_non_json_payloads() {
-        let err = resolve_tee_deployment_profile_from_profiling_data("tee")
-            .expect_err("expected unsupported format error");
-        assert!(matches!(
-            err,
-            TeeDeploymentProfileError::UnsupportedProfilingDataFormat
-        ));
-    }
-
-    #[test]
-    fn tolerant_parser_errors_on_malformed_json_object_payloads() {
-        let err = resolve_tee_deployment_profile_from_profiling_data("{")
-            .expect_err("expected parse error");
-        assert!(matches!(err, TeeDeploymentProfileError::InvalidJson { .. }));
-    }
-
-    #[test]
-    fn strict_parser_errors_on_non_boolean_fields() {
-        let err = try_resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":"true"}}"#,
+    fn strict_parser_errors_on_non_string_confidentiality() {
+        let err = resolve_execution_profile_from_profiling_data(
+            r#"{"execution_profile":{"confidentiality":true}}"#,
         )
         .expect_err("expected type error");
         assert!(matches!(
             err,
-            TeeDeploymentProfileError::InvalidDeploymentProfile { .. }
-        ));
-    }
-
-    #[test]
-    fn strict_parser_errors_on_contradictory_policy_flags() {
-        let err = try_resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":true,"supports_tee":false}}"#,
-        )
-        .expect_err("expected contradiction error");
-        assert!(matches!(
-            err,
-            TeeDeploymentProfileError::ContradictoryPolicy
+            ExecutionProfileError::InvalidExecutionProfile { .. }
         ));
     }
 
     #[test]
     fn strict_parser_errors_on_unknown_fields() {
-        let err = try_resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":true,"tee_requred":true}}"#,
+        let err = resolve_execution_profile_from_profiling_data(
+            r#"{"execution_profile":{"confidentiality":"tee_required","bad":true}}"#,
         )
         .expect_err("expected schema error");
         assert!(matches!(
             err,
-            TeeDeploymentProfileError::InvalidDeploymentProfile { .. }
+            ExecutionProfileError::InvalidExecutionProfile { .. }
         ));
     }
 
     #[test]
-    fn explicit_non_tee_profile_is_preserved() {
-        let parsed = try_resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":false,"supports_tee":false}}"#,
-        )
-        .unwrap();
-        assert_eq!(
-            parsed,
-            Some(TeeDeploymentProfile {
-                tee_required: false,
-                supports_tee: false,
-            })
-        );
-    }
-
-    #[test]
-    fn required_implies_supports() {
-        let profile = TeeDeploymentProfile {
-            tee_required: true,
-            supports_tee: false,
-        }
-        .normalized();
-        assert_eq!(
-            profile,
-            TeeDeploymentProfile {
-                tee_required: true,
-                supports_tee: true,
-            }
-        );
-    }
-
-    #[test]
     fn injects_into_empty_payload() {
-        let payload = inject_tee_deployment_profile(
+        let payload = inject_execution_profile(
             "",
-            TeeDeploymentProfile {
-                tee_required: false,
-                supports_tee: true,
+            ExecutionProfile {
+                confidentiality: ConfidentialityPolicy::Any,
             },
         );
         let value: Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(
             value
-                .get(DEPLOYMENT_PROFILE_KEY)
-                .and_then(|v| v.get("supports_tee"))
-                .and_then(Value::as_bool),
-            Some(true)
+                .get(EXECUTION_PROFILE_KEY)
+                .and_then(|v| v.get("confidentiality"))
+                .and_then(Value::as_str),
+            Some("any")
         );
     }
 
     #[test]
-    fn injects_into_existing_object_payload() {
-        let payload = inject_tee_deployment_profile(
+    fn updates_existing_object_payload() {
+        let payload = inject_execution_profile(
             r#"{"job_profiles_b64_gzip":"abc"}"#,
-            TeeDeploymentProfile {
-                tee_required: true,
-                supports_tee: true,
+            ExecutionProfile {
+                confidentiality: ConfidentialityPolicy::TeeRequired,
             },
         );
         let value: Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(
             value
-                .get(DEPLOYMENT_PROFILE_KEY)
-                .and_then(|v| v.get("tee_required"))
-                .and_then(Value::as_bool),
-            Some(true)
+                .get(EXECUTION_PROFILE_KEY)
+                .and_then(|v| v.get("confidentiality"))
+                .and_then(Value::as_str),
+            Some("tee_required")
         );
-    }
-
-    #[test]
-    fn inject_overwrites_stale_schema_marker() {
-        let payload = inject_tee_deployment_profile(
-            r#"{"schema":"legacy.v0"}"#,
-            TeeDeploymentProfile {
-                tee_required: false,
-                supports_tee: true,
-            },
-        );
-        let value: Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(
-            value.get("schema").and_then(Value::as_str),
-            Some(METADATA_SCHEMA_V1)
+            value.get(JOB_PROFILES_BLOB_KEY).and_then(Value::as_str),
+            Some("abc")
         );
     }
 
     #[test]
-    fn wraps_legacy_blob_payload() {
-        let payload = inject_tee_deployment_profile(
-            "H4sIAAAAA...",
-            TeeDeploymentProfile {
-                tee_required: true,
-                supports_tee: true,
+    fn wraps_non_json_payload_as_job_profiles_blob() {
+        let payload = inject_execution_profile(
+            "H4sIAAAAAAAA/2NgYGBgBGIOAwA6rY+4BQAAAA==",
+            ExecutionProfile {
+                confidentiality: ConfidentialityPolicy::TeeRequired,
             },
         );
         let value: Value = serde_json::from_str(&payload).unwrap();
         assert_eq!(
             value.get(JOB_PROFILES_BLOB_KEY).and_then(Value::as_str),
-            Some("H4sIAAAAA...")
+            Some("H4sIAAAAAAAA/2NgYGBgBGIOAwA6rY+4BQAAAA==")
         );
     }
 
     #[test]
     fn extracts_profiles_blob_from_structured_payload() {
-        let payload = r#"{"deployment_profile":{"tee_required":true,"supports_tee":true},"job_profiles_b64_gzip":"abc"}"#;
+        let payload = r#"{"execution_profile":{"confidentiality":"tee_required"},"job_profiles_b64_gzip":"abc"}"#;
         assert_eq!(extract_job_profiles_blob(payload), Some("abc".to_string()));
     }
 

--- a/crates/clients/tangle/src/lib.rs
+++ b/crates/clients/tangle/src/lib.rs
@@ -73,10 +73,9 @@ pub mod services;
 
 // Re-exports
 pub use blueprint_metadata::{
-    TeeDeploymentProfile, TeeDeploymentProfileError, extract_job_profiles_blob,
-    inject_tee_deployment_profile, resolve_tee_deployment_profile,
-    resolve_tee_deployment_profile_from_profiling_data, resolve_tee_required, resolve_tee_support,
-    try_resolve_tee_deployment_profile_from_profiling_data,
+    ConfidentialityPolicy, ExecutionProfile, ExecutionProfileError, extract_job_profiles_blob,
+    inject_execution_profile, resolve_confidentiality_policy, resolve_execution_profile,
+    resolve_execution_profile_from_profiling_data,
 };
 pub use client::{
     AggregationConfig, AssetInfo, AssetKind, BlueprintSelectionMode, DelegationInfo,

--- a/crates/manager/src/protocol/eigenlayer/event_handler.rs
+++ b/crates/manager/src/protocol/eigenlayer/event_handler.rs
@@ -20,6 +20,7 @@ use crate::rt::service::Status;
 use crate::sources::testing::TestSourceFetcher;
 use crate::sources::types::{BlueprintSource, TestFetcher};
 use crate::sources::{BlueprintArgs, BlueprintEnvVars, BlueprintSourceHandler, DynBlueprintSource};
+use blueprint_client_tangle::ConfidentialityPolicy;
 use blueprint_core::{error, info, warn};
 use blueprint_runner::config::{BlueprintEnvironment, Protocol};
 
@@ -477,7 +478,7 @@ impl EigenlayerEventHandler {
                         container_image,
                         blueprint_env.clone(),
                         args.clone(),
-                        false,
+                        ConfidentialityPolicy::StandardRequired,
                         false, // debug mode
                     )
                     .await?
@@ -517,7 +518,7 @@ impl EigenlayerEventHandler {
                             container_image,
                             blueprint_env.clone(),
                             args.clone(),
-                            true,
+                            ConfidentialityPolicy::TeeRequired,
                             false, // debug mode
                         )
                         .await?

--- a/crates/manager/src/protocol/tangle/event_handler.rs
+++ b/crates/manager/src/protocol/tangle/event_handler.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use alloy_sol_types::sol;
 use async_trait::async_trait;
+use blueprint_client_tangle::ConfidentialityPolicy;
 use blueprint_client_tangle::contracts::ITangle;
 use blueprint_core::{info, warn};
 use blueprint_runner::config::{BlueprintEnvironment, Protocol};
@@ -37,7 +38,7 @@ pub struct BlueprintMetadata {
     pub service_id: u64,
     pub name: String,
     pub sources: Vec<BlueprintSource>,
-    pub tee_required: bool,
+    pub confidentiality_policy: ConfidentialityPolicy,
     pub registration_mode: bool,
     pub registration_capture_only: bool,
 }
@@ -109,13 +110,26 @@ fn supports_tee(source: &BlueprintSource) -> bool {
 fn ordered_source_indices(
     sources: &[BlueprintSource],
     preferred_source: SourceType,
-    require_tee: bool,
+    confidentiality_policy: ConfidentialityPolicy,
 ) -> Vec<usize> {
+    let require_tee = matches!(confidentiality_policy, ConfidentialityPolicy::TeeRequired);
     let mut indexed: Vec<(usize, u8)> = sources
         .iter()
         .enumerate()
         .filter(|(_, source)| !require_tee || supports_tee(source))
-        .map(|(idx, source)| (idx, source_priority(source, preferred_source)))
+        .map(|(idx, source)| {
+            let priority = if matches!(confidentiality_policy, ConfidentialityPolicy::TeePreferred)
+            {
+                if matches!(source_category(source), SourceCategory::Container) {
+                    0
+                } else {
+                    source_priority(source, preferred_source).saturating_add(1)
+                }
+            } else {
+                source_priority(source, preferred_source)
+            };
+            (idx, priority)
+        })
         .collect();
     indexed.sort_by_key(|(idx, priority)| (*priority, *idx));
     indexed.into_iter().map(|(idx, _)| idx).collect()
@@ -359,9 +373,13 @@ impl TangleEventHandler {
         let ordered_source_idxs = ordered_source_indices(
             &metadata.sources,
             ctx.preferred_source,
-            metadata.tee_required,
+            metadata.confidentiality_policy,
         );
-        if metadata.tee_required && ordered_source_idxs.is_empty() {
+        if matches!(
+            metadata.confidentiality_policy,
+            ConfidentialityPolicy::TeeRequired
+        ) && ordered_source_idxs.is_empty()
+        {
             return Err(Error::TeeRuntimeUnavailable {
                 reason: "Blueprint requires TEE execution but exposes no container source"
                     .to_string(),
@@ -374,7 +392,7 @@ impl TangleEventHandler {
         info!(
             blueprint_id = metadata.blueprint_id,
             service_id = metadata.service_id,
-            tee_required = metadata.tee_required,
+            confidentiality_policy = ?metadata.confidentiality_policy,
             preferred_source = %ctx.preferred_source,
             source_order = ?ordered_source_labels,
             "Resolved deterministic source fallback ordering"
@@ -419,7 +437,7 @@ impl TangleEventHandler {
                     service_idx,
                     env_vars,
                     args,
-                    metadata.tee_required,
+                    metadata.confidentiality_policy,
                     &service_label,
                     &cache_dir,
                     &runtime_dir,
@@ -471,7 +489,12 @@ impl TangleEventHandler {
 
         // Fallback: when preferred_source is Native and all on-chain sources failed,
         // try building from local cargo workspace if BLUEPRINT_CARGO_BIN is set.
-        if ctx.preferred_source == SourceType::Native && !metadata.tee_required {
+        if ctx.preferred_source == SourceType::Native
+            && !matches!(
+                metadata.confidentiality_policy,
+                ConfidentialityPolicy::TeeRequired
+            )
+        {
             if let Ok(cargo_bin) = std::env::var("BLUEPRINT_CARGO_BIN") {
                 let base_path = std::env::current_dir()
                     .map(|p| p.display().to_string())
@@ -512,7 +535,7 @@ impl TangleEventHandler {
                         service_idx,
                         env_vars,
                         args,
-                        false,
+                        metadata.confidentiality_policy,
                         &service_label,
                         &cache_dir,
                         &runtime_dir,
@@ -676,7 +699,8 @@ mod tests {
             remote_source(),
             github_source(),
         ];
-        let ordered = ordered_source_indices(&sources, SourceType::Native, false);
+        let ordered =
+            ordered_source_indices(&sources, SourceType::Native, ConfidentialityPolicy::Any);
         assert_eq!(ordered, vec![2, 3, 1, 0]);
     }
 
@@ -688,7 +712,8 @@ mod tests {
             remote_source(),
             github_source(),
         ];
-        let ordered = ordered_source_indices(&sources, SourceType::Container, false);
+        let ordered =
+            ordered_source_indices(&sources, SourceType::Container, ConfidentialityPolicy::Any);
         assert_eq!(ordered, vec![1, 2, 3, 0]);
     }
 
@@ -700,8 +725,8 @@ mod tests {
             remote_source(),
             container_source(),
         ];
-        let first = ordered_source_indices(&sources, SourceType::Wasm, false);
-        let second = ordered_source_indices(&sources, SourceType::Wasm, false);
+        let first = ordered_source_indices(&sources, SourceType::Wasm, ConfidentialityPolicy::Any);
+        let second = ordered_source_indices(&sources, SourceType::Wasm, ConfidentialityPolicy::Any);
         assert_eq!(first, second);
         assert_eq!(first, vec![0, 2, 3, 1]);
     }
@@ -714,14 +739,38 @@ mod tests {
             remote_source(),
             github_source(),
         ];
-        let ordered = ordered_source_indices(&sources, SourceType::Native, true);
+        let ordered = ordered_source_indices(
+            &sources,
+            SourceType::Native,
+            ConfidentialityPolicy::TeeRequired,
+        );
         assert_eq!(ordered, vec![1]);
     }
 
     #[test]
     fn tee_required_without_container_sources_returns_empty_order() {
         let sources = vec![test_source(), remote_source(), github_source()];
-        let ordered = ordered_source_indices(&sources, SourceType::Container, true);
+        let ordered = ordered_source_indices(
+            &sources,
+            SourceType::Container,
+            ConfidentialityPolicy::TeeRequired,
+        );
         assert!(ordered.is_empty());
+    }
+
+    #[test]
+    fn tee_preferred_prioritizes_container_sources() {
+        let sources = vec![
+            test_source(),
+            remote_source(),
+            github_source(),
+            container_source(),
+        ];
+        let ordered = ordered_source_indices(
+            &sources,
+            SourceType::Native,
+            ConfidentialityPolicy::TeePreferred,
+        );
+        assert_eq!(ordered[0], 3);
     }
 }

--- a/crates/manager/src/protocol/tangle/metadata.rs
+++ b/crates/manager/src/protocol/tangle/metadata.rs
@@ -15,7 +15,9 @@ use crate::sources::types::{
     GithubFetcher as ManagerGithubFetcher, ImageRegistryFetcher, RemoteFetcher, TestFetcher,
 };
 use blueprint_client_tangle::contracts::ITangleTypes;
-use blueprint_client_tangle::resolve_tee_deployment_profile_from_profiling_data;
+use blueprint_client_tangle::{
+    ConfidentialityPolicy, resolve_execution_profile_from_profiling_data,
+};
 use serde::Deserialize;
 use serde_json;
 type OnChainBlueprintSource = <ITangleTypes::BlueprintSource as SolType>::RustType;
@@ -56,7 +58,7 @@ impl OnChainMetadataProvider {
         service_id: u64,
         registration_mode: bool,
     ) -> Result<Option<ManagerBlueprintMetadata>> {
-        let Some((blueprint_name, sources, tee_required)) =
+        let Some((blueprint_name, sources, confidentiality_policy)) =
             Self::load_blueprint_sources(client, blueprint_id).await?
         else {
             return Ok(None);
@@ -67,7 +69,7 @@ impl OnChainMetadataProvider {
             service_id,
             name: blueprint_name,
             sources,
-            tee_required,
+            confidentiality_policy,
             registration_mode,
             registration_capture_only: false,
         }))
@@ -76,7 +78,7 @@ impl OnChainMetadataProvider {
     async fn load_blueprint_sources(
         client: &TangleProtocolClient,
         blueprint_id: u64,
-    ) -> Result<Option<(String, Vec<ManagerBlueprintSource>, bool)>> {
+    ) -> Result<Option<(String, Vec<ManagerBlueprintSource>, ConfidentialityPolicy)>> {
         let inner = client.client();
         let definition = match inner.get_blueprint_definition(blueprint_id).await {
             Ok(definition) => definition,
@@ -88,7 +90,7 @@ impl OnChainMetadataProvider {
         };
 
         let blueprint_name = definition.metadata.name.clone().to_string();
-        let tee_required = Self::resolve_tee_required(&definition.metadata)?;
+        let confidentiality_policy = Self::resolve_confidentiality_policy(&definition.metadata)?;
         let onchain_sources = definition.sources;
 
         let sources = Self::convert_sources(&onchain_sources);
@@ -101,18 +103,22 @@ impl OnChainMetadataProvider {
             return Ok(None);
         }
 
-        Ok(Some((blueprint_name, sources, tee_required)))
+        Ok(Some((blueprint_name, sources, confidentiality_policy)))
     }
 
-    fn resolve_tee_required(metadata: &OnChainBlueprintMetadata) -> Result<bool> {
+    fn resolve_confidentiality_policy(
+        metadata: &OnChainBlueprintMetadata,
+    ) -> Result<ConfidentialityPolicy> {
         let profile =
-            resolve_tee_deployment_profile_from_profiling_data(metadata.profilingData.as_str())
+            resolve_execution_profile_from_profiling_data(metadata.profilingData.as_str())
                 .map_err(|err| {
                     Error::Other(format!(
-                        "invalid profilingData for TEE deployment profile: {err}"
+                        "invalid profilingData for execution profile: {err}"
                     ))
                 })?;
-        Ok(profile.map(|value| value.tee_required).unwrap_or(false))
+        Ok(profile
+            .map(|value| value.confidentiality)
+            .unwrap_or(ConfidentialityPolicy::Any))
     }
 
     fn convert_sources(sources: &[OnChainBlueprintSource]) -> Vec<ManagerBlueprintSource> {
@@ -639,77 +645,77 @@ mod tests {
     }
 
     #[test]
-    fn resolve_tee_required_from_structured_required_profile() {
-        let parsed = blueprint_client_tangle::resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":true,"supports_tee":true}}"#,
+    fn resolve_confidentiality_policy_from_structured_required_profile() {
+        let parsed = blueprint_client_tangle::resolve_execution_profile_from_profiling_data(
+            r#"{"execution_profile":{"confidentiality":"tee_required"}}"#,
         )
         .unwrap();
-        assert_eq!(parsed.map(|profile| profile.tee_required), Some(true));
+        assert_eq!(
+            parsed.map(|profile| profile.confidentiality),
+            Some(ConfidentialityPolicy::TeeRequired)
+        );
     }
 
     #[test]
-    fn resolve_tee_required_from_structured_optional_profile() {
-        let parsed = blueprint_client_tangle::resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":false,"supports_tee":true}}"#,
+    fn resolve_confidentiality_policy_from_structured_optional_profile() {
+        let parsed = blueprint_client_tangle::resolve_execution_profile_from_profiling_data(
+            r#"{"execution_profile":{"confidentiality":"tee_preferred"}}"#,
         )
         .unwrap();
-        assert_eq!(parsed.map(|profile| profile.tee_required), Some(false));
+        assert_eq!(
+            parsed.map(|profile| profile.confidentiality),
+            Some(ConfidentialityPolicy::TeePreferred)
+        );
     }
 
     #[test]
-    fn resolve_tee_required_normalizes_missing_supports_flag() {
-        let parsed = blueprint_client_tangle::resolve_tee_deployment_profile_from_profiling_data(
-            r#"{"deployment_profile":{"tee_required":true}}"#,
+    fn resolve_confidentiality_policy_defaults_to_any_when_missing() {
+        let parsed = blueprint_client_tangle::resolve_execution_profile_from_profiling_data(
+            r#"{"execution_profile":{}}"#,
         )
         .unwrap();
-        assert_eq!(parsed.map(|profile| profile.tee_required), Some(true));
+        assert_eq!(
+            parsed.map(|profile| profile.confidentiality),
+            Some(ConfidentialityPolicy::Any)
+        );
     }
 
     #[test]
-    fn resolve_tee_required_errors_on_unknown_non_structured_payloads() {
-        let err =
-            blueprint_client_tangle::resolve_tee_deployment_profile_from_profiling_data("native")
-                .expect_err("expected unsupported format error");
+    fn resolve_confidentiality_policy_errors_on_non_structured_payloads() {
+        let err = blueprint_client_tangle::resolve_execution_profile_from_profiling_data("native")
+            .expect_err("expected strict parse error");
         assert!(
             err.to_string()
-                .contains("does not match legacy profile format"),
+                .contains("profiling_data must be valid JSON"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn resolve_tee_required_ignores_legacy_profile_markers() {
-        let parsed = blueprint_client_tangle::resolve_tee_deployment_profile_from_profiling_data(
-            "[PROFILING_DATA_V1]H4sIAAAAAAAA/2NgYGBgBGIOAwA6rY+4BQAAAA==",
-        )
-        .unwrap();
-        assert_eq!(parsed, None);
-    }
-
-    #[test]
-    fn resolve_tee_required_errors_on_malformed_json() {
+    fn resolve_confidentiality_policy_errors_on_malformed_json() {
         let metadata = ITangleTypes::BlueprintMetadata {
             profilingData: "{".into(),
             ..Default::default()
         };
-        let err = OnChainMetadataProvider::resolve_tee_required(&metadata).unwrap_err();
+        let err = OnChainMetadataProvider::resolve_confidentiality_policy(&metadata).unwrap_err();
         assert!(
             err.to_string()
-                .contains("invalid profilingData for TEE deployment profile"),
+                .contains("invalid profilingData for execution profile"),
             "unexpected error: {err}"
         );
     }
 
     #[test]
-    fn resolve_tee_required_defaults_false_for_legacy_non_json_payloads() {
+    fn resolve_confidentiality_policy_defaults_to_any_for_empty_payload() {
         let metadata = ITangleTypes::BlueprintMetadata {
-            profilingData: "[PROFILING_DATA_V1]H4sIAAAAAAAA/2NgYGBgBGIOAwA6rY+4BQAAAA==".into(),
+            profilingData: "".into(),
             ..Default::default()
         };
-        let parsed = OnChainMetadataProvider::resolve_tee_required(&metadata).unwrap();
-        assert!(
-            !parsed,
-            "legacy payload should default to tee_required=false"
+        let parsed = OnChainMetadataProvider::resolve_confidentiality_policy(&metadata).unwrap();
+        assert_eq!(
+            parsed,
+            ConfidentialityPolicy::Any,
+            "empty payload should default to confidentiality=any"
         );
     }
 

--- a/crates/manager/src/rt/container/mod.rs
+++ b/crates/manager/src/rt/container/mod.rs
@@ -3,6 +3,7 @@ use crate::error::Result;
 use crate::rt::ResourceLimits;
 use crate::rt::service::Status;
 use crate::sources::{BlueprintArgs, BlueprintEnvVars};
+use blueprint_client_tangle::ConfidentialityPolicy;
 use blueprint_core::{info, warn};
 use k8s_openapi::api::core::v1::{
     Container, EndpointAddress, EndpointPort, EndpointSubset, Endpoints, EnvVar,
@@ -46,7 +47,7 @@ pub struct ContainerInstance {
     image: String,
     env: BlueprintEnvVars,
     args: BlueprintArgs,
-    require_tee: bool,
+    confidentiality_policy: ConfidentialityPolicy,
 
     // TODO: Debug logging for containers
     /// Whether this instance should run in debug mode
@@ -70,7 +71,7 @@ impl ContainerInstance {
         image: String,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
-        require_tee: bool,
+        confidentiality_policy: ConfidentialityPolicy,
         debug: bool,
     ) -> Result<ContainerInstance> {
         let client = ctx.containers.kube_client.clone().ok_or_else(|| {
@@ -91,7 +92,7 @@ impl ContainerInstance {
             image,
             env,
             args,
-            require_tee,
+            confidentiality_policy,
             debug,
         })
     }
@@ -120,27 +121,34 @@ impl ContainerInstance {
         self.ensure_host_service().await?;
         self.ensure_host_endpoints().await?;
 
-        let kata_available = match detect_kata(self.client.clone()).await {
-            Ok(v) => v,
-            Err(err) => {
-                if self.require_tee {
-                    return Err(err);
+        let runtime = match self.confidentiality_policy {
+            ConfidentialityPolicy::TeeRequired => {
+                let kata_available = detect_kata(self.client.clone()).await?;
+                if !kata_available {
+                    return Err(crate::error::Error::TeePrerequisiteMissing {
+                        prerequisite: "kata runtime class".to_string(),
+                        hint: "TEE runtime requires Kubernetes RuntimeClass 'kata' to enforce sandbox isolation".to_string(),
+                    });
                 }
-                warn!("Failed to detect kata runtime class, continuing without kata: {err}");
-                false
+                Some(String::from("kata"))
             }
-        };
-        if self.require_tee && !kata_available {
-            return Err(crate::error::Error::TeePrerequisiteMissing {
-                prerequisite: "kata runtime class".to_string(),
-                hint: "TEE runtime requires Kubernetes RuntimeClass 'kata' to enforce sandbox isolation".to_string(),
-            });
-        }
-
-        let runtime = if kata_available {
-            Some(String::from("kata"))
-        } else {
-            None
+            ConfidentialityPolicy::TeePreferred => {
+                let kata_available = match detect_kata(self.client.clone()).await {
+                    Ok(v) => v,
+                    Err(err) => {
+                        warn!(
+                            "Failed to detect kata runtime class, continuing without kata: {err}"
+                        );
+                        false
+                    }
+                };
+                if kata_available {
+                    Some(String::from("kata"))
+                } else {
+                    None
+                }
+            }
+            ConfidentialityPolicy::Any | ConfidentialityPolicy::StandardRequired => None,
         };
 
         let pods: Api<Pod> = Api::namespaced(self.client.clone(), BLUEPRINT_NAMESPACE);

--- a/crates/manager/src/rt/service.rs
+++ b/crates/manager/src/rt/service.rs
@@ -9,6 +9,7 @@ use crate::rt::container::ContainerInstance;
 #[cfg(feature = "remote-providers")]
 use crate::rt::remote::RemoteServiceInstance;
 use crate::sources::{BlueprintArgs, BlueprintEnvVars};
+use blueprint_client_tangle::ConfidentialityPolicy;
 use blueprint_core::error;
 use blueprint_core::{info, warn};
 use blueprint_manager_bridge::server::{Bridge, BridgeHandle};
@@ -230,7 +231,7 @@ impl Service {
         image: String,
         mut env_vars: BlueprintEnvVars,
         arguments: BlueprintArgs,
-        require_tee: bool,
+        confidentiality_policy: ConfidentialityPolicy,
         debug: bool,
     ) -> Result<Service> {
         let (bridge_base_socket, bridge_handle, alive_rx) =
@@ -245,7 +246,7 @@ impl Service {
             image,
             env_vars,
             arguments,
-            require_tee,
+            confidentiality_policy,
             debug,
         )
         .await?;

--- a/crates/manager/src/sources/container.rs
+++ b/crates/manager/src/sources/container.rs
@@ -5,6 +5,7 @@ use crate::error::{Error, Result};
 use crate::rt::ResourceLimits;
 use crate::rt::service::Service;
 use crate::sources::types::ImageRegistryFetcher;
+use blueprint_client_tangle::ConfidentialityPolicy;
 use blueprint_core::info;
 use blueprint_runner::config::BlueprintEnvironment;
 use std::path::{Path, PathBuf};
@@ -70,7 +71,7 @@ impl BlueprintSourceHandler for ContainerSource {
         _id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
-        require_tee: bool,
+        confidentiality_policy: ConfidentialityPolicy,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,
@@ -84,7 +85,7 @@ impl BlueprintSourceHandler for ContainerSource {
             image.to_string_lossy().to_string(),
             env,
             args,
-            require_tee,
+            confidentiality_policy,
             false,
         )
         .await

--- a/crates/manager/src/sources/github.rs
+++ b/crates/manager/src/sources/github.rs
@@ -207,7 +207,7 @@ impl BlueprintSourceHandler for GithubBinaryFetcher {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
-        _require_tee: bool,
+        _confidentiality_policy: blueprint_client_tangle::ConfidentialityPolicy,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -4,6 +4,7 @@ use crate::error::{Error, Result};
 use crate::rt::ResourceLimits;
 use crate::rt::service::Service;
 use alloy_primitives::Address;
+use blueprint_client_tangle::ConfidentialityPolicy;
 use blueprint_runner::config::{BlueprintEnvironment, Protocol, SupportedChains};
 use std::io::Read;
 use std::path::{Path, PathBuf};
@@ -76,7 +77,7 @@ pub trait BlueprintSourceHandler: Send + Sync {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
-        require_tee: bool,
+        confidentiality_policy: ConfidentialityPolicy,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/crates/manager/src/sources/remote.rs
+++ b/crates/manager/src/sources/remote.rs
@@ -384,7 +384,7 @@ impl BlueprintSourceHandler for RemoteBinaryFetcher {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
-        _require_tee: bool,
+        _confidentiality_policy: blueprint_client_tangle::ConfidentialityPolicy,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,

--- a/crates/manager/src/sources/testing.rs
+++ b/crates/manager/src/sources/testing.rs
@@ -146,7 +146,7 @@ impl BlueprintSourceHandler for TestSourceFetcher {
         id: u32,
         env: BlueprintEnvVars,
         args: BlueprintArgs,
-        _require_tee: bool,
+        _confidentiality_policy: blueprint_client_tangle::ConfidentialityPolicy,
         sub_service_str: &str,
         cache_dir: &Path,
         runtime_dir: &Path,


### PR DESCRIPTION
## Summary
- recover and commit the previously uncommitted TEE follow-up changes from the dirty local checkout
- propagate confidentiality/execution-profile handling through Tangle metadata resolution and manager source selection
- wire source/container runtime plumbing updates across manager and CLI paths

## Verification
- cargo fmt --all
- cargo check -p blueprint-manager -p cargo-tangle -p blueprint-client-tangle
- pre-push hook checks (clippy + changed-crate tests) during push
