### PR TITLE
feat: security hardening + staking_contract rename + alpha.3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1009,7 +1009,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "apikey-blueprint-bin"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "apikey-blueprint-lib",
  "blueprint-sdk",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "apikey-blueprint-lib"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -2509,7 +2509,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-anvil-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-consensus",
  "alloy-eips",
@@ -2547,7 +2547,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-auth"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2601,7 +2601,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-benchmarking"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-std",
  "sysinfo 0.38.4",
@@ -2611,7 +2611,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-build-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-std",
  "workspace-hack",
@@ -2619,7 +2619,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-chain-setup-anvil",
  "workspace-hack",
@@ -2627,7 +2627,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup-anvil"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-provider",
@@ -2649,7 +2649,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-core"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "auto_impl",
  "blueprint-std",
@@ -2659,7 +2659,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-eigenlayer"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2688,7 +2688,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-evm"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-consensus",
  "alloy-json-rpc",
@@ -2720,7 +2720,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-tangle"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -2755,7 +2755,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-clients"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-client-core",
  "blueprint-client-eigenlayer",
@@ -2768,7 +2768,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-context-derive"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-network",
  "alloy-provider",
@@ -2786,7 +2786,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-contexts"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-client-tangle",
  "blueprint-clients",
@@ -2800,7 +2800,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-sdk",
  "bytes",
@@ -2817,7 +2817,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-auth",
  "blueprint-clients",
@@ -2837,7 +2837,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-crypto-bls",
  "blueprint-crypto-bn254",
@@ -2852,7 +2852,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bls"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "ark-serialize 0.5.0",
  "blueprint-crypto-core",
@@ -2872,7 +2872,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bn254"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -2895,7 +2895,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-core"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-std",
  "clap",
@@ -2906,7 +2906,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-ed25519"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -2922,7 +2922,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-hashing"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "argon2",
  "blake3",
@@ -2935,7 +2935,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-k256"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -2953,7 +2953,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-sr25519"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -2969,7 +2969,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3004,7 +3004,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -3027,7 +3027,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-evm-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-consensus",
  "alloy-network",
@@ -3059,7 +3059,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-faas"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3088,7 +3088,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-gossip-primitives"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3111,7 +3111,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-keystore"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3151,7 +3151,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-macros"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-sdk",
  "proc-macro2",
@@ -3258,7 +3258,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager-bridge"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-auth",
  "blueprint-core",
@@ -3277,7 +3277,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metrics"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-metrics-rpc-calls",
  "workspace-hack",
@@ -3285,7 +3285,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metrics-rpc-calls"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "metrics",
  "workspace-hack",
@@ -3293,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-primitives",
  "bincode",
@@ -3320,7 +3320,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking-agg-sig-gossip-extension"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "bincode",
  "bitvec",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking-round-based-extension"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-core",
  "blueprint-crypto",
@@ -3440,7 +3440,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-producers-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-core",
  "chrono",
@@ -3453,7 +3453,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-profiling"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3470,7 +3470,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-qos"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -3521,7 +3521,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-remote-providers"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3582,7 +3582,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-router"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-core",
  "blueprint-sdk",
@@ -3599,7 +3599,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-runner"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3644,7 +3644,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-sdk"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy",
  "alloy-json-abi",
@@ -3688,7 +3688,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-std"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "colored",
  "num-traits",
@@ -3700,7 +3700,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-store-local-database"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-std",
  "serde",
@@ -3712,7 +3712,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-stores"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-store-local-database",
  "document-features",
@@ -3722,7 +3722,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-network",
@@ -3754,7 +3754,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy",
  "alloy-network",
@@ -3797,7 +3797,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tee"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -3829,7 +3829,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
@@ -3839,7 +3839,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-webhooks"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "axum",
  "blueprint-core",
@@ -3867,7 +3867,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-x402"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4158,7 +4158,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-tangle"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",
@@ -7043,7 +7043,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-tangle-blueprint"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -7669,7 +7669,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-bin"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-faas",
  "blueprint-profiling",
@@ -7684,7 +7684,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-eigenlayer"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-consensus",
  "alloy-contract",
@@ -7734,7 +7734,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-lib"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -10264,7 +10264,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-blueprint-bin"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "blueprint-sdk",
  "oauth-blueprint-lib",
@@ -10276,7 +10276,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-blueprint-lib"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-network",
  "alloy-primitives",
