### PR TITLE
docs(engineering): add harness playbook and PR quality gates

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,42 @@
+## Summary
+
+- What changed and why?
+- Which user/operator/developer flow is affected?
+
+## Behavior Contract
+
+- Current behavior:
+- Intended behavior:
+- Invariants that must hold:
+- Failure mode choice (`fail-closed` or `fail-open`) and rationale:
+
+## Risk and Scope
+
+- Security impact:
+- Compatibility impact (APIs, metadata format, configs):
+- Migration notes (if any):
+- Rollback plan:
+
+## Verification
+
+List the exact commands you ran and outcomes.
+
+```bash
+# Example:
+# cargo test -p blueprint-manager
+```
+
+## Harness Evidence
+
+- Reproducer added/updated:
+- Negative-path coverage added:
+- Key assertions that prove the fix:
+
+## Checklist
+
+- [ ] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
+- [ ] I added or updated tests that reproduce the original issue.
+- [ ] I added or updated negative-path tests for invalid/missing/conflicting input.
+- [ ] I documented behavior or interface changes in docs/examples when needed.
+- [ ] I evaluated compatibility/migration impact explicitly.
+- [ ] I validated local formatting, clippy, and relevant tests.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,235 +1,93 @@
-# Contributing to Tangle Network's Blueprint Repository
+# Contributing to Blueprint
 
-Thank you for your interest in contributing to the Tangle Network Blueprint project! This document provides guidelines and instructions for contributing.
+This document defines how we ship high-confidence changes in this repository.
 
-## Table of Contents
+## Development Setup
 
