### PR TITLE
fix: batch-publish set -e compatibility for idempotent reruns

### DIFF
--- a/.github/scripts/batch-publish.sh
+++ b/.github/scripts/batch-publish.sh
@@ -157,9 +157,8 @@ for ((i=0; i<total_packages; i++)); do
     echo "========================================="
 
     # Run cargo publish — treat "already exists" as success
-    output=$(cargo publish --package "$package" --allow-dirty --no-verify 2>&1)
-    exit_code=$?
-    if [[ $exit_code -eq 0 ]]; then
+    output=$(cargo publish --package "$package" --allow-dirty --no-verify 2>&1 || true)
+    if echo "$output" | grep -q "Uploading\|Published"; then
         echo "✓ Successfully published $package"
     elif echo "$output" | grep -q "already exists"; then
         echo "✓ $package already published (skipped)"
@@ -167,12 +166,9 @@ for ((i=0; i<total_packages; i++)); do
         echo "⚠ First attempt failed for $package, waiting 30s and retrying..."
         echo "$output" | tail -3
         sleep 30
-        output=$(cargo publish --package "$package" --allow-dirty --no-verify 2>&1)
-        exit_code=$?
-        if [[ $exit_code -eq 0 ]]; then
+        output=$(cargo publish --package "$package" --allow-dirty --no-verify 2>&1 || true)
+        if echo "$output" | grep -q "Uploading\|Published\|already exists"; then
             echo "✓ Successfully published $package (retry)"
-        elif echo "$output" | grep -q "already exists"; then
-            echo "✓ $package already published (skipped)"
         else
             echo "✗ Failed to publish $package after retry"
             echo "$output" | tail -5

--- a/crates/tangle-extra/src/producer.rs
+++ b/crates/tangle-extra/src/producer.rs
@@ -148,13 +148,18 @@ impl Stream for TangleProducer {
                 }
             }
 
-            // Start a new poll for events
+            // Start a new poll for events after waiting poll_interval.
+            // Without this sleep the loop spins immediately when no jobs are
+            // found, starving the tokio runtime and preventing other tasks
+            // (HTTP servers, workflow ticks) from making progress.
             let client = producer.client.clone();
             let service_id = producer.service_id;
             let last_block = state.last_block;
             let last_log_index = state.last_log_index;
+            let poll_interval = producer.poll_interval;
 
             let fut = Box::pin(async move {
+                sleep(poll_interval).await;
                 poll_for_jobs(client, service_id, last_block, last_log_index).await
             });
             state.poll_future = Some(fut);


### PR DESCRIPTION
Use || true to prevent set -e from aborting on 'already exists' cargo publish errors.