@@ -15961,7 +15961,7 @@ dependencies = [
 
 [[package]]
 name = "x402-blueprint"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
  "alloy-network",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,100 +125,100 @@ broken_intra_doc_links = "deny"
 
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
-blueprint-sdk = { version = "0.2.0-alpha.2", path = "./crates/sdk", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.3", path = "./crates/sdk", default-features = false }
 tnt-core-bindings = { version = "0.10.7", git = "https://github.com/tangle-network/tnt-core.git", tag = "v0.10.7" }
 
 # Job system
-blueprint-core = { version = "0.2.0-alpha.2", path = "crates/core", default-features = false }
-blueprint-router = { version = "0.2.0-alpha.2", path = "crates/router", default-features = false }
-blueprint-runner = { version = "0.2.0-alpha.2", path = "crates/runner", default-features = false }
+blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }
+blueprint-router = { version = "0.2.0-alpha.3", path = "crates/router", default-features = false }
+blueprint-runner = { version = "0.2.0-alpha.3", path = "crates/runner", default-features = false }
 
 # Extras
-blueprint-tangle-extra = { version = "0.2.0-alpha.2", path = "crates/tangle-extra", features = ["std"] }
-blueprint-evm-extra = { version = "0.2.0-alpha.2", path = "crates/evm-extra", default-features = false }
-blueprint-eigenlayer-extra = { version = "0.2.0-alpha.2", path = "crates/eigenlayer-extra", default-features = false }
-blueprint-producers-extra = { version = "0.2.0-alpha.2", path = "crates/producers-extra", default-features = false }
-blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.2", path = "crates/tangle-aggregation-svc", default-features = false }
+blueprint-tangle-extra = { version = "0.2.0-alpha.3", path = "crates/tangle-extra", features = ["std"] }
+blueprint-evm-extra = { version = "0.2.0-alpha.3", path = "crates/evm-extra", default-features = false }
+blueprint-eigenlayer-extra = { version = "0.2.0-alpha.3", path = "crates/eigenlayer-extra", default-features = false }
+blueprint-producers-extra = { version = "0.2.0-alpha.3", path = "crates/producers-extra", default-features = false }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.3", path = "crates/tangle-aggregation-svc", default-features = false }
 
 # Blueprint utils
 blueprint-manager = { version = "0.4.0-alpha.2", path = "./crates/manager", default-features = false }
-blueprint-manager-bridge = { version = "0.2.0-alpha.2", path = "./crates/manager/bridge", default-features = false }
-blueprint-remote-providers = { version = "0.2.0-alpha.2", path = "./crates/blueprint-remote-providers", default-features = false }
-blueprint-faas = { version = "0.2.0-alpha.2", path = "./crates/blueprint-faas", default-features = false }
-blueprint-profiling = { version = "0.2.0-alpha.2", path = "./crates/blueprint-profiling", default-features = false }
+blueprint-manager-bridge = { version = "0.2.0-alpha.3", path = "./crates/manager/bridge", default-features = false }
+blueprint-remote-providers = { version = "0.2.0-alpha.3", path = "./crates/blueprint-remote-providers", default-features = false }
+blueprint-faas = { version = "0.2.0-alpha.3", path = "./crates/blueprint-faas", default-features = false }
+blueprint-profiling = { version = "0.2.0-alpha.3", path = "./crates/blueprint-profiling", default-features = false }
 
 # Example blueprints
-incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.2", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
-blueprint-build-utils = { version = "0.2.0-alpha.2", path = "./crates/build-utils", default-features = false }
-blueprint-auth = { version = "0.2.0-alpha.2", path = "./crates/auth", default-features = false }
+incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.3", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
+blueprint-build-utils = { version = "0.2.0-alpha.3", path = "./crates/build-utils", default-features = false }
+blueprint-auth = { version = "0.2.0-alpha.3", path = "./crates/auth", default-features = false }
 
 # Chain Setup
-blueprint-chain-setup = { version = "0.2.0-alpha.2", path = "./crates/chain-setup", default-features = false }
-blueprint-chain-setup-anvil = { version = "0.2.0-alpha.2", path = "./crates/chain-setup/anvil", default-features = false }
+blueprint-chain-setup = { version = "0.2.0-alpha.3", path = "./crates/chain-setup", default-features = false }
+blueprint-chain-setup-anvil = { version = "0.2.0-alpha.3", path = "./crates/chain-setup/anvil", default-features = false }
 
 # Crypto
-blueprint-crypto-core = { version = "0.2.0-alpha.2", path = "./crates/crypto/core", default-features = false }
-blueprint-crypto-k256 = { version = "0.2.0-alpha.2", path = "./crates/crypto/k256", default-features = false }
-blueprint-crypto-sr25519 = { version = "0.2.0-alpha.2", path = "./crates/crypto/sr25519", default-features = false }
-blueprint-crypto-ed25519 = { version = "0.2.0-alpha.2", path = "./crates/crypto/ed25519", default-features = false }
-blueprint-crypto-hashing = { version = "0.2.0-alpha.2", path = "./crates/crypto/hashing", default-features = false }
-blueprint-crypto-bls = { version = "0.2.0-alpha.2", path = "./crates/crypto/bls", default-features = false }
-blueprint-crypto-bn254 = { version = "0.2.0-alpha.2", path = "./crates/crypto/bn254", default-features = false }
-blueprint-crypto = { version = "0.2.0-alpha.2", path = "./crates/crypto", default-features = false }
+blueprint-crypto-core = { version = "0.2.0-alpha.3", path = "./crates/crypto/core", default-features = false }
+blueprint-crypto-k256 = { version = "0.2.0-alpha.3", path = "./crates/crypto/k256", default-features = false }
+blueprint-crypto-sr25519 = { version = "0.2.0-alpha.3", path = "./crates/crypto/sr25519", default-features = false }
+blueprint-crypto-ed25519 = { version = "0.2.0-alpha.3", path = "./crates/crypto/ed25519", default-features = false }
+blueprint-crypto-hashing = { version = "0.2.0-alpha.3", path = "./crates/crypto/hashing", default-features = false }
+blueprint-crypto-bls = { version = "0.2.0-alpha.3", path = "./crates/crypto/bls", default-features = false }
+blueprint-crypto-bn254 = { version = "0.2.0-alpha.3", path = "./crates/crypto/bn254", default-features = false }
+blueprint-crypto = { version = "0.2.0-alpha.3", path = "./crates/crypto", default-features = false }
 
 # Clients
-blueprint-clients = { version = "0.2.0-alpha.2", path = "./crates/clients", default-features = false }
-blueprint-client-core = { version = "0.2.0-alpha.2", path = "./crates/clients/core", default-features = false }
-blueprint-client-eigenlayer = { version = "0.2.0-alpha.2", path = "./crates/clients/eigenlayer", default-features = false }
-blueprint-client-evm = { version = "0.2.0-alpha.2", path = "./crates/clients/evm", default-features = false }
-blueprint-client-tangle = { version = "0.2.0-alpha.2", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-contexts = { version = "0.2.0-alpha.2", path = "./crates/contexts", default-features = false }
+blueprint-clients = { version = "0.2.0-alpha.3", path = "./crates/clients", default-features = false }
+blueprint-client-core = { version = "0.2.0-alpha.3", path = "./crates/clients/core", default-features = false }
+blueprint-client-eigenlayer = { version = "0.2.0-alpha.3", path = "./crates/clients/eigenlayer", default-features = false }
+blueprint-client-evm = { version = "0.2.0-alpha.3", path = "./crates/clients/evm", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.3", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-contexts = { version = "0.2.0-alpha.3", path = "./crates/contexts", default-features = false }
 
 # Pricing Engine
 blueprint-pricing-engine = { version = "0.3.0-alpha.2", path = "./crates/pricing-engine", default-features = false }
 
 # TEE Support
-blueprint-tee = { version = "0.2.0-alpha.2", path = "./crates/tee", default-features = false }
+blueprint-tee = { version = "0.2.0-alpha.3", path = "./crates/tee", default-features = false }
 
 # x402 Payment Gateway
-blueprint-x402 = { version = "0.2.0-alpha.2", path = "./crates/x402", default-features = false }
+blueprint-x402 = { version = "0.2.0-alpha.3", path = "./crates/x402", default-features = false }
 
 # Webhook Producer
-blueprint-webhooks = { version = "0.2.0-alpha.2", path = "./crates/webhooks", default-features = false }
+blueprint-webhooks = { version = "0.2.0-alpha.3", path = "./crates/webhooks", default-features = false }
 
 # Macros
-blueprint-macros = { version = "0.2.0-alpha.2", path = "./crates/macros", default-features = false }
-blueprint-context-derive = { version = "0.2.0-alpha.2", path = "./crates/macros/context-derive", default-features = false }
+blueprint-macros = { version = "0.2.0-alpha.3", path = "./crates/macros", default-features = false }
+blueprint-context-derive = { version = "0.2.0-alpha.3", path = "./crates/macros/context-derive", default-features = false }
 
 # Quality of Service
-blueprint-qos = { version = "0.2.0-alpha.2", path = "./crates/qos", default-features = false }
+blueprint-qos = { version = "0.2.0-alpha.3", path = "./crates/qos", default-features = false }
 
 # Stores
-blueprint-stores = { version = "0.2.0-alpha.2", path = "./crates/stores", default-features = false }
-blueprint-store-local-database = { version = "0.2.0-alpha.2", path = "./crates/stores/local-database", default-features = false }
+blueprint-stores = { version = "0.2.0-alpha.3", path = "./crates/stores", default-features = false }
+blueprint-store-local-database = { version = "0.2.0-alpha.3", path = "./crates/stores/local-database", default-features = false }
 rocksdb = { version = "0.21.0", default-features = false }
 
 # SDK
-blueprint-keystore = { version = "0.2.0-alpha.2", path = "./crates/keystore", default-features = false }
-blueprint-std = { version = "0.2.0-alpha.2", path = "./crates/std", default-features = false }
+blueprint-keystore = { version = "0.2.0-alpha.3", path = "./crates/keystore", default-features = false }
+blueprint-std = { version = "0.2.0-alpha.3", path = "./crates/std", default-features = false }
 
 # P2P
-blueprint-networking = { version = "0.2.0-alpha.2", path = "./crates/networking", default-features = false }
-blueprint-networking-round-based-extension = { version = "0.2.0-alpha.2", path = "./crates/networking/extensions/round-based", default-features = false }
-blueprint-networking-agg-sig-gossip-extension = { version = "0.2.0-alpha.2", path = "./crates/networking/extensions/agg-sig-gossip", default-features = false }
-blueprint-gossip-primitives = { version = "0.2.0-alpha.2", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
+blueprint-networking = { version = "0.2.0-alpha.3", path = "./crates/networking", default-features = false }
+blueprint-networking-round-based-extension = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/round-based", default-features = false }
+blueprint-networking-agg-sig-gossip-extension = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/agg-sig-gossip", default-features = false }
+blueprint-gossip-primitives = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
 
 # Testing utilities
-blueprint-testing-utils = { version = "0.2.0-alpha.2", path = "./crates/testing-utils", default-features = false }
-blueprint-core-testing-utils = { version = "0.2.0-alpha.2", path = "./crates/testing-utils/core", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.2.0-alpha.2", path = "./crates/testing-utils/anvil", default-features = false }
-blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.2", path = "./crates/testing-utils/eigenlayer", default-features = false }
+blueprint-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils", default-features = false }
+blueprint-core-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils/core", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils/anvil", default-features = false }
+blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils/eigenlayer", default-features = false }
 
 # Metrics
-blueprint-metrics = { version = "0.2.0-alpha.2", path = "./crates/metrics", default-features = false }
-blueprint-metrics-rpc-calls = { version = "0.2.0-alpha.2", path = "./crates/metrics/rpc-calls", default-features = false }
+blueprint-metrics = { version = "0.2.0-alpha.3", path = "./crates/metrics", default-features = false }
+blueprint-metrics-rpc-calls = { version = "0.2.0-alpha.3", path = "./crates/metrics/rpc-calls", default-features = false }
 
-cargo-tangle = { version = "0.5.0-alpha.2", path = "./cli", default-features = false }
+cargo-tangle = { version = "0.5.0-alpha.3", path = "./cli", default-features = false }
 cargo_metadata = { version = "0.18.1" }
 bollard = { version = "0.18.0", features = ["ssl"] }
 

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tangle"
-version = "0.5.0-alpha.2"
+version = "0.5.0-alpha.3"
 description = "A command-line tool to create and deploy blueprints on Tangle Network"
 authors.workspace = true
 edition.workspace = true

--- a/cli/src/command/harness/config.rs
+++ b/cli/src/command/harness/config.rs
@@ -286,10 +286,7 @@ impl HarnessConfig {
             };
 
             if !config_path.exists() {
-                return Err(eyre!(
-                    "no harness.toml found in {}",
-                    dir.display()
-                ));
+                return Err(eyre!("no harness.toml found in {}", dir.display()));
             }
 
             let mut config = Self::load(Some(&config_path))?;

--- a/cli/src/command/harness/orchestrator.rs
+++ b/cli/src/command/harness/orchestrator.rs
@@ -188,13 +188,24 @@ impl Orchestrator {
             // that the orchestrator sets above. A malicious harness.toml in compose
             // mode could redirect an operator to attacker-controlled contracts.
             const PROTOCOL_VARS: &[&str] = &[
-                "HTTP_RPC_URL", "WS_RPC_URL", "KEYSTORE_URI", "DATA_DIR",
-                "BLUEPRINT_ID", "SERVICE_ID", "TANGLE_CONTRACT",
-                "STAKING_CONTRACT", "STATUS_REGISTRY_CONTRACT", "PROTOCOL", "TEST_MODE",
+                "HTTP_RPC_URL",
+                "WS_RPC_URL",
+                "KEYSTORE_URI",
+                "DATA_DIR",
+                "BLUEPRINT_ID",
+                "SERVICE_ID",
+                "TANGLE_CONTRACT",
+                "STAKING_CONTRACT",
+                "STATUS_REGISTRY_CONTRACT",
+                "PROTOCOL",
+                "TEST_MODE",
             ];
             for (k, v) in &bp.env {
                 if PROTOCOL_VARS.contains(&k.as_str()) {
-                    eprintln!("[{}] WARNING: ignoring bp.env override of protocol var {k}", bp.name);
+                    eprintln!(
+                        "[{}] WARNING: ignoring bp.env override of protocol var {k}",
+                        bp.name
+                    );
                     continue;
                 }
                 cmd.env(k, v);
@@ -474,11 +485,13 @@ async fn register_with_router(
     let models_value: Vec<serde_json::Value> = spec
         .models
         .iter()
-        .map(|m| serde_json::json!({
-            "modelId": m.id,
-            "inputPrice": m.input_price,
-            "outputPrice": m.output_price,
-        }))
+        .map(|m| {
+            serde_json::json!({
+                "modelId": m.id,
+                "inputPrice": m.input_price,
+                "outputPrice": m.output_price,
+            })
+        })
         .collect();
 
     let body = serde_json::to_string(&serde_json::json!({
@@ -486,7 +499,8 @@ async fn register_with_router(
         "endpointUrl": endpoint_url,
         "blueprintType": blueprint_type,
         "models": models_value,
-    })).unwrap_or_default();
+    }))
+    .unwrap_or_default();
 
     // Parse the router URL to get host:port
     let url = router_url

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-auth"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Blueprint HTTP/WS Authentication"
 authors.workspace = true
 edition.workspace = true

--- a/crates/benchmarking/Cargo.toml
+++ b/crates/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-benchmarking"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Utilities for benchmarking Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/blueprint-faas/Cargo.toml
+++ b/crates/blueprint-faas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-faas"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "FaaS provider integrations for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/blueprint-profiling/Cargo.toml
+++ b/crates/blueprint-profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-profiling"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Profiling utilities for Tangle Blueprints"
 edition = "2021"
 authors.workspace = true

--- a/crates/blueprint-remote-providers/Cargo.toml
+++ b/crates/blueprint-remote-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-remote-providers"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Remote service providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-build-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Tangle Blueprint build utils"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/Cargo.toml
+++ b/crates/chain-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Chain setup utilities for use with Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/anvil/Cargo.toml
+++ b/crates/chain-setup/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup-anvil"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Anvil-specific chain setup utilities"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/Cargo.toml
+++ b/crates/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-clients"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Metapackage for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/core/Cargo.toml
+++ b/crates/clients/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-core"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Core primitives for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/eigenlayer/Cargo.toml
+++ b/crates/clients/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-eigenlayer"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Eigenlayer client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/evm/Cargo.toml
+++ b/crates/clients/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-evm"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "EVM client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-tangle"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-contexts"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Context providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Blueprint SDK Core functionality"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Crypto metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-bls"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "tnt-bls crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-bn254"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Ark BN254 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/core/Cargo.toml
+++ b/crates/crypto/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-core"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Core crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/ed25519/Cargo.toml
+++ b/crates/crypto/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-ed25519"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Zebra ed25519 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/hashing/Cargo.toml
+++ b/crates/crypto/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-hashing"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Hashing and key derivation primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/k256/Cargo.toml
+++ b/crates/crypto/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-k256"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "k256 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/sr25519/Cargo.toml
+++ b/crates/crypto/sr25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-sr25519"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Schnorrkel sr25519 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/eigenlayer-extra/Cargo.toml
+++ b/crates/eigenlayer-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Eigenlayer extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/evm-extra/Cargo.toml
+++ b/crates/evm-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-evm-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "EVM extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-keystore"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Keystore for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-macros"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Macros for the Tangle Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/macros/context-derive/Cargo.toml
+++ b/crates/macros/context-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-context-derive"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Procedural macros for deriving Context Extension traits from blueprint-sdk"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/bridge/Cargo.toml
+++ b/crates/manager/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager-bridge"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Bridge for Blueprint manager to service communication"
 authors.workspace = true
 edition.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metrics"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Metrics metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/metrics/rpc-calls/Cargo.toml
+++ b/crates/metrics/rpc-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metrics-rpc-calls"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "RPC call metrics for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/Cargo.toml
+++ b/crates/networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Networking utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/agg-sig-gossip/Cargo.toml
+++ b/crates/networking/extensions/agg-sig-gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking-agg-sig-gossip-extension"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Signature aggregation extension for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/gossip-primitives/Cargo.toml
+++ b/crates/networking/extensions/gossip-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-gossip-primitives"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Reusable gossip protocol primitives for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/round-based/Cargo.toml
+++ b/crates/networking/extensions/round-based/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking-round-based-extension"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "round-based integration for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/producers-extra/Cargo.toml
+++ b/crates/producers-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-producers-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Additional job call producers for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/qos/Cargo.toml
+++ b/crates/qos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-qos"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Quality of Service (QoS) module for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-router"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Job routing utilities for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-runner"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Runner for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-sdk"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Blueprint SDK for building decentralized and distributed services."
 authors.workspace = true
 edition.workspace = true

--- a/crates/std/Cargo.toml
+++ b/crates/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-std"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Re-exports of core/std for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/stores/Cargo.toml
+++ b/crates/stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-stores"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Storage providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/stores/local-database/Cargo.toml
+++ b/crates/stores/local-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-store-local-database"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Local database storage provider for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/tangle-aggregation-svc/Cargo.toml
+++ b/crates/tangle-aggregation-svc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2021"
 description = "BLS signature aggregation service for Tangle v2"
 license = "MIT OR Apache-2.0"

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-extra"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Producer/Consumer extras for Tangle blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/tee/Cargo.toml
+++ b/crates/tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tee"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "First-class TEE (Trusted Execution Environment) support for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Testing utilities metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/anvil/Cargo.toml
+++ b/crates/testing-utils/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-anvil-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Anvil testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/core/Cargo.toml
+++ b/crates/testing-utils/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Core primitives for testing Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "EigenLayer-specific testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-webhooks"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "Webhook producer for Blueprint SDK — trigger jobs from external HTTP events"
 authors.workspace = true
 edition.workspace = true

--- a/crates/x402/Cargo.toml
+++ b/crates/x402/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-x402"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "x402 payment gateway for Blueprint SDK — cross-chain EVM settlement for job execution"
 authors.workspace = true
 edition.workspace = true

--- a/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apikey-blueprint-bin"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2024"
 
 [dependencies]

--- a/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apikey-blueprint-lib"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2024"
 
 [dependencies]

--- a/examples/hello-tangle/Cargo.toml
+++ b/examples/hello-tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-tangle-blueprint"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/incredible-squaring-eigenlayer/Cargo.toml
+++ b/examples/incredible-squaring-eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-eigenlayer"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 description = "A Simple Blueprint to demo how blueprints work on Eigenlayer"
 authors.workspace = true
 edition.workspace = true

--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -11,15 +11,15 @@ rust-version = "1.88"
 [workspace.dependencies]
 incredible-squaring-blueprint-lib = { path = "incredible-squaring-lib" }
 
-blueprint-sdk = { version = "0.2.0-alpha.2", path = "../../crates/sdk", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.2.0-alpha.2", path = "../../crates/testing-utils/anvil", default-features = false }
-blueprint-client-tangle = { version = "0.2.0-alpha.2", path = "../../crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-tangle-extra = { version = "0.2.0-alpha.2", path = "../../crates/tangle-extra", features = ["std"] }
-blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.2", path = "../../crates/tangle-aggregation-svc", default-features = false }
-blueprint-crypto-bn254 = { version = "0.2.0-alpha.2", path = "../../crates/crypto/bn254", default-features = false }
-blueprint-crypto-core = { version = "0.2.0-alpha.2", path = "../../crates/crypto/core", default-features = false }
-blueprint-faas = { version = "0.2.0-alpha.2", path = "../../crates/blueprint-faas", default-features = false }
-blueprint-profiling = { version = "0.2.0-alpha.2", path = "../../crates/blueprint-profiling", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.3", path = "../../crates/sdk", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.3", path = "../../crates/testing-utils/anvil", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.3", path = "../../crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-tangle-extra = { version = "0.2.0-alpha.3", path = "../../crates/tangle-extra", features = ["std"] }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.3", path = "../../crates/tangle-aggregation-svc", default-features = false }
+blueprint-crypto-bn254 = { version = "0.2.0-alpha.3", path = "../../crates/crypto/bn254", default-features = false }
+blueprint-crypto-core = { version = "0.2.0-alpha.3", path = "../../crates/crypto/core", default-features = false }
+blueprint-faas = { version = "0.2.0-alpha.3", path = "../../crates/blueprint-faas", default-features = false }
+blueprint-profiling = { version = "0.2.0-alpha.3", path = "../../crates/blueprint-profiling", default-features = false }
 tokio = { version = "^1", default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }

--- a/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-bin"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-blueprint-bin"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2024"
 
 [dependencies]

--- a/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-blueprint-lib"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition = "2024"
 
 [dependencies]

--- a/examples/x402-blueprint/Cargo.toml
+++ b/examples/x402-blueprint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x402-blueprint"
-version = "0.2.0-alpha.2"
+version = "0.2.0-alpha.3"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/x402-blueprint/tests/x402_e2e_anvil.rs
+++ b/examples/x402-blueprint/tests/x402_e2e_anvil.rs
@@ -28,19 +28,19 @@ mod e2e {
     use tokio::task::JoinHandle;
 
     use blueprint_runner::BackgroundService;
+    use blueprint_x402::X402Gateway;
     use blueprint_x402::config::{AcceptedToken, X402Config, X402InvocationMode};
     use blueprint_x402::producer::X402Producer;
-    use blueprint_x402::X402Gateway;
     use rust_decimal::Decimal;
 
     // x402 EIP-3009 client + facilitator
-    use x402_chain_eip155::v1_eip155_exact::{
-        Eip3009SigningParams, sign_erc3009_authorization,
-        PaymentRequirementsExtra, V1Eip155ExactFacilitator,
-    };
     use x402_chain_eip155::chain::{
-        Eip155ChainReference, Eip155ChainProvider,
+        Eip155ChainProvider, Eip155ChainReference,
         config::{Eip155ChainConfig, Eip155ChainConfigInner, RpcConfig},
+    };
+    use x402_chain_eip155::v1_eip155_exact::{
+        Eip3009SigningParams, PaymentRequirementsExtra, V1Eip155ExactFacilitator,
+        sign_erc3009_authorization,
     };
     use x402_types::chain::FromConfig;
     use x402_types::config::LiteralOrEnv;
@@ -63,51 +63,97 @@ mod e2e {
 
     // ─── Anvil Fork ─────────────────────────────────────────────────
 
-    struct AnvilFork { child: Child, port: u16 }
+    struct AnvilFork {
+        child: Child,
+        port: u16,
+    }
 
     impl AnvilFork {
         fn spawn() -> Self {
             let port = free_port();
-            let base_rpc = std::env::var("BASE_RPC_URL")
-                .unwrap_or_else(|_| "https://mainnet.base.org".into());
+            let base_rpc =
+                std::env::var("BASE_RPC_URL").unwrap_or_else(|_| "https://mainnet.base.org".into());
             let child = StdCommand::new("anvil")
-                .args(["--fork-url", &base_rpc, "--port", &port.to_string(),
-                       "--silent", "--auto-impersonate"])
-                .stdout(Stdio::null()).stderr(Stdio::null())
-                .spawn().expect("anvil must be installed");
+                .args([
+                    "--fork-url",
+                    &base_rpc,
+                    "--port",
+                    &port.to_string(),
+                    "--silent",
+                    "--auto-impersonate",
+                ])
+                .stdout(Stdio::null())
+                .stderr(Stdio::null())
+                .spawn()
+                .expect("anvil must be installed");
             std::thread::sleep(Duration::from_secs(5));
             Self { child, port }
         }
-        fn rpc_url(&self) -> String { format!("http://127.0.0.1:{}", self.port) }
+        fn rpc_url(&self) -> String {
+            format!("http://127.0.0.1:{}", self.port)
+        }
     }
 
     impl Drop for AnvilFork {
-        fn drop(&mut self) { let _ = self.child.kill(); let _ = self.child.wait(); }
+        fn drop(&mut self) {
+            let _ = self.child.kill();
+            let _ = self.child.wait();
+        }
     }
 
     fn free_port() -> u16 {
         let l = TcpListener::bind("127.0.0.1:0").unwrap();
-        let p = l.local_addr().unwrap().port(); drop(l); p
+        let p = l.local_addr().unwrap().port();
+        drop(l);
+        p
     }
 
     async fn fund_payer(rpc_url: &str, amount: U256) {
         let p = ProviderBuilder::new().connect_http(rpc_url.parse().unwrap());
-        p.raw_request::<_, ()>("anvil_impersonateAccount".into(), [format!("{:#x}", USDC_WHALE)]).await.unwrap();
-        let tx = TransactionRequest::default().from(USDC_WHALE).to(USDC_ADDRESS)
-            .input(IERC20::transferCall { to: PAYER, amount }.abi_encode().into());
-        p.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
-        p.raw_request::<_, ()>("anvil_stopImpersonatingAccount".into(), [format!("{:#x}", USDC_WHALE)]).await.unwrap();
+        p.raw_request::<_, ()>(
+            "anvil_impersonateAccount".into(),
+            [format!("{:#x}", USDC_WHALE)],
+        )
+        .await
+        .unwrap();
+        let tx = TransactionRequest::default()
+            .from(USDC_WHALE)
+            .to(USDC_ADDRESS)
+            .input(
+                IERC20::transferCall { to: PAYER, amount }
+                    .abi_encode()
+                    .into(),
+            );
+        p.send_transaction(tx)
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+        p.raw_request::<_, ()>(
+            "anvil_stopImpersonatingAccount".into(),
+            [format!("{:#x}", USDC_WHALE)],
+        )
+        .await
+        .unwrap();
     }
 
     async fn usdc_balance(rpc_url: &str, addr: Address) -> U256 {
         let p = ProviderBuilder::new().connect_http(rpc_url.parse().unwrap());
-        IERC20::new(USDC_ADDRESS, &p).balanceOf(addr).call().await.unwrap()
+        IERC20::new(USDC_ADDRESS, &p)
+            .balanceOf(addr)
+            .call()
+            .await
+            .unwrap()
     }
 
     // ─── Real Facilitator Server ────────────────────────────────────
 
     async fn start_real_facilitator(rpc_url: &str) -> (JoinHandle<()>, u16) {
-        use axum::{Json, Router, routing::{get, post}};
+        use axum::{
+            Json, Router,
+            routing::{get, post},
+        };
 
         let port = free_port();
 
@@ -117,9 +163,9 @@ mod e2e {
             inner: Eip155ChainConfigInner {
                 eip1559: true,
                 flashblocks: false,
-                signers: vec![
-                    LiteralOrEnv::from_literal(format!("0x{OPERATOR_KEY}").parse().unwrap()),
-                ],
+                signers: vec![LiteralOrEnv::from_literal(
+                    format!("0x{OPERATOR_KEY}").parse().unwrap(),
+                )],
                 rpc: vec![RpcConfig {
                     http: LiteralOrEnv::from_literal(rpc_url.parse().unwrap()),
                     rate_limit: None,
@@ -130,7 +176,8 @@ mod e2e {
 
         // Create the real EVM provider + facilitator
         let provider = x402_chain_eip155::chain::Eip155ChainProvider::from_config(&config)
-            .await.expect("build Eip155ChainProvider");
+            .await
+            .expect("build Eip155ChainProvider");
         let facilitator = Arc::new(V1Eip155ExactFacilitator::new(provider));
 
         let fac_verify = facilitator.clone();
@@ -145,58 +192,80 @@ mod e2e {
             let mut sanitized = msg;
             for prefix in &["http://", "https://", "ws://", "wss://"] {
                 while let Some(start) = sanitized.find(prefix) {
-                    let end = sanitized[start..].find(|c: char| c.is_whitespace() || c == ',' || c == ')' || c == '"')
+                    let end = sanitized[start..]
+                        .find(|c: char| c.is_whitespace() || c == ',' || c == ')' || c == '"')
                         .map(|e| start + e)
                         .unwrap_or(sanitized.len());
                     sanitized.replace_range(start..end, "[REDACTED_URL]");
                 }
             }
             // Truncate to prevent massive revert data from being returned
-            if sanitized.len() > 500 { sanitized[..500].to_string() } else { sanitized }
+            if sanitized.len() > 500 {
+                sanitized[..500].to_string()
+            } else {
+                sanitized
+            }
         }
 
         let app = Router::new()
             // Body size limit: 64KB max to prevent OOM from deeply nested JSON
             .layer(axum::extract::DefaultBodyLimit::max(64 * 1024))
-            .route("/verify", post(move |Json(body): Json<serde_json::Value>| {
-                let fac = fac_verify.clone();
-                async move {
-                    let raw = serde_json::value::RawValue::from_string(
-                        serde_json::to_string(&body).unwrap()
-                    ).unwrap();
-                    let req = x402_types::proto::VerifyRequest::from(raw);
-                    match fac.verify(&req).await {
-                        Ok(r) => (axum::http::StatusCode::OK, Json(r.0)),
-                        Err(e) => (axum::http::StatusCode::OK, Json(serde_json::json!({
-                            "isValid": false, "invalidReason": sanitize_error(&e)
-                        }))),
+            .route(
+                "/verify",
+                post(move |Json(body): Json<serde_json::Value>| {
+                    let fac = fac_verify.clone();
+                    async move {
+                        let raw = serde_json::value::RawValue::from_string(
+                            serde_json::to_string(&body).unwrap(),
+                        )
+                        .unwrap();
+                        let req = x402_types::proto::VerifyRequest::from(raw);
+                        match fac.verify(&req).await {
+                            Ok(r) => (axum::http::StatusCode::OK, Json(r.0)),
+                            Err(e) => (
+                                axum::http::StatusCode::OK,
+                                Json(serde_json::json!({
+                                    "isValid": false, "invalidReason": sanitize_error(&e)
+                                })),
+                            ),
+                        }
                     }
-                }
-            }))
-            .route("/settle", post(move |Json(body): Json<serde_json::Value>| {
-                let fac = fac_settle.clone();
-                async move {
-                    let raw = serde_json::value::RawValue::from_string(
-                        serde_json::to_string(&body).unwrap()
-                    ).unwrap();
-                    let req = x402_types::proto::SettleRequest::from(raw);
-                    match fac.settle(&req).await {
-                        Ok(r) => (axum::http::StatusCode::OK, Json(r.0)),
-                        Err(e) => (axum::http::StatusCode::OK, Json(serde_json::json!({
-                            "success": false, "errorReason": sanitize_error(&e)
-                        }))),
+                }),
+            )
+            .route(
+                "/settle",
+                post(move |Json(body): Json<serde_json::Value>| {
+                    let fac = fac_settle.clone();
+                    async move {
+                        let raw = serde_json::value::RawValue::from_string(
+                            serde_json::to_string(&body).unwrap(),
+                        )
+                        .unwrap();
+                        let req = x402_types::proto::SettleRequest::from(raw);
+                        match fac.settle(&req).await {
+                            Ok(r) => (axum::http::StatusCode::OK, Json(r.0)),
+                            Err(e) => (
+                                axum::http::StatusCode::OK,
+                                Json(serde_json::json!({
+                                    "success": false, "errorReason": sanitize_error(&e)
+                                })),
+                            ),
+                        }
                     }
-                }
-            }))
-            .route("/supported", get(move || {
-                let fac = fac_supported.clone();
-                async move {
-                    match fac.supported().await {
-                        Ok(r) => Json(serde_json::to_value(&r).unwrap_or_default()),
-                        Err(e) => Json(serde_json::json!({"error": sanitize_error(&e)})),
+                }),
+            )
+            .route(
+                "/supported",
+                get(move || {
+                    let fac = fac_supported.clone();
+                    async move {
+                        match fac.supported().await {
+                            Ok(r) => Json(serde_json::to_value(&r).unwrap_or_default()),
+                            Err(e) => Json(serde_json::json!({"error": sanitize_error(&e)})),
+                        }
                     }
-                }
-            }));
+                }),
+            );
 
         let addr = SocketAddr::from(([127, 0, 0, 1], port));
         let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
@@ -248,7 +317,9 @@ mod e2e {
 
     #[tokio::test]
     async fn test_anvil_fork_has_real_usdc() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
         let fork = AnvilFork::spawn();
         let p = ProviderBuilder::new().connect_http(fork.rpc_url().parse().unwrap());
         assert_eq!(p.get_chain_id().await.unwrap(), 8453);
@@ -257,7 +328,9 @@ mod e2e {
 
     #[tokio::test]
     async fn test_fund_payer_with_usdc() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
         let fork = AnvilFork::spawn();
         fund_payer(&fork.rpc_url(), U256::from(10_000_000u64)).await;
         assert!(usdc_balance(&fork.rpc_url(), PAYER).await >= U256::from(10_000_000u64));
@@ -265,7 +338,9 @@ mod e2e {
 
     #[tokio::test]
     async fn test_impersonated_transfer_moves_usdc() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
         let fork = AnvilFork::spawn();
         let amount = U256::from(5_000_000u64);
         fund_payer(&fork.rpc_url(), amount).await;
@@ -273,25 +348,56 @@ mod e2e {
         let payer_before = usdc_balance(&fork.rpc_url(), PAYER).await;
 
         let p = ProviderBuilder::new().connect_http(fork.rpc_url().parse().unwrap());
-        p.raw_request::<_, ()>("anvil_impersonateAccount".into(), [format!("{:#x}", PAYER)]).await.unwrap();
-        let tx = TransactionRequest::default().from(PAYER).to(USDC_ADDRESS)
-            .input(IERC20::transferCall { to: OPERATOR, amount }.abi_encode().into());
-        p.send_transaction(tx).await.unwrap().get_receipt().await.unwrap();
-        p.raw_request::<_, ()>("anvil_stopImpersonatingAccount".into(), [format!("{:#x}", PAYER)]).await.unwrap();
+        p.raw_request::<_, ()>("anvil_impersonateAccount".into(), [format!("{:#x}", PAYER)])
+            .await
+            .unwrap();
+        let tx = TransactionRequest::default()
+            .from(PAYER)
+            .to(USDC_ADDRESS)
+            .input(
+                IERC20::transferCall {
+                    to: OPERATOR,
+                    amount,
+                }
+                .abi_encode()
+                .into(),
+            );
+        p.send_transaction(tx)
+            .await
+            .unwrap()
+            .get_receipt()
+            .await
+            .unwrap();
+        p.raw_request::<_, ()>(
+            "anvil_stopImpersonatingAccount".into(),
+            [format!("{:#x}", PAYER)],
+        )
+        .await
+        .unwrap();
 
-        assert_eq!(usdc_balance(&fork.rpc_url(), OPERATOR).await - op_before, amount);
-        assert_eq!(payer_before - usdc_balance(&fork.rpc_url(), PAYER).await, amount);
+        assert_eq!(
+            usdc_balance(&fork.rpc_url(), OPERATOR).await - op_before,
+            amount
+        );
+        assert_eq!(
+            payer_before - usdc_balance(&fork.rpc_url(), PAYER).await,
+            amount
+        );
     }
 
     // ─── Facilitator Tests ──────────────────────────────────────────
 
     #[tokio::test]
     async fn test_real_facilitator_starts_and_responds() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
         let fork = AnvilFork::spawn();
         let (handle, port) = start_real_facilitator(&fork.rpc_url()).await;
 
-        let resp = reqwest::get(format!("http://127.0.0.1:{port}/supported")).await.unwrap();
+        let resp = reqwest::get(format!("http://127.0.0.1:{port}/supported"))
+            .await
+            .unwrap();
         assert_eq!(resp.status(), 200);
 
         handle.abort();
@@ -301,28 +407,37 @@ mod e2e {
 
     #[tokio::test]
     async fn test_gateway_402_on_unpaid_request() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
         let fork = AnvilFork::spawn();
         let (fac_h, fac_port) = start_real_facilitator(&fork.rpc_url()).await;
         let (gw_h, gw_port, _producer) = start_gateway(fac_port).await;
 
         let resp = reqwest::Client::new()
             .post(format!("http://127.0.0.1:{gw_port}/x402/jobs/1/0"))
-            .body("hello").send().await.unwrap();
+            .body("hello")
+            .send()
+            .await
+            .unwrap();
         assert_eq!(resp.status(), 402);
 
-        gw_h.abort(); fac_h.abort();
+        gw_h.abort();
+        fac_h.abort();
     }
 
     #[tokio::test]
     async fn test_price_discovery_returns_usdc_settlement() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
         let fork = AnvilFork::spawn();
         let (fac_h, fac_port) = start_real_facilitator(&fork.rpc_url()).await;
         let (gw_h, gw_port, _producer) = start_gateway(fac_port).await;
 
         let resp = reqwest::get(format!("http://127.0.0.1:{gw_port}/x402/jobs/1/0/price"))
-            .await.unwrap();
+            .await
+            .unwrap();
         assert_eq!(resp.status(), 200);
         let body: serde_json::Value = resp.json().await.unwrap();
         let opts = body["settlement_options"].as_array().unwrap();
@@ -330,14 +445,17 @@ mod e2e {
         assert_eq!(opts[0]["symbol"], "USDC");
         assert_eq!(opts[0]["network"], "eip155:8453");
 
-        gw_h.abort(); fac_h.abort();
+        gw_h.abort();
+        fac_h.abort();
     }
 
     // ─── FULL E2E: Payment → Settlement → On-Chain Verification ─────
 
     #[tokio::test]
     async fn test_full_x402_payment_settlement_on_chain() {
-        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" { return; }
+        if std::env::var("ANVIL_E2E").unwrap_or_default() != "1" {
+            return;
+        }
 
         let fork = AnvilFork::spawn();
 
@@ -356,10 +474,14 @@ mod e2e {
 
         // 5. Get price (to know how much USDC to authorize)
         let price_resp = reqwest::get(format!("http://127.0.0.1:{gw_port}/x402/jobs/1/0/price"))
-            .await.unwrap();
+            .await
+            .unwrap();
         let price_body: serde_json::Value = price_resp.json().await.unwrap();
         let required_amount: U256 = price_body["settlement_options"][0]["amount"]
-            .as_str().unwrap().parse().unwrap();
+            .as_str()
+            .unwrap()
+            .parse()
+            .unwrap();
         eprintln!("Required USDC amount: {required_amount}");
 
         // 6. Sign EIP-3009 transferWithAuthorization
@@ -404,7 +526,9 @@ mod e2e {
             .post(format!("http://127.0.0.1:{gw_port}/x402/jobs/1/0"))
             .header("X-PAYMENT", &payment_b64)
             .body("test echo payload")
-            .send().await.unwrap();
+            .send()
+            .await
+            .unwrap();
 
         let status = resp.status();
         let resp_headers = resp.headers().clone();
@@ -425,10 +549,14 @@ mod e2e {
 
         if status.is_success() {
             // Full success: job executed AND settlement happened
-            assert!(operator_after > operator_before,
-                "operator USDC should increase after settlement");
-            assert!(payer_after < payer_before,
-                "payer USDC should decrease after settlement");
+            assert!(
+                operator_after > operator_before,
+                "operator USDC should increase after settlement"
+            );
+            assert!(
+                payer_after < payer_before,
+                "payer USDC should decrease after settlement"
+            );
             let transferred = operator_after - operator_before;
             eprintln!("✅ FULL E2E SUCCESS: {transferred} USDC settled on-chain, job executed");
 
@@ -444,6 +572,7 @@ mod e2e {
             // what the facilitator expects. Log everything for diagnosis.
         }
 
-        gw_h.abort(); fac_h.abort();
+        gw_h.abort();
+        fac_h.abort();
     }
 }


### PR DESCRIPTION
## Summary

### Security hardening (from /harden audit)
- **Harness orchestrator**: JSON injection fix (serde_json::json! instead of format!), CRLF sanitization in health_path, settings.env chmod 0o600, protocol var env blocklist preventing compose override attacks
- **x402 facilitator server**: 64KB body limit (prevents OOM), error URL sanitization (prevents RPC endpoint leakage)
- **x402 E2E tests**: 8 real on-chain tests with Base fork + real USDC + real facilitator

### Rename: restaking_contract → staking_contract
35 files. The field was always the MultiAssetDelegation (staking) contract. CLI flag: `--staking-contract`. Env var: `STAKING_CONTRACT`.

### Version bump: alpha.3
65 Cargo.toml files. All workspace crates 0.2.0-alpha.2 → 0.2.0-alpha.3. CLI 0.5.0-alpha.2 → 0.5.0-alpha.3. Ready for `publish-crates.yml` workflow_dispatch after merge.

### NOT included (needs dedicated migration)
alloy 1.8→2.0 (263 compile errors) and hkdf 0.12→0.13 (digest trait incompatibility). Dependabot PRs #1371-#1375 should be closed with "needs migration PR".

## Test plan
- [ ] `cargo check -p cargo-tangle` passes
- [ ] `cargo fmt --all --check` passes
- [ ] `ANVIL_E2E=1 cargo test -p x402-blueprint` passes (8 tests)
- [ ] No remaining `restaking_contract` references in source