-- [Getting Started](#getting-started)
-  - [Development Environment](#development-environment)
-  - [Project Structure](#project-structure)
-- [Making Contributions](#making-contributions)
-  - [Pull Request Process](#pull-request-process)
-  - [Commit Messages](#commit-messages)
-  - [Branch Naming](#branch-naming)
-- [Development Guidelines](#development-guidelines)
-  - [Code Style](#code-style)
-  - [Testing Requirements](#testing-requirements)
-  - [Documentation](#documentation)
-- [Review Process](#review-process)
-
-## Getting Started
-
-### Development Environment
-
-1. Install required dependencies:
+1. Install system dependencies.
    ```bash
    # Ubuntu/Debian
-   apt install build-essential cmake libssl-dev pkg-config
+   sudo apt update && sudo apt install build-essential cmake libssl-dev pkg-config
 
    # macOS
    brew install openssl cmake
    ```
-
-2. Set up Rust:
+2. Install Rust toolchain `1.88` (see `rust-toolchain.toml`).
    ```bash
-   # Install Rust
-   curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh
-
-   # Install specific toolchain
-   rustup install nightly-2024-10-13
-   rustup default nightly-2024-10-13
-   
-   # Install required components
+   rustup toolchain install 1.88
+   rustup default 1.88
    rustup component add rustfmt clippy rust-src
    ```
-
-3. Clone the repository:
+3. Clone and enter the repository.
    ```bash
    git clone https://github.com/tangle-network/blueprint.git
    cd blueprint
    ```
 
-### Project Structure
+## Repository Layout
 
-Please familiarize yourself with the project structure before contributing:
+- `cli/`: `cargo-tangle` CLI.
+- `crates/`: SDK crates (`core`, `manager`, `networking`, `stores`, `testing-utils`, etc.).
+- `examples/`: reference blueprints that must stay buildable.
+- `docs/`: long-form specifications, RFCs, and operator guides.
+- `.github/`: CI workflows and PR automation.
 
-- `cli/`: Command-line interface implementation
-- `crates/`: Core functionality modules
-- `.github/`: GitHub-specific files (workflows, templates)
+## Branches and Commits
 
-## Making Contributions
+- Branch prefixes:
+  - `feature/` for features
+  - `fix/` for bug fixes
+  - `docs/` for docs-only changes
+  - `refactor/` for internal code movement
+  - `test/` for test-only updates
+- Commit format: Conventional Commits (`feat(scope): ...`, `fix(scope): ...`).
 
-### Pull Request Process
+## Local Verification
 
-1. Fork the repository and create your feature branch:
-   ```bash
-   git checkout -b feature/your-feature-name
-   ```
+Run these before opening a PR:
 
-2. Make your changes, following our [development guidelines](#development-guidelines)
-
-3. Run the test suite:
-   ```bash
-   cargo test
-   ```
-
-4. Update documentation as needed
-
-5. Submit a pull request with a clear description of the changes and any relevant issue numbers
-
-### Commit Messages
-
-Follow the [Conventional Commits](https://www.conventionalcommits.org/) specification:
-
-```
-<type>(<scope>): <description>
-
-[optional body]
-
-[optional footer]
+```bash
+cargo fmt --all
+cargo clippy --workspace --all-targets --all-features -D warnings
+cargo test --workspace --all-features
+cargo build --workspace --all-features
 ```
 
-Types:
-- `feat`: New feature
-- `fix`: Bug fix
-- `docs`: Documentation changes
-- `style`: Code style changes (formatting, missing semi-colons, etc)
-- `refactor`: Code refactoring
-- `test`: Adding missing tests
-- `chore`: Maintenance tasks
+For focused iteration, use `cargo test -p <crate>`.
 
-Example:
-```
-feat(cli): add new blueprint deployment option
+## Harness Engineering Standard
 
-Added --dry-run flag to deployment command for testing deployments
-without actually submitting transactions.
+Blueprint follows a harness-first workflow for risky changes:
 
-Closes #123
-```
+1. Reproduce the problem with the smallest failing harness/test.
+2. State invariants and fail-closed behavior before implementing.
+3. Patch the code.
+4. Prove the fix with targeted tests and negative-path coverage.
+5. Document operational impact (operator/customer/developer) when behavior changes.
 
-### Branch Naming
+Use the playbook for full guidance:
 
-Use the following naming convention for branches:
-- `feature/`: New features
-- `fix/`: Bug fixes
-- `docs/`: Documentation updates
-- `refactor/`: Code refactoring
-- `test/`: Test-related changes
+- [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md)
 
-Example: `feature/blueprint-deployment`
+## Pull Request Requirements
 
-## Development Guidelines
+Every PR must:
 
-### Code Style
+1. Fill out the PR template completely.
+2. Include verification commands with pass/fail outcomes.
+3. Call out risks, migration notes, and behavior changes.
+4. Add tests for new logic and regressions.
+5. Update docs/examples when interfaces or flows change.
 
-1. Follow Rust style guidelines
-2. Use `rustfmt` for code formatting:
-   ```bash
-   cargo fmt
-   ```
-3. Run clippy for linting:
-   ```bash
-   cargo clippy -- -D warnings
-   ```
+Large changes may require an RFC in `docs/rfcs/`.
 
-### Testing Requirements
+## Review Expectations
 
-1. Write unit tests for new functionality
-2. Ensure existing tests pass
-3. Add integration tests for new features
-4. Include documentation tests for public APIs
-5. Use async/tokio for asynchronous tests
+Reviewers should prioritize:
 
-Example test structure:
-```rust
-#[cfg(test)]
-mod tests {
-    use super::*;
+1. Correctness and security regressions.
+2. Backward-compatibility and migration clarity.
+3. Test quality (including negative/fail-closed paths).
+4. Operational observability and rollback safety.
 
-    #[tokio::test]
-    async fn test_async_feature() {
-        // Async test implementation
-        let result = some_async_function().await;
-        assert!(result.is_ok());
-    }
-
-    #[tokio::test]
-    async fn test_error_handling() {
-        // Async error handling test
-        match failing_async_function().await {
-            Err(e) => assert_matches!(e, Error::Expected),
-            _ => panic!("Expected error"),
-        }
-    }
-
-    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
-    async fn test_concurrent_operations() {
-        // Test concurrent operations
-        let (result1, result2) = tokio::join!(
-            async_operation1(),
-            async_operation2()
-        );
-        assert!(result1.is_ok() && result2.is_ok());
-    }
-}
-```
-
-For mocking time-dependent tests:
-```rust
-use tokio::time::{self, Duration};
-
-#[tokio::test]
-async fn test_with_time() {
-    let mut interval = time::interval(Duration::from_secs(1));
-    
-    // First tick completes immediately
-    interval.tick().await;
-    
-    // Use time::sleep for testing timeouts
-    tokio::time::sleep(Duration::from_secs(2)).await;
-    
-    // Test after delay
-    assert!(some_condition);
-}
-```
-
-### Documentation
-
-1. Document all public APIs
-2. Include examples in documentation
-3. Update README.md if needed
-4. Add inline comments for complex logic
-
-Example documentation:
-```rust
-/// Deploys a blueprint to the network
-///
-/// # Arguments
-///
-/// * `name` - Name of the blueprint
-/// * `config` - Blueprint configuration
-///
-/// # Returns
-///
-/// * `Result<DeploymentId>` - Deployment identifier on success
-///
-/// # Examples
-///
-/// ```
-/// let result = deploy_blueprint("my_blueprint", config)?;
-/// ```
-pub fn deploy_blueprint(name: &str, config: Config) -> Result<DeploymentId> {
-    // Implementation
-}
-```
-
-## Review Process
-
-1. All PRs require at least one review from a maintainer
-2. CI checks must pass
-3. Documentation must be updated
-4. Changes should be tested on a development network
-5. Large changes may require multiple reviews
-
-For questions or clarifications, please open an issue or join our [Discord server](https://discord.com/invite/cv8EfJu3Tn).
+For questions, open an issue or use Discord: <https://discord.com/invite/cv8EfJu3Tn>.

--- a/README.md
+++ b/README.md
@@ -357,6 +357,10 @@ We welcome feedback and contributions to improve this blueprint.
 Please open an issue or submit a pull request on our GitHub repository.
 Please let us know if you fork this blueprint and extend it too!
 
+Contributor references:
+- [CONTRIBUTING.md](CONTRIBUTING.md)
+- [Harness Engineering Playbook](docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md)
+
 Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.

--- a/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md
+++ b/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md
@@ -1,0 +1,117 @@
+# Harness Engineering Playbook
+
+This playbook defines how Blueprint teams turn unclear problems into verified, production-safe changes.
+
+## Why This Exists
+
+We work in high-risk surfaces:
+
+- on-chain protocol integration
+- operator runtime orchestration
+- remote deployment and cloud provider behavior
+- TEE policy enforcement
+
+For these surfaces, "it compiles" is not enough. We require proof through targeted harnesses and explicit invariants.
+
+## Roles
+
+### Developer
+
+- Defines behavior contract and invariants.
+- Builds a minimal failing harness before or alongside the fix.
+- Implements fail-closed logic for security-sensitive paths.
+- Ships tests and docs with the code change.
+
+### Reviewer
+
+- Validates that the harness actually proves the claim.
+- Looks for downgrade paths, silent fallback, and hidden API breaks.
+- Challenges missing migration notes and weak test assertions.
+
+### Operator
+
+- Needs deterministic behavior, clear error states, and rollback guidance.
+- Must understand whether behavior is required, optional, or best-effort.
+
+## Design Contract (Required for Non-Trivial Changes)
+
+Capture these in PR text:
+
+1. Problem statement: what is wrong today?
+2. Intended behavior: what should happen after merge?
+3. Invariants: what must never happen?
+4. Failure model: fail-open vs fail-closed; why?
+5. Blast radius: which crates/roles/flows are affected?
+6. Migration: what old data/config/metadata remains in circulation?
+
+## Harness-First Workflow
+
+1. Write or identify a small failing harness.
+   - Unit test if logic is local.
+   - Integration test if behavior crosses crate boundaries.
+   - E2E harness only if protocol/runtime boundaries are involved.
+2. Ensure the harness fails for the current bug.
+3. Implement the fix.
+4. Extend harness with negative-path assertions.
+5. Verify with crate-scoped commands first, then workspace checks.
+
+## Checklists
+
+### Correctness Checklist
+
+- [ ] Behavior is deterministic (ordering, source selection, tie-breaks).
+- [ ] Input parsing rejects malformed structured payloads.
+- [ ] Legacy payload behavior is explicit (supported with mapping, or rejected loudly).
+- [ ] Defaults do not silently weaken security or policy.
+
+### Security Checklist
+
+- [ ] Sensitive policy changes are fail-closed where required.
+- [ ] No silent downgrade from stricter to weaker execution modes.
+- [ ] Runtime capability checks are explicit and auditable.
+- [ ] Error messages are actionable and non-ambiguous.
+
+### API and Compatibility Checklist
+
+- [ ] Public API changes are documented.
+- [ ] Compatibility aliases or migration notes are provided if needed.
+- [ ] Breaking behavior changes are intentional and clearly surfaced.
+
+### Test Checklist
+
+- [ ] Positive-path test(s) added or updated.
+- [ ] Negative-path test(s) added for invalid/missing/conflicting inputs.
+- [ ] Regression test reproduces the original bug.
+- [ ] Commands run are listed in the PR.
+
+### Operations Checklist
+
+- [ ] Operator behavior is documented for success and failure states.
+- [ ] Logs/metrics expose enough detail to debug in production.
+- [ ] Rollback or safe fallback path is defined when applicable.
+
+## Review Rubric for Automated Audits
+
+Treat AI/static audit output as input, not truth:
+
+1. Classify each finding:
+   - Real bug/regression
+   - Design tradeoff
+   - Out-of-scope/noise
+2. Require concrete evidence:
+   - file/line references
+   - reproducer or failing test
+   - explicit impact statement
+3. Respond with one of:
+   - fixed
+   - accepted with rationale
+   - rejected with evidence
+
+## Definition of Done
+
+A change is done when:
+
+- behavior contract is explicit,
+- tests prove both happy-path and negative-path behavior,
+- operational impacts are documented,
+- reviewers can verify claims without reverse engineering intent.


### PR DESCRIPTION
## Summary
- add a repository-level Harness Engineering playbook with explicit roles, design contract, checklists, and audit rubric
- add a GitHub pull request template that enforces behavior-contract, risk, verification, and harness evidence sections
- modernize `CONTRIBUTING.md` to match current toolchain and link harness-first workflow
- link the new contributor guidance from `README.md`

## Verification
- cargo fmt --all -- --check