### PR TITLE
chore: bump all crates to 0.2.0-alpha.1 for v2 EVM release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1004,7 +1004,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "apikey-blueprint-bin"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "apikey-blueprint-lib",
  "blueprint-sdk",
@@ -1015,7 +1015,7 @@ dependencies = [
 
 [[package]]
 name = "apikey-blueprint-lib"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -2561,7 +2561,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-anvil-testing-utils"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2598,7 +2598,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-auth"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2651,7 +2651,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-benchmarking"
-version = "0.1.0-alpha.5"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-std",
  "sysinfo 0.38.3",
@@ -2660,21 +2660,21 @@ dependencies = [
 
 [[package]]
 name = "blueprint-build-utils"
-version = "0.1.0-alpha.4"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-std",
 ]
 
 [[package]]
 name = "blueprint-chain-setup"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-chain-setup-anvil",
 ]
 
 [[package]]
 name = "blueprint-chain-setup-anvil"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-provider",
@@ -2695,7 +2695,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-core"
-version = "0.1.0-alpha.4"
+version = "0.2.0-alpha.1"
 dependencies = [
  "auto_impl",
  "blueprint-std",
@@ -2704,7 +2704,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-eigenlayer"
-version = "0.1.0-alpha.20"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2732,7 +2732,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-evm"
-version = "0.1.0-alpha.7"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -2763,7 +2763,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-tangle"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2797,7 +2797,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-clients"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-client-core",
  "blueprint-client-eigenlayer",
@@ -2809,7 +2809,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-context-derive"
-version = "0.1.0-alpha.13"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -2826,7 +2826,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-contexts"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-client-tangle",
  "blueprint-clients",
@@ -2839,7 +2839,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core"
-version = "0.1.0-alpha.5"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-sdk",
  "bytes",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core-testing-utils"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-auth",
  "blueprint-clients",
@@ -2874,7 +2874,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto"
-version = "0.1.0-alpha.14"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-crypto-bls",
  "blueprint-crypto-bn254",
@@ -2888,7 +2888,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bls"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 dependencies = [
  "ark-serialize 0.5.0",
  "blueprint-crypto-core",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bn254"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2927,7 +2927,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-core"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-std",
  "clap",
@@ -2937,7 +2937,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-ed25519"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -2951,7 +2951,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-hashing"
-version = "0.1.0-alpha.5"
+version = "0.2.0-alpha.1"
 dependencies = [
  "argon2",
  "blake3",
@@ -2963,7 +2963,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-k256"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -2979,7 +2979,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-sr25519"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -2993,7 +2993,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-extra"
-version = "0.1.0-alpha.13"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -3049,7 +3049,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-evm-extra"
-version = "0.1.0-alpha.8"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -3080,7 +3080,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-faas"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3108,7 +3108,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-gossip-primitives"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3130,7 +3130,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-keystore"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3169,7 +3169,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-macros"
-version = "0.1.0-alpha.7"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-sdk",
  "proc-macro2",
@@ -3184,7 +3184,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager"
-version = "0.3.0-alpha.23"
+version = "0.4.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3273,7 +3273,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager-bridge"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-auth",
  "blueprint-core",
@@ -3291,21 +3291,21 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metrics"
-version = "0.1.0-alpha.3"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-metrics-rpc-calls",
 ]
 
 [[package]]
 name = "blueprint-metrics-rpc-calls"
-version = "0.1.0-alpha.3"
+version = "0.2.0-alpha.1"
 dependencies = [
  "metrics",
 ]
 
 [[package]]
 name = "blueprint-networking"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "bincode",
@@ -3331,7 +3331,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking-agg-sig-gossip-extension"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 dependencies = [
  "bincode",
  "bitvec",
@@ -3360,7 +3360,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking-round-based-extension"
-version = "0.1.0-alpha.16"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-core",
  "blueprint-crypto",
@@ -3388,7 +3388,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-pricing-engine"
-version = "0.2.6"
+version = "0.3.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-producers-extra"
-version = "0.1.0-alpha.6"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-core",
  "chrono",
@@ -3460,7 +3460,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-profiling"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3476,7 +3476,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-qos"
-version = "0.1.0-alpha.6"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3526,7 +3526,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-remote-providers"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3586,7 +3586,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-router"
-version = "0.1.0-alpha.6"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-core",
  "blueprint-sdk",
@@ -3602,7 +3602,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-runner"
-version = "0.1.0-alpha.20"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3647,7 +3647,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-sdk"
-version = "0.1.0-alpha.22"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy",
  "alloy-json-abi",
@@ -3690,7 +3690,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-std"
-version = "0.1.0-alpha.4"
+version = "0.2.0-alpha.1"
 dependencies = [
  "colored",
  "num-traits",
@@ -3701,7 +3701,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-store-local-database"
-version = "0.1.0-alpha.7"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-std",
  "serde",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-stores"
-version = "0.1.0-alpha.8"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-store-local-database",
  "document-features",
@@ -3721,7 +3721,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -3752,7 +3752,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-extra"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -3794,7 +3794,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tee"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -3825,7 +3825,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-testing-utils"
-version = "0.1.0-alpha.20"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
@@ -3834,7 +3834,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-webhooks"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "axum",
  "blueprint-core",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-x402"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4143,7 +4143,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-tangle"
-version = "0.4.0-alpha.23"
+version = "0.5.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",
@@ -7044,7 +7044,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-tangle-blueprint"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -7691,7 +7691,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-bin"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-faas",
  "blueprint-profiling",
@@ -7705,7 +7705,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-eigenlayer"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7754,7 +7754,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-lib"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -10198,7 +10198,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-blueprint-bin"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "blueprint-sdk",
  "oauth-blueprint-lib",
@@ -10209,7 +10209,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-blueprint-lib"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15573,7 +15573,7 @@ dependencies = [
 
 [[package]]
 name = "x402-blueprint"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 dependencies = [
  "alloy-contract",
  "alloy-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -147,100 +147,100 @@ broken_intra_doc_links = "deny"
 
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
-blueprint-sdk = { version = "0.1.0-alpha.22", path = "./crates/sdk", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.1", path = "./crates/sdk", default-features = false }
 tnt-core-bindings = "0.10.4"
 
 # Job system
-blueprint-core = { version = "0.1.0-alpha.5", path = "crates/core", default-features = false }
-blueprint-router = { version = "0.1.0-alpha.6", path = "crates/router", default-features = false }
-blueprint-runner = { version = "0.1.0-alpha.20", path = "crates/runner", default-features = false }
+blueprint-core = { version = "0.2.0-alpha.1", path = "crates/core", default-features = false }
+blueprint-router = { version = "0.2.0-alpha.1", path = "crates/router", default-features = false }
+blueprint-runner = { version = "0.2.0-alpha.1", path = "crates/runner", default-features = false }
 
 # Extras
-blueprint-tangle-extra = { version = "0.1.1", path = "crates/tangle-extra", features = ["std"] }
-blueprint-evm-extra = { version = "0.1.0-alpha.8", path = "crates/evm-extra", default-features = false }
-blueprint-eigenlayer-extra = { version = "0.1.0-alpha.13", path = "crates/eigenlayer-extra", default-features = false }
-blueprint-producers-extra = { version = "0.1.0-alpha.6", path = "crates/producers-extra", default-features = false }
-blueprint-tangle-aggregation-svc = { version = "0.1.0", path = "crates/tangle-aggregation-svc", default-features = false }
+blueprint-tangle-extra = { version = "0.2.0-alpha.1", path = "crates/tangle-extra", features = ["std"] }
+blueprint-evm-extra = { version = "0.2.0-alpha.1", path = "crates/evm-extra", default-features = false }
+blueprint-eigenlayer-extra = { version = "0.2.0-alpha.1", path = "crates/eigenlayer-extra", default-features = false }
+blueprint-producers-extra = { version = "0.2.0-alpha.1", path = "crates/producers-extra", default-features = false }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.1", path = "crates/tangle-aggregation-svc", default-features = false }
 
 # Blueprint utils
-blueprint-manager = { version = "0.3.0-alpha.23", path = "./crates/manager", default-features = false }
-blueprint-manager-bridge = { version = "0.1.0-alpha.9", path = "./crates/manager/bridge", default-features = false }
-blueprint-remote-providers = { version = "0.1.0-alpha.1", path = "./crates/blueprint-remote-providers", default-features = false }
-blueprint-faas = { version = "0.1.0-alpha.1", path = "./crates/blueprint-faas", default-features = false }
-blueprint-profiling = { version = "0.1.0-alpha.1", path = "./crates/blueprint-profiling", default-features = false }
+blueprint-manager = { version = "0.4.0-alpha.1", path = "./crates/manager", default-features = false }
+blueprint-manager-bridge = { version = "0.2.0-alpha.1", path = "./crates/manager/bridge", default-features = false }
+blueprint-remote-providers = { version = "0.2.0-alpha.1", path = "./crates/blueprint-remote-providers", default-features = false }
+blueprint-faas = { version = "0.2.0-alpha.1", path = "./crates/blueprint-faas", default-features = false }
+blueprint-profiling = { version = "0.2.0-alpha.1", path = "./crates/blueprint-profiling", default-features = false }
 
 # Example blueprints
-incredible-squaring-blueprint-lib = { version = "0.1.1", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
-blueprint-build-utils = { version = "0.1.0-alpha.4", path = "./crates/build-utils", default-features = false }
-blueprint-auth = { version = "0.1.0-alpha.10", path = "./crates/auth", default-features = false }
+incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.1", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
+blueprint-build-utils = { version = "0.2.0-alpha.1", path = "./crates/build-utils", default-features = false }
+blueprint-auth = { version = "0.2.0-alpha.1", path = "./crates/auth", default-features = false }
 
 # Chain Setup
-blueprint-chain-setup = { version = "0.1.0-alpha.21", path = "./crates/chain-setup", default-features = false }
-blueprint-chain-setup-anvil = { version = "0.1.0-alpha.21", path = "./crates/chain-setup/anvil", default-features = false }
+blueprint-chain-setup = { version = "0.2.0-alpha.1", path = "./crates/chain-setup", default-features = false }
+blueprint-chain-setup-anvil = { version = "0.2.0-alpha.1", path = "./crates/chain-setup/anvil", default-features = false }
 
 # Crypto
-blueprint-crypto-core = { version = "0.1.0-alpha.9", path = "./crates/crypto/core", default-features = false }
-blueprint-crypto-k256 = { version = "0.1.0-alpha.10", path = "./crates/crypto/k256", default-features = false }
-blueprint-crypto-sr25519 = { version = "0.1.0-alpha.10", path = "./crates/crypto/sr25519", default-features = false }
-blueprint-crypto-ed25519 = { version = "0.1.0-alpha.10", path = "./crates/crypto/ed25519", default-features = false }
-blueprint-crypto-hashing = { version = "0.1.0-alpha.5", path = "./crates/crypto/hashing", default-features = false }
-blueprint-crypto-bls = { version = "0.1.0-alpha.9", path = "./crates/crypto/bls", default-features = false }
-blueprint-crypto-bn254 = { version = "0.1.0-alpha.9", path = "./crates/crypto/bn254", default-features = false }
-blueprint-crypto = { version = "0.1.0-alpha.14", path = "./crates/crypto", default-features = false }
+blueprint-crypto-core = { version = "0.2.0-alpha.1", path = "./crates/crypto/core", default-features = false }
+blueprint-crypto-k256 = { version = "0.2.0-alpha.1", path = "./crates/crypto/k256", default-features = false }
+blueprint-crypto-sr25519 = { version = "0.2.0-alpha.1", path = "./crates/crypto/sr25519", default-features = false }
+blueprint-crypto-ed25519 = { version = "0.2.0-alpha.1", path = "./crates/crypto/ed25519", default-features = false }
+blueprint-crypto-hashing = { version = "0.2.0-alpha.1", path = "./crates/crypto/hashing", default-features = false }
+blueprint-crypto-bls = { version = "0.2.0-alpha.1", path = "./crates/crypto/bls", default-features = false }
+blueprint-crypto-bn254 = { version = "0.2.0-alpha.1", path = "./crates/crypto/bn254", default-features = false }
+blueprint-crypto = { version = "0.2.0-alpha.1", path = "./crates/crypto", default-features = false }
 
 # Clients
-blueprint-clients = { version = "0.1.0-alpha.21", path = "./crates/clients", default-features = false }
-blueprint-client-core = { version = "0.1.0-alpha.4", path = "./crates/clients/core", default-features = false }
-blueprint-client-eigenlayer = { version = "0.1.0-alpha.20", path = "./crates/clients/eigenlayer", default-features = false }
-blueprint-client-evm = { version = "0.1.0-alpha.7", path = "./crates/clients/evm", default-features = false }
-blueprint-client-tangle = { version = "0.1.1", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-contexts = { version = "0.1.0-alpha.21", path = "./crates/contexts", default-features = false }
+blueprint-clients = { version = "0.2.0-alpha.1", path = "./crates/clients", default-features = false }
+blueprint-client-core = { version = "0.2.0-alpha.1", path = "./crates/clients/core", default-features = false }
+blueprint-client-eigenlayer = { version = "0.2.0-alpha.1", path = "./crates/clients/eigenlayer", default-features = false }
+blueprint-client-evm = { version = "0.2.0-alpha.1", path = "./crates/clients/evm", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.1", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-contexts = { version = "0.2.0-alpha.1", path = "./crates/contexts", default-features = false }
 
 # Pricing Engine
-blueprint-pricing-engine = { version = "0.2.6", path = "./crates/pricing-engine", default-features = false }
+blueprint-pricing-engine = { version = "0.3.0-alpha.1", path = "./crates/pricing-engine", default-features = false }
 
 # TEE Support
-blueprint-tee = { version = "0.1.0-alpha.1", path = "./crates/tee", default-features = false }
+blueprint-tee = { version = "0.2.0-alpha.1", path = "./crates/tee", default-features = false }
 
 # x402 Payment Gateway
-blueprint-x402 = { version = "0.1.0-alpha.1", path = "./crates/x402", default-features = false }
+blueprint-x402 = { version = "0.2.0-alpha.1", path = "./crates/x402", default-features = false }
 
 # Webhook Producer
-blueprint-webhooks = { version = "0.1.0-alpha.1", path = "./crates/webhooks", default-features = false }
+blueprint-webhooks = { version = "0.2.0-alpha.1", path = "./crates/webhooks", default-features = false }
 
 # Macros
-blueprint-macros = { version = "0.1.0-alpha.7", path = "./crates/macros", default-features = false }
-blueprint-context-derive = { version = "0.1.0-alpha.13", path = "./crates/macros/context-derive", default-features = false }
+blueprint-macros = { version = "0.2.0-alpha.1", path = "./crates/macros", default-features = false }
+blueprint-context-derive = { version = "0.2.0-alpha.1", path = "./crates/macros/context-derive", default-features = false }
 
 # Quality of Service
-blueprint-qos = { version = "0.1.0-alpha.6", path = "./crates/qos", default-features = false }
+blueprint-qos = { version = "0.2.0-alpha.1", path = "./crates/qos", default-features = false }
 
 # Stores
-blueprint-stores = { version = "0.1.0-alpha.8", path = "./crates/stores", default-features = false }
-blueprint-store-local-database = { version = "0.1.0-alpha.7", path = "./crates/stores/local-database", default-features = false }
+blueprint-stores = { version = "0.2.0-alpha.1", path = "./crates/stores", default-features = false }
+blueprint-store-local-database = { version = "0.2.0-alpha.1", path = "./crates/stores/local-database", default-features = false }
 rocksdb = { version = "0.21.0", default-features = false }
 
 # SDK
-blueprint-keystore = { version = "0.1.0-alpha.15", path = "./crates/keystore", default-features = false }
-blueprint-std = { version = "0.1.0-alpha.4", path = "./crates/std", default-features = false }
+blueprint-keystore = { version = "0.2.0-alpha.1", path = "./crates/keystore", default-features = false }
+blueprint-std = { version = "0.2.0-alpha.1", path = "./crates/std", default-features = false }
 
 # P2P
-blueprint-networking = { version = "0.1.0-alpha.15", path = "./crates/networking", default-features = false }
-blueprint-networking-round-based-extension = { version = "0.1.0-alpha.16", path = "./crates/networking/extensions/round-based", default-features = false }
-blueprint-networking-agg-sig-gossip-extension = { version = "0.1.0-alpha.15", path = "./crates/networking/extensions/agg-sig-gossip", default-features = false }
-blueprint-gossip-primitives = { version = "0.1.0-alpha.15", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
+blueprint-networking = { version = "0.2.0-alpha.1", path = "./crates/networking", default-features = false }
+blueprint-networking-round-based-extension = { version = "0.2.0-alpha.1", path = "./crates/networking/extensions/round-based", default-features = false }
+blueprint-networking-agg-sig-gossip-extension = { version = "0.2.0-alpha.1", path = "./crates/networking/extensions/agg-sig-gossip", default-features = false }
+blueprint-gossip-primitives = { version = "0.2.0-alpha.1", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
 
 # Testing utilities
-blueprint-testing-utils = { version = "0.1.0-alpha.20", path = "./crates/testing-utils", default-features = false }
-blueprint-core-testing-utils = { version = "0.1.0-alpha.21", path = "./crates/testing-utils/core", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.1.0-alpha.21", path = "./crates/testing-utils/anvil", default-features = false }
-blueprint-eigenlayer-testing-utils = { version = "0.1.0-alpha.21", path = "./crates/testing-utils/eigenlayer", default-features = false }
+blueprint-testing-utils = { version = "0.2.0-alpha.1", path = "./crates/testing-utils", default-features = false }
+blueprint-core-testing-utils = { version = "0.2.0-alpha.1", path = "./crates/testing-utils/core", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.1", path = "./crates/testing-utils/anvil", default-features = false }
+blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.1", path = "./crates/testing-utils/eigenlayer", default-features = false }
 
 # Metrics
-blueprint-metrics = { version = "0.1.0-alpha.3", path = "./crates/metrics", default-features = false }
-blueprint-metrics-rpc-calls = { version = "0.1.0-alpha.3", path = "./crates/metrics/rpc-calls", default-features = false }
+blueprint-metrics = { version = "0.2.0-alpha.1", path = "./crates/metrics", default-features = false }
+blueprint-metrics-rpc-calls = { version = "0.2.0-alpha.1", path = "./crates/metrics/rpc-calls", default-features = false }
 
-cargo-tangle = { version = "0.4.0-alpha.23", path = "./cli", default-features = false }
+cargo-tangle = { version = "0.5.0-alpha.1", path = "./cli", default-features = false }
 cargo_metadata = { version = "0.18.1" }
 bollard = { version = "0.18.0", features = ["ssl"] }
 

--- a/blueprint_apikey.json
+++ b/blueprint_apikey.json
@@ -32,5 +32,5 @@
   },
   "master_revision": "Latest",
   "name": "apikey-blueprint",
-  "version": "0.1.0"
+  "version": "0.2.0-alpha.1"
 }

--- a/blueprint_oauth.json
+++ b/blueprint_oauth.json
@@ -33,5 +33,5 @@
   },
   "master_revision": "Latest",
   "name": "oauth-blueprint",
-  "version": "0.1.0"
+  "version": "0.2.0-alpha.1"
 }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tangle"
-version = "0.4.0-alpha.23"
+version = "0.5.0-alpha.1"
 description = "A command-line tool to create and deploy blueprints on Tangle Network"
 authors.workspace = true
 edition.workspace = true

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-auth"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 description = "Blueprint HTTP/WS Authentication"
 authors.workspace = true
 edition.workspace = true

--- a/crates/benchmarking/Cargo.toml
+++ b/crates/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-benchmarking"
-version = "0.1.0-alpha.5"
+version = "0.2.0-alpha.1"
 description = "Utilities for benchmarking Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/blueprint-faas/Cargo.toml
+++ b/crates/blueprint-faas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-faas"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 description = "FaaS provider integrations for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/blueprint-profiling/Cargo.toml
+++ b/crates/blueprint-profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-profiling"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2021"
 authors.workspace = true
 homepage.workspace = true

--- a/crates/blueprint-remote-providers/Cargo.toml
+++ b/crates/blueprint-remote-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-remote-providers"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-build-utils"
-version = "0.1.0-alpha.4"
+version = "0.2.0-alpha.1"
 description = "Tangle Blueprint build utils"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/Cargo.toml
+++ b/crates/chain-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "Chain setup utilities for use with Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/anvil/Cargo.toml
+++ b/crates/chain-setup/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup-anvil"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "Anvil-specific chain setup utilities"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/Cargo.toml
+++ b/crates/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-clients"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "Metapackage for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/core/Cargo.toml
+++ b/crates/clients/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-core"
-version = "0.1.0-alpha.4"
+version = "0.2.0-alpha.1"
 description = "Core primitives for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/eigenlayer/Cargo.toml
+++ b/crates/clients/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-eigenlayer"
-version = "0.1.0-alpha.20"
+version = "0.2.0-alpha.1"
 description = "Eigenlayer client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/evm/Cargo.toml
+++ b/crates/clients/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-evm"
-version = "0.1.0-alpha.7"
+version = "0.2.0-alpha.1"
 description = "EVM client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-tangle"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-contexts"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "Context providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core"
-version = "0.1.0-alpha.5"
+version = "0.2.0-alpha.1"
 description = "Blueprint SDK Core functionality"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto"
-version = "0.1.0-alpha.14"
+version = "0.2.0-alpha.1"
 description = "Crypto metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-bls"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 description = "tnt-bls crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-bn254"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 description = "Ark BN254 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/core/Cargo.toml
+++ b/crates/crypto/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-core"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 description = "Core crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/ed25519/Cargo.toml
+++ b/crates/crypto/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-ed25519"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 description = "Zebra ed25519 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/hashing/Cargo.toml
+++ b/crates/crypto/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-hashing"
-version = "0.1.0-alpha.5"
+version = "0.2.0-alpha.1"
 description = "Hashing and key derivation primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/k256/Cargo.toml
+++ b/crates/crypto/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-k256"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 description = "k256 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/sr25519/Cargo.toml
+++ b/crates/crypto/sr25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-sr25519"
-version = "0.1.0-alpha.10"
+version = "0.2.0-alpha.1"
 description = "Schnorrkel sr25519 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/eigenlayer-extra/Cargo.toml
+++ b/crates/eigenlayer-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-extra"
-version = "0.1.0-alpha.13"
+version = "0.2.0-alpha.1"
 description = "Eigenlayer extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/evm-extra/Cargo.toml
+++ b/crates/evm-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-evm-extra"
-version = "0.1.0-alpha.8"
+version = "0.2.0-alpha.1"
 description = "EVM extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-keystore"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 description = "Keystore for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-macros"
-version = "0.1.0-alpha.7"
+version = "0.2.0-alpha.1"
 description = "Macros for the Tangle Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/macros/context-derive/Cargo.toml
+++ b/crates/macros/context-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-context-derive"
-version = "0.1.0-alpha.13"
+version = "0.2.0-alpha.1"
 description = "Procedural macros for deriving Context Extension traits from blueprint-sdk"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager"
-version = "0.3.0-alpha.23"
+version = "0.4.0-alpha.1"
 description = "Tangle Blueprint manager and Runner"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/bridge/Cargo.toml
+++ b/crates/manager/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager-bridge"
-version = "0.1.0-alpha.9"
+version = "0.2.0-alpha.1"
 description = "Bridge for Blueprint manager to service communication"
 authors.workspace = true
 edition.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metrics"
-version = "0.1.0-alpha.3"
+version = "0.2.0-alpha.1"
 description = "Metrics metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/metrics/rpc-calls/Cargo.toml
+++ b/crates/metrics/rpc-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metrics-rpc-calls"
-version = "0.1.0-alpha.3"
+version = "0.2.0-alpha.1"
 description = "RPC call metrics for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/Cargo.toml
+++ b/crates/networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 description = "Networking utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/agg-sig-gossip/Cargo.toml
+++ b/crates/networking/extensions/agg-sig-gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking-agg-sig-gossip-extension"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 description = "Signature aggregation extension for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/gossip-primitives/Cargo.toml
+++ b/crates/networking/extensions/gossip-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-gossip-primitives"
-version = "0.1.0-alpha.15"
+version = "0.2.0-alpha.1"
 description = "Reusable gossip protocol primitives for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/round-based/Cargo.toml
+++ b/crates/networking/extensions/round-based/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking-round-based-extension"
-version = "0.1.0-alpha.16"
+version = "0.2.0-alpha.1"
 description = "round-based integration for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/pricing-engine/Cargo.toml
+++ b/crates/pricing-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-pricing-engine"
-version = "0.2.6"
+version = "0.3.0-alpha.1"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/producers-extra/Cargo.toml
+++ b/crates/producers-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-producers-extra"
-version = "0.1.0-alpha.6"
+version = "0.2.0-alpha.1"
 description = "Additional job call producers for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/qos/Cargo.toml
+++ b/crates/qos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-qos"
-version = "0.1.0-alpha.6"
+version = "0.2.0-alpha.1"
 description = "Quality of Service (QoS) module for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-router"
-version = "0.1.0-alpha.6"
+version = "0.2.0-alpha.1"
 description = "Job routing utilities for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-runner"
-version = "0.1.0-alpha.20"
+version = "0.2.0-alpha.1"
 description = "Runner for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-sdk"
-version = "0.1.0-alpha.22"
+version = "0.2.0-alpha.1"
 description = "Blueprint SDK for building decentralized and distributed services."
 authors.workspace = true
 edition.workspace = true

--- a/crates/std/Cargo.toml
+++ b/crates/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-std"
-version = "0.1.0-alpha.4"
+version = "0.2.0-alpha.1"
 description = "Re-exports of core/std for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/stores/Cargo.toml
+++ b/crates/stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-stores"
-version = "0.1.0-alpha.8"
+version = "0.2.0-alpha.1"
 description = "Storage providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/stores/local-database/Cargo.toml
+++ b/crates/stores/local-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-store-local-database"
-version = "0.1.0-alpha.7"
+version = "0.2.0-alpha.1"
 description = "Local database storage provider for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/tangle-aggregation-svc/Cargo.toml
+++ b/crates/tangle-aggregation-svc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2021"
 description = "BLS signature aggregation service for Tangle v2"
 license = "MIT OR Apache-2.0"

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-extra"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 description = "Producer/Consumer extras for Tangle blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/tee/Cargo.toml
+++ b/crates/tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tee"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 description = "First-class TEE (Trusted Execution Environment) support for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-testing-utils"
-version = "0.1.0-alpha.20"
+version = "0.2.0-alpha.1"
 description = "Testing utilities metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/anvil/Cargo.toml
+++ b/crates/testing-utils/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-anvil-testing-utils"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "Anvil testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/core/Cargo.toml
+++ b/crates/testing-utils/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core-testing-utils"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "Core primitives for testing Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.1.0-alpha.21"
+version = "0.2.0-alpha.1"
 description = "EigenLayer-specific testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-webhooks"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 description = "Webhook producer for Blueprint SDK — trigger jobs from external HTTP events"
 authors.workspace = true
 edition.workspace = true

--- a/crates/x402/Cargo.toml
+++ b/crates/x402/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-x402"
-version = "0.1.0-alpha.1"
+version = "0.2.0-alpha.1"
 description = "x402 payment gateway for Blueprint SDK — cross-chain EVM settlement for job execution"
 authors.workspace = true
 edition.workspace = true

--- a/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apikey-blueprint-bin"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apikey-blueprint-lib"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/examples/hello-tangle/Cargo.toml
+++ b/examples/hello-tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-tangle-blueprint"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/incredible-squaring-eigenlayer/Cargo.toml
+++ b/examples/incredible-squaring-eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-eigenlayer"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 description = "A Simple Blueprint to demo how blueprints work on Eigenlayer"
 authors.workspace = true
 edition.workspace = true

--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -11,14 +11,14 @@ rust-version = "1.88"
 [workspace.dependencies]
 incredible-squaring-blueprint-lib = { path = "incredible-squaring-lib" }
 
-blueprint-sdk = { version = "0.1.0-alpha.22", path = "../../crates/sdk", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.1.0-alpha.21", path = "../../crates/testing-utils/anvil", default-features = false }
-blueprint-client-tangle = { version = "0.1.1", path = "../../crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-tangle-extra = { version = "0.1.1", path = "../../crates/tangle-extra", features = ["std"] }
-blueprint-tangle-aggregation-svc = { version = "0.1.0", path = "../../crates/tangle-aggregation-svc", default-features = false }
-blueprint-crypto-bn254 = { version = "0.1.0-alpha.9", path = "../../crates/crypto/bn254", default-features = false }
-blueprint-crypto-core = { version = "0.1.0-alpha.9", path = "../../crates/crypto/core", default-features = false }
-blueprint-faas = { version = "0.1.0-alpha.1", path = "../../crates/blueprint-faas", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.1", path = "../../crates/sdk", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.1", path = "../../crates/testing-utils/anvil", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.1", path = "../../crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-tangle-extra = { version = "0.2.0-alpha.1", path = "../../crates/tangle-extra", features = ["std"] }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.1", path = "../../crates/tangle-aggregation-svc", default-features = false }
+blueprint-crypto-bn254 = { version = "0.2.0-alpha.1", path = "../../crates/crypto/bn254", default-features = false }
+blueprint-crypto-core = { version = "0.2.0-alpha.1", path = "../../crates/crypto/core", default-features = false }
+blueprint-faas = { version = "0.2.0-alpha.1", path = "../../crates/blueprint-faas", default-features = false }
 blueprint-profiling = { version = "0.1.0-alpha.1", path = "../../crates/blueprint-profiling", default-features = false }
 tokio = { version = "^1", default-features = false }
 tower = { version = "0.5.2", default-features = false }

--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -19,7 +19,7 @@ blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.1", path = "../../cr
 blueprint-crypto-bn254 = { version = "0.2.0-alpha.1", path = "../../crates/crypto/bn254", default-features = false }
 blueprint-crypto-core = { version = "0.2.0-alpha.1", path = "../../crates/crypto/core", default-features = false }
 blueprint-faas = { version = "0.2.0-alpha.1", path = "../../crates/blueprint-faas", default-features = false }
-blueprint-profiling = { version = "0.1.0-alpha.1", path = "../../crates/blueprint-profiling", default-features = false }
+blueprint-profiling = { version = "0.2.0-alpha.1", path = "../../crates/blueprint-profiling", default-features = false }
 tokio = { version = "^1", default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }

--- a/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-bin"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
-version = "0.1.1"
+version = "0.2.0-alpha.1"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-blueprint-bin"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-blueprint-lib"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition = "2024"
 
 [dependencies]

--- a/examples/x402-blueprint/Cargo.toml
+++ b/examples/x402-blueprint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x402-blueprint"
-version = "0.1.0"
+version = "0.2.0-alpha.1"
 edition.workspace = true
 license.workspace = true
 publish = false


### PR DESCRIPTION
## Summary

Bump all 64 workspace crate versions for v2 EVM migration. Gives release-plz a clean baseline at current commit so it can publish without diffing against stale substrate-based tags from Nov 2025.

## Change Class

- Selected class: Class C
- Why this class: Version bumps across all 64 workspace crates. No code changes, but multiple crates touched.

## Behavior Contract

- All crate versions bumped from 0.1.x to 0.2.0-alpha.1
- blueprint-manager: 0.3.x to 0.4.0-alpha.1
- cargo-tangle: 0.4.x to 0.5.0-alpha.1
- blueprint-pricing-engine: 0.2.x to 0.3.0-alpha.1
- No runtime behavior changes

## Risk And Scope

- Scope: 69 files, version strings only
- Risk: Low — version bumps, no code changes
- Required for release-plz to create clean tags and publish to crates.io

## Verification

```bash
cargo check
```

## Harness Evidence

Full workspace compiles clean (64 crates).

## Checklist

- [x] All 64 crates compile
- [x] No code changes
- [x] Internal dep version references updated