### PR TITLE
fix(tangle): cap log queries and add gas fallbacks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -107,25 +107,25 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50ab0cd8afe573d1f7dc2353698a51b1f93aec362c8211e28cfd3948c6adba39"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.8.3",
  "alloy-contract",
  "alloy-core",
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-genesis",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network 1.8.3",
  "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-client",
+ "alloy-pubsub 1.8.3",
+ "alloy-rpc-client 1.8.3",
  "alloy-rpc-types",
- "alloy-serde",
- "alloy-signer",
- "alloy-signer-aws",
+ "alloy-serde 1.8.3",
+ "alloy-signer 1.8.3",
+ "alloy-signer-aws 1.8.3",
  "alloy-signer-local",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
+ "alloy-transport-ipc 1.8.3",
+ "alloy-transport-ws 1.8.3",
  "alloy-trie",
 ]
 
@@ -146,12 +146,39 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f16daaf7e1f95f62c6c3bf8a3fc3d78b08ae9777810c0bb5e94966c7cd57ef0"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
  "alloy-trie",
- "alloy-tx-macros",
+ "alloy-tx-macros 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "k256",
+ "once_cell",
+ "rand 0.8.6",
+ "secp256k1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-consensus"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dbe4e5e9107bf6854e7550b666ca654ff2027eabf8153913e2e31ac4b089779"
+dependencies = [
+ "alloy-eips 2.0.0",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
+ "alloy-trie",
+ "alloy-tx-macros 2.0.0",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -173,11 +200,25 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "118998d9015332ab1b4720ae1f1e3009491966a0349938a1f43ff45a8a4c6299"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-consensus-any"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88fc7bbfb98cf5605a35aadf0ba43a7d9f1608d6f220d05e4fbd5144d3b0b625"
+dependencies = [
+ "alloy-consensus 2.0.0",
+ "alloy-eips 2.0.0",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -187,17 +228,17 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ac9e0c34dc6bce643b182049cdfcca1b8ce7d9c260cbdd561f511873b7e26cd"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.8.3",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-network 1.8.3",
+ "alloy-network-primitives 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-types-eth",
+ "alloy-pubsub 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "futures",
  "futures-util",
  "serde_json",
@@ -298,7 +339,30 @@ dependencies = [
  "alloy-eip7928",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "auto_impl",
+ "borsh",
+ "c-kzg",
+ "derive_more",
+ "either",
+ "serde",
+ "serde_with",
+ "sha2 0.10.9",
+]
+
+[[package]]
+name = "alloy-eips"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afb4919fa34b268842f434bfafa9c09136ab7b1a87ce0dd40a61befa35b5408c"
+dependencies = [
+ "alloy-eip2124",
+ "alloy-eip2930",
+ "alloy-eip7702",
+ "alloy-eip7928",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
  "auto_impl",
  "borsh",
  "c-kzg",
@@ -315,9 +379,9 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbf9480307b09d22876efb67d30cadd9013134c21f3a17ec9f93fd7536d38024"
 dependencies = [
- "alloy-eips",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 1.8.3",
  "alloy-trie",
  "borsh",
  "serde",
@@ -352,21 +416,62 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-json-rpc"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31b6af6f374c1eeef8ab8dc26232cd440db167322a4207a3debd3d1ee565ca47"
+dependencies = [
+ "alloy-primitives",
+ "alloy-sol-types",
+ "http 1.4.0",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
 name = "alloy-network"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7197a66d94c4de1591cdc16a9bcea5f8cccd0da81b865b49aef97b1b4016e0fa"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network-primitives",
+ "alloy-consensus 1.8.3",
+ "alloy-consensus-any 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network-primitives 1.8.3",
  "alloy-primitives",
- "alloy-rpc-types-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
- "alloy-signer",
+ "alloy-rpc-types-any 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
+ "alloy-signer 1.8.3",
+ "alloy-sol-types",
+ "async-trait",
+ "auto_impl",
+ "derive_more",
+ "futures-utils-wasm",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-network"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a3f5a7f3678b71d33fcc45b714fab8928dbc647d5aff2145e72032d5c849bb"
+dependencies = [
+ "alloy-consensus 2.0.0",
+ "alloy-consensus-any 2.0.0",
+ "alloy-eips 2.0.0",
+ "alloy-json-rpc 2.0.0",
+ "alloy-network-primitives 2.0.0",
+ "alloy-primitives",
+ "alloy-rpc-types-any 2.0.0",
+ "alloy-rpc-types-eth 2.0.0",
+ "alloy-serde 2.0.0",
+ "alloy-signer 2.0.0",
  "alloy-sol-types",
  "async-trait",
  "auto_impl",
@@ -383,10 +488,23 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb82711d59a43fdfd79727c99f270b974c784ec4eb5728a0d0d22f26716c87ef"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "serde",
+]
+
+[[package]]
+name = "alloy-network-primitives"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb50dc1fb0e0b2c8748d5bee1aa7acdd18f9e036311bc93a71d97be624030317"
+dependencies = [
+ "alloy-consensus 2.0.0",
+ "alloy-eips 2.0.0",
+ "alloy-primitives",
+ "alloy-serde 2.0.0",
  "serde",
 ]
 
@@ -424,25 +542,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf6b18b929ef1d078b834c3631e9c925177f3b23ddc6fa08a722d13047205876"
 dependencies = [
  "alloy-chains",
- "alloy-consensus",
- "alloy-eips",
- "alloy-json-rpc",
- "alloy-network",
- "alloy-network-primitives",
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network 1.8.3",
+ "alloy-network-primitives 1.8.3",
  "alloy-primitives",
- "alloy-pubsub",
- "alloy-rpc-client",
+ "alloy-pubsub 1.8.3",
+ "alloy-rpc-client 1.8.3",
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
+ "alloy-transport-ipc 1.8.3",
+ "alloy-transport-ws 1.8.3",
  "async-stream",
  "async-trait",
  "auto_impl",
@@ -469,9 +587,31 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5ad54073131e7292d4e03e1aa2287730f737280eb160d8b579fb31939f558c11"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-primitives",
- "alloy-transport",
+ "alloy-transport 1.8.3",
+ "auto_impl",
+ "bimap",
+ "futures",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-pubsub"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffcefb5d3391a320eadb95d398e4135f8cc35c7bf29a6bdb357eadcfc5ee5638"
+dependencies = [
+ "alloy-json-rpc 2.0.0",
+ "alloy-primitives",
+ "alloy-transport 2.0.0",
  "auto_impl",
  "bimap",
  "futures",
@@ -513,13 +653,39 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94fcc9604042ca80bd37aa5e232ea1cd851f337e31e2babbbb345bc0b1c30de3"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "alloy-primitives",
- "alloy-pubsub",
- "alloy-transport",
- "alloy-transport-http",
- "alloy-transport-ipc",
- "alloy-transport-ws",
+ "alloy-pubsub 1.8.3",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
+ "alloy-transport-ipc 1.8.3",
+ "alloy-transport-ws 1.8.3",
+ "futures",
+ "pin-project",
+ "reqwest 0.13.2",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-stream",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
+name = "alloy-rpc-client"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222fd4efff0fb9a25184684742c44fe9fa9a16c4ab5bf97583e71c86598ef8f0"
+dependencies = [
+ "alloy-json-rpc 2.0.0",
+ "alloy-primitives",
+ "alloy-pubsub 2.0.0",
+ "alloy-transport 2.0.0",
+ "alloy-transport-http 2.0.0",
+ "alloy-transport-ipc 2.0.0",
+ "alloy-transport-ws 2.0.0",
  "futures",
  "pin-project",
  "reqwest 0.13.2",
@@ -543,10 +709,10 @@ dependencies = [
  "alloy-rpc-types-anvil",
  "alloy-rpc-types-debug",
  "alloy-rpc-types-engine",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-rpc-types-trace",
  "alloy-rpc-types-txpool",
- "alloy-serde",
+ "alloy-serde 1.8.3",
  "serde",
 ]
 
@@ -557,8 +723,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47df51bedb3e6062cb9981187a51e86d0d64a4de66eb0855e9efe6574b044ddf"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
  "serde",
 ]
 
@@ -568,9 +734,24 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3823026d1ed239a40f12364fac50726c8daf1b6ab8077a97212c5123910429ed"
 dependencies = [
- "alloy-consensus-any",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-consensus-any 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "949c0f16a94ae33cdb1139b8dbf9e34d7f26ebfe97962e2a4d620b5f65f48fe4"
+dependencies = [
+ "alloy-consensus-any 2.0.0",
+ "alloy-network-primitives 2.0.0",
+ "alloy-primitives",
+ "alloy-rpc-types-eth 2.0.0",
+ "alloy-serde 2.0.0",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -591,11 +772,11 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb9b97b6e7965679ad22df297dda809b11cebc13405c1b537e5cffecc95834fa"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
+ "alloy-consensus 1.8.3",
+ "alloy-eips 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
  "derive_more",
  "rand 0.8.6",
  "serde",
@@ -608,13 +789,34 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59c095f92c4e1ff4981d89e9aa02d5f98c762a1980ab66bec49c44be11349da2"
 dependencies = [
- "alloy-consensus",
- "alloy-consensus-any",
- "alloy-eips",
- "alloy-network-primitives",
+ "alloy-consensus 1.8.3",
+ "alloy-consensus-any 1.8.3",
+ "alloy-eips 1.8.3",
+ "alloy-network-primitives 1.8.3",
  "alloy-primitives",
  "alloy-rlp",
- "alloy-serde",
+ "alloy-serde 1.8.3",
+ "alloy-sol-types",
+ "itertools 0.14.0",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "alloy-rpc-types-eth"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc280a41931bd419af86e9e859dd9726b73313aaa2e479b33c0e344f4b892ddb"
+dependencies = [
+ "alloy-consensus 2.0.0",
+ "alloy-consensus-any 2.0.0",
+ "alloy-eips 2.0.0",
+ "alloy-network-primitives 2.0.0",
+ "alloy-primitives",
+ "alloy-rlp",
+ "alloy-serde 2.0.0",
  "alloy-sol-types",
  "itertools 0.14.0",
  "serde",
@@ -630,8 +832,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2e5a4d010f86cd4e01e5205ec273911e538e1738e76d8bafe9ecd245910ea5a3"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -644,8 +846,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "942d26a2ca8891b26de4a8529d21091e21c1093e27eb99698f1a86405c76b1ff"
 dependencies = [
  "alloy-primitives",
- "alloy-rpc-types-eth",
- "alloy-serde",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-serde 1.8.3",
  "serde",
 ]
 
@@ -654,6 +856,17 @@ name = "alloy-serde"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "11ece63b89294b8614ab3f483560c08d016930f842bf36da56bf0b764a15c11e"
+dependencies = [
+ "alloy-primitives",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "alloy-serde"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4848831ff994c88b1c32b7df9c4c1c3eedea4b535bde5eb3c421ef0bdc5ac052"
 dependencies = [
  "alloy-primitives",
  "serde",
@@ -678,15 +891,49 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-signer"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84b8ad9890b212e224291024b1aecfeef72127d27a2f6eebc5e347c40275c4bf"
+dependencies = [
+ "alloy-primitives",
+ "async-trait",
+ "auto_impl",
+ "either",
+ "elliptic-curve",
+ "k256",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "alloy-signer-aws"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8194c416115dc27f03796c0075dee0731239e2d7fbce735a74894aa8f6a47d7d"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.8.3",
+ "alloy-network 1.8.3",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 1.8.3",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "k256",
+ "spki",
+ "thiserror 2.0.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-signer-aws"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7a57d1e72b1f9b11e5e71ebdab0569cb02277a462bbea6793fcaebfcd794ae9"
+dependencies = [
+ "alloy-consensus 2.0.0",
+ "alloy-network 2.0.0",
+ "alloy-primitives",
+ "alloy-signer 2.0.0",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -702,10 +949,10 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4fa71d57808c8ce3c41342a71245d67839b032d7e18072b50a8d262e28143c18"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.8.3",
+ "alloy-network 1.8.3",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "async-trait",
  "gcloud-sdk",
  "k256",
@@ -720,11 +967,11 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1f199e1a28175d8dbed35b4a726d2080bf0a696017e865d063090895f3342965"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.8.3",
  "alloy-dyn-abi",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "alloy-sol-types",
  "async-trait",
  "coins-ledger",
@@ -740,10 +987,10 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f721f4bf2e4812e5505aaf5de16ef3065a8e26b9139ac885862d00b5a55a659a"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.8.3",
+ "alloy-network 1.8.3",
  "alloy-primitives",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "async-trait",
  "coins-bip32",
  "coins-bip39",
@@ -832,7 +1079,7 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8098f965442a9feb620965ba4b4be5e2b320f4ec5a3fff6bfa9e1ff7ef42bed1"
 dependencies = [
- "alloy-json-rpc",
+ "alloy-json-rpc 1.8.3",
  "auto_impl",
  "base64 0.22.1",
  "derive_more",
@@ -851,13 +1098,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32b7b755e64ae6b5de0d762ed2c780e072167ea5e542076a559e00314352a0bf"
+dependencies = [
+ "alloy-json-rpc 2.0.0",
+ "auto_impl",
+ "base64 0.22.1",
+ "derive_more",
+ "futures",
+ "futures-utils-wasm",
+ "parking_lot 0.12.5",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+ "wasmtimer",
+]
+
+[[package]]
 name = "alloy-transport-http"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
- "alloy-json-rpc",
- "alloy-transport",
+ "alloy-json-rpc 1.8.3",
+ "alloy-transport 1.8.3",
  "itertools 0.14.0",
  "opentelemetry 0.31.0",
  "opentelemetry-http",
@@ -870,14 +1140,50 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloy-transport-http"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a29980e69119444ed26b75e7ee5bed2043870f904a64318297e55800db686564"
+dependencies = [
+ "alloy-json-rpc 2.0.0",
+ "alloy-transport 2.0.0",
+ "itertools 0.14.0",
+ "reqwest 0.13.2",
+ "serde_json",
+ "tower 0.5.3",
+ "tracing",
+ "url",
+]
+
+[[package]]
 name = "alloy-transport-ipc"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1bd98c3870b8a44b79091dde5216a81d58ffbc1fd8ed61b776f9fee0f3bdf20"
 dependencies = [
- "alloy-json-rpc",
- "alloy-pubsub",
- "alloy-transport",
+ "alloy-json-rpc 1.8.3",
+ "alloy-pubsub 1.8.3",
+ "alloy-transport 1.8.3",
+ "bytes",
+ "futures",
+ "interprocess",
+ "pin-project",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-util 0.7.18",
+ "tracing",
+]
+
+[[package]]
+name = "alloy-transport-ipc"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b27802653330740c88c28394cdaf1d55190b15b48ef9b99a946f37c9cdb19fa"
+dependencies = [
+ "alloy-json-rpc 2.0.0",
+ "alloy-pubsub 2.0.0",
+ "alloy-transport 2.0.0",
  "bytes",
  "futures",
  "interprocess",
@@ -895,8 +1201,27 @@ version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec3ab7a72b180992881acc112628b7668337a19ce15293ee974600ea7b693691"
 dependencies = [
- "alloy-pubsub",
- "alloy-transport",
+ "alloy-pubsub 1.8.3",
+ "alloy-transport 1.8.3",
+ "futures",
+ "http 1.4.0",
+ "rustls 0.23.38",
+ "serde_json",
+ "tokio",
+ "tokio-tungstenite",
+ "tracing",
+ "url",
+ "ws_stream_wasm",
+]
+
+[[package]]
+name = "alloy-transport-ws"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4b71dc951db66795cfb52eef835f64cf15163bc93b656e061b457ce5ebff370"
+dependencies = [
+ "alloy-pubsub 2.0.0",
+ "alloy-transport 2.0.0",
  "futures",
  "http 1.4.0",
  "rustls 0.23.38",
@@ -929,6 +1254,18 @@ name = "alloy-tx-macros"
 version = "1.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d69722eddcdf1ce096c3ab66cf8116999363f734eb36fe94a148f4f71c85da84"
+dependencies = [
+ "darling 0.23.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "alloy-tx-macros"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8d8228b9236479ff16b03041b64b86c2bd4e53da1caa45d59b5868cd1571131e"
 dependencies = [
  "darling 0.23.0",
  "proc-macro2",
@@ -1023,7 +1360,7 @@ dependencies = [
 name = "apikey-blueprint-lib"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -2511,15 +2848,15 @@ dependencies = [
 name = "blueprint-anvil-testing-utils"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-consensus",
- "alloy-eips",
- "alloy-network",
+ "alloy-consensus 1.8.3",
+ "alloy-eips 2.0.0",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-signer-local",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "anyhow",
  "blueprint-chain-setup-anvil",
  "blueprint-client-tangle",
@@ -2632,7 +2969,7 @@ dependencies = [
  "alloy-contract",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "blueprint-core",
  "blueprint-core-testing-utils",
  "blueprint-keystore",
@@ -2662,10 +2999,10 @@ name = "blueprint-client-eigenlayer"
 version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "blueprint-chain-setup-anvil",
  "blueprint-client-core",
  "blueprint-core",
@@ -2690,17 +3027,17 @@ dependencies = [
 name = "blueprint-client-evm"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-consensus",
- "alloy-json-rpc",
- "alloy-network",
+ "alloy-consensus 1.8.3",
+ "alloy-json-rpc 1.8.3",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-pubsub",
+ "alloy-pubsub 1.8.3",
  "alloy-rlp",
  "alloy-rpc-types",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-signer-local",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "blueprint-anvil-testing-utils",
  "blueprint-chain-setup-anvil",
  "blueprint-client-core",
@@ -2723,14 +3060,14 @@ name = "blueprint-client-tangle"
 version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "anyhow",
  "blueprint-anvil-testing-utils",
  "blueprint-chain-setup-anvil",
@@ -2770,9 +3107,9 @@ dependencies = [
 name = "blueprint-context-derive"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-provider",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "blueprint-context-derive",
  "blueprint-sdk",
  "proc-macro2",
@@ -2973,7 +3310,7 @@ version = "0.2.0-alpha.3"
 dependencies = [
  "alloy",
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-signer-local",
@@ -3029,17 +3366,17 @@ dependencies = [
 name = "blueprint-evm-extra"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-consensus",
- "alloy-network",
+ "alloy-consensus 1.8.3",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-client",
+ "alloy-rpc-client 2.0.0",
  "alloy-rpc-types",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 2.0.0",
  "async-stream",
  "blueprint-core",
  "blueprint-std",
@@ -3113,10 +3450,10 @@ dependencies = [
 name = "blueprint-keystore"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
- "alloy-signer",
- "alloy-signer-aws",
+ "alloy-signer 1.8.3",
+ "alloy-signer-aws 2.0.0",
  "alloy-signer-gcp",
  "alloy-signer-ledger",
  "alloy-signer-local",
@@ -3169,13 +3506,13 @@ dependencies = [
 name = "blueprint-manager"
 version = "0.4.0-alpha.2"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport-http",
+ "alloy-transport-http 2.0.0",
  "anyhow",
  "async-trait",
  "auto_impl",
@@ -3381,7 +3718,7 @@ dependencies = [
 name = "blueprint-pricing-engine"
 version = "0.3.0-alpha.2"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -3472,13 +3809,13 @@ dependencies = [
 name = "blueprint-qos"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "anyhow",
  "async-trait",
  "axum",
@@ -3604,7 +3941,7 @@ dependencies = [
  "alloy-contract",
  "alloy-primitives",
  "alloy-provider",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "alloy-signer-local",
  "async-trait",
  "blueprint-auth",
@@ -3725,10 +4062,10 @@ name = "blueprint-tangle-aggregation-svc"
 version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-signer",
+ "alloy-signer 1.8.3",
  "alloy-signer-local",
  "ark-bn254",
  "ark-ec",
@@ -3757,7 +4094,7 @@ name = "blueprint-tangle-extra"
 version = "0.2.0-alpha.3"
 dependencies = [
  "alloy",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -4163,13 +4500,13 @@ dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",
  "alloy-json-abi",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "anyhow",
  "assert_cmd",
  "bip39",
@@ -5833,7 +6170,7 @@ dependencies = [
  "alloy-json-abi",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-types-eth",
+ "alloy-rpc-types-eth 1.8.3",
  "alloy-sol-types",
  "color-eyre",
  "eigensdk",
@@ -7686,21 +8023,21 @@ dependencies = [
 name = "incredible-squaring-blueprint-eigenlayer"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-consensus",
+ "alloy-consensus 1.8.3",
  "alloy-contract",
  "alloy-json-abi",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-pubsub",
- "alloy-rpc-client",
+ "alloy-pubsub 1.8.3",
+ "alloy-rpc-client 2.0.0",
  "alloy-rpc-types",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-signer 1.8.3",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 2.0.0",
  "ark-bn254",
  "ark-ec",
  "ark-ff 0.5.0",
@@ -10278,7 +10615,7 @@ dependencies = [
 name = "oauth-blueprint-lib"
 version = "0.2.0-alpha.3"
 dependencies = [
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
@@ -15677,28 +16014,28 @@ dependencies = [
  "ahash 0.8.12",
  "aho-corasick",
  "alloy",
- "alloy-consensus",
+ "alloy-consensus 1.8.3",
  "alloy-contract",
  "alloy-core",
  "alloy-dyn-abi",
  "alloy-eip7702",
- "alloy-eips",
+ "alloy-eips 2.0.0",
  "alloy-json-abi",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rlp",
- "alloy-rpc-client",
+ "alloy-rpc-client 2.0.0",
  "alloy-rpc-types",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-signer 1.8.3",
  "alloy-signer-local",
  "alloy-sol-macro",
  "alloy-sol-macro-expander",
  "alloy-sol-macro-input",
  "alloy-sol-type-parser",
  "alloy-sol-types",
- "alloy-transport-http",
+ "alloy-transport-http 2.0.0",
  "anyhow",
  "argon2",
  "ark-bn254",
@@ -15964,13 +16301,13 @@ name = "x402-blueprint"
 version = "0.2.0-alpha.3"
 dependencies = [
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
  "alloy-rpc-types",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
+ "alloy-transport 1.8.3",
  "axum",
  "base64 0.22.1",
  "blueprint-core",
@@ -16001,16 +16338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c292f822e5072cbb1ad9e3271f5daa9b589b065ed2321172eb307d2066681e9"
 dependencies = [
  "alloy-contract",
- "alloy-network",
+ "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",
- "alloy-rpc-client",
- "alloy-rpc-types-eth",
- "alloy-signer",
+ "alloy-rpc-client 1.8.3",
+ "alloy-rpc-types-eth 1.8.3",
+ "alloy-signer 1.8.3",
  "alloy-signer-local",
  "alloy-sol-types",
- "alloy-transport",
- "alloy-transport-http",
+ "alloy-transport 1.8.3",
+ "alloy-transport-http 1.8.3",
  "async-trait",
  "dashmap",
  "rand 0.9.4",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -393,7 +393,7 @@ alloy-json-rpc = { version = "1.8", default-features = false }
 alloy-dyn-abi = { version = "1.5", default-features = false, features = ["eip712"] }
 alloy-sol-types = { version = "1.5", default-features = false }
 alloy-rlp = { version = "0.3.12", default-features = false }
-alloy-rpc-client = { version = "1.8", default-features = false }
+alloy-rpc-client = { version = "2.0", default-features = false }
 alloy-rpc-types = { version = "1.8", default-features = false }
 alloy-rpc-types-eth = { version = "1.8", default-features = false }
 alloy-provider = { version = "1.8", default-features = false, features = ["reqwest", "ws"] }
@@ -403,14 +403,14 @@ alloy-signer-local = { version = "1.8", default-features = false }
 alloy-network = { version = "1.8", default-features = false }
 alloy-contract = { version = "1.8", default-features = false }
 alloy-consensus = { version = "1.8", default-features = false }
-alloy-eips = { version = "1.8", default-features = false }
+alloy-eips = { version = "2.0", default-features = false }
 alloy-transport = { version = "1.8", default-features = false }
-alloy-transport-http = { version = "1.8", default-features = false }
+alloy-transport-http = { version = "2.0", default-features = false }
 ripemd = { version = "0.1.3", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 
 # Remote signing
-alloy-signer-aws = { version = "1.8", default-features = false }
+alloy-signer-aws = { version = "2.0", default-features = false }
 alloy-signer-gcp = { version = "1.8", default-features = false }
 alloy-signer-ledger = { version = "1.8", default-features = false, features = ["eip712"] }
 aws-config = { version = "1", default-features = false }

--- a/crates/blueprint-remote-providers/src/deployment/ssh/client.rs
+++ b/crates/blueprint-remote-providers/src/deployment/ssh/client.rs
@@ -525,11 +525,11 @@ impl SshDeploymentClient {
             .iter()
             .map(|(k, v)| {
                 // Prevent injection: reject keys with =, newline, or whitespace.
-                let k_safe = k
-                    .chars()
-                    .all(|c| c.is_alphanumeric() || c == '_')
-                    .then_some(k.as_str())
-                    .unwrap_or("INVALID");
+                let k_safe = if k.chars().all(|c| c.is_alphanumeric() || c == '_') {
+                    k.as_str()
+                } else {
+                    "INVALID"
+                };
                 // Escape single quotes in value.
                 let v_safe = v.replace('\'', "'\\''");
                 format!("{k_safe}='{v_safe}'")

--- a/crates/clients/tangle/src/client.rs
+++ b/crates/clients/tangle/src/client.rs
@@ -14,7 +14,7 @@ use alloy_rpc_types::{
     Block, BlockNumberOrTag, Filter, Log, TransactionReceipt,
     transaction::{TransactionInput, TransactionRequest},
 };
-use alloy_sol_types::SolType;
+use alloy_sol_types::{SolCall, SolType};
 use blueprint_client_core::{BlueprintServicesClient, OperatorSet};
 use blueprint_crypto::k256::K256Ecdsa;
 use blueprint_keystore::Keystore;
@@ -38,6 +38,18 @@ use IMultiAssetDelegation::IMultiAssetDelegationInstance;
 use IOperatorStatusRegistry::IOperatorStatusRegistryInstance;
 use ITangle::ITangleInstance;
 
+const SUBMIT_RESULT_MIN_GAS_LIMIT: u64 = 8_000_000;
+const SUBMIT_RESULT_GAS_BUFFER_NUMERATOR: u64 = 13;
+const SUBMIT_RESULT_GAS_BUFFER_DENOMINATOR: u64 = 10;
+const CREATE_BLUEPRINT_MIN_GAS_LIMIT: u64 = 5_000_000;
+const REGISTER_BLUEPRINT_OPERATOR_MIN_GAS_LIMIT: u64 = 1_000_000;
+const REQUEST_SERVICE_MIN_GAS_LIMIT: u64 = 2_000_000;
+const APPROVE_SERVICE_MIN_GAS_LIMIT: u64 = 1_000_000;
+const ERC20_APPROVE_MIN_GAS_LIMIT: u64 = 100_000;
+const REGISTER_OPERATOR_RESTAKING_MIN_GAS_LIMIT: u64 = 500_000;
+const INITIAL_LOG_LOOKBACK_BLOCKS: u64 = 9;
+const MAX_LOG_RANGE_BLOCKS: u64 = 10;
+
 #[allow(missing_docs)]
 mod erc20 {
     alloy_sol_types::sol! {
@@ -51,6 +63,76 @@ mod erc20 {
 }
 
 use erc20::IERC20;
+
+/// Compute the gas limit to submit with: buffered estimate if available, else the
+/// caller-provided minimum. Always `>= min_gas_limit`.
+fn buffered_gas_limit(estimated_gas: Option<u64>, min_gas_limit: u64) -> u64 {
+    estimated_gas
+        .map(|gas| {
+            gas.saturating_mul(SUBMIT_RESULT_GAS_BUFFER_NUMERATOR)
+                / SUBMIT_RESULT_GAS_BUFFER_DENOMINATOR
+        })
+        .unwrap_or(min_gas_limit)
+        .max(min_gas_limit)
+}
+
+/// Send a transaction with buffered estimated gas, falling back to a conservative
+/// minimum when estimation fails.
+///
+/// `from` must be the operator/wallet address that will sign the tx. It is applied
+/// before `eth_estimateGas` so operator-gated calls simulate correctly — without
+/// it, alloy's `WalletFiller` only populates `from` on `send_transaction`, so
+/// estimation runs as `0x0` and reverts for any auth-checked entrypoint,
+/// causing the helper to always take the fallback path (and masking real reverts).
+///
+/// An on-chain revert (`receipt.status() == false`) is surfaced as
+/// `Error::Contract` carrying the tx hash, gas used, and — when available —
+/// the estimator's revert reason. Without this, callers that fold the receipt
+/// into `TransactionResult { success, .. }` silently return `Ok(success=false)`,
+/// which looks like a passing path to anything that only checks `Result::is_ok`.
+async fn send_transaction_with_fallback_gas<P>(
+    provider: &P,
+    from: Address,
+    tx_request: TransactionRequest,
+    min_gas_limit: u64,
+) -> Result<TransactionReceipt>
+where
+    P: Provider<Ethereum>,
+{
+    let tx_request = tx_request.from(from);
+    let (estimated_gas, estimate_error) = match provider.estimate_gas(tx_request.clone()).await {
+        Ok(gas) => (Some(gas), None),
+        Err(err) => {
+            let msg = err.to_string();
+            tracing::warn!(
+                "eth_estimateGas failed; falling back to min_gas_limit={min_gas_limit}: {msg}"
+            );
+            (None, Some(msg))
+        }
+    };
+    let gas_limit = buffered_gas_limit(estimated_gas, min_gas_limit);
+    let pending_tx = provider
+        .send_transaction(tx_request.gas_limit(gas_limit))
+        .await
+        .map_err(Error::Transport)?;
+
+    let receipt = pending_tx
+        .get_receipt()
+        .await
+        .map_err(Error::PendingTransaction)?;
+
+    if !receipt.status() {
+        let tail = estimate_error
+            .map(|e| format!(" (estimate_gas reported: {e})"))
+            .unwrap_or_default();
+        return Err(Error::Contract(format!(
+            "transaction {} reverted on-chain (block={:?}, gas_used={}){tail}",
+            receipt.transaction_hash, receipt.block_number, receipt.gas_used,
+        )));
+    }
+
+    Ok(receipt)
+}
 
 /// Type alias for the dynamic provider
 pub type TangleProvider = DynProvider<Ethereum>;
@@ -542,15 +624,26 @@ impl TangleClient {
 
     /// Get the next event (polls for new blocks)
     ///
-    /// On the first call, scans from block 0 to catch up on any historical
-    /// events (e.g. ServiceActivated) that were emitted before the client
-    /// started.  Subsequent calls only scan new blocks.
+    /// On the first call, scans a small recent window to catch up on any
+    /// near-realtime events while staying compatible with hosted RPC plans
+    /// that cap `eth_getLogs` block ranges. Older active services are still
+    /// discovered by the manager's contract-state fallback during initialize.
+    /// Subsequent calls only scan new blocks.
     pub async fn next_event(&self) -> Option<TangleEvent> {
         loop {
-            let current_block = self.block_number().await.ok()?;
+            let current_block = match self.block_number().await {
+                Ok(block) => block,
+                Err(err) => {
+                    tracing::warn!("Failed to fetch current block number: {err}");
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
 
             let mut last_block = self.block_subscription.lock().await;
-            let from_block = last_block.map(|b| b + 1).unwrap_or(0);
+            let from_block = last_block
+                .map(|b| b + 1)
+                .unwrap_or_else(|| current_block.saturating_sub(INITIAL_LOG_LOOKBACK_BLOCKS));
 
             if from_block > current_block {
                 drop(last_block);
@@ -558,24 +651,47 @@ impl TangleClient {
                 continue;
             }
 
+            let to_block = current_block
+                .min(from_block.saturating_add(MAX_LOG_RANGE_BLOCKS.saturating_sub(1)));
+
             // Get block info
-            let block = self
-                .get_block(BlockNumberOrTag::Number(current_block))
-                .await
-                .ok()??;
+            let Some(block) = (match self.get_block(BlockNumberOrTag::Number(to_block)).await {
+                Ok(block) => block,
+                Err(err) => {
+                    tracing::warn!("Failed to fetch block data for block {to_block}: {err}");
+                    drop(last_block);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            }) else {
+                tracing::warn!("RPC returned no block data for block {current_block}");
+                drop(last_block);
+                tokio::time::sleep(Duration::from_secs(1)).await;
+                continue;
+            };
 
             // Create filter for Tangle contract events
             let filter = Filter::new()
                 .address(self.tangle_address)
                 .from_block(from_block)
-                .to_block(current_block);
+                .to_block(to_block);
 
-            let logs = self.get_logs(&filter).await.ok()?;
+            let logs = match self.get_logs(&filter).await {
+                Ok(logs) => logs,
+                Err(err) => {
+                    tracing::warn!(
+                        "Failed to fetch Tangle logs for blocks {from_block}..={to_block}: {err}"
+                    );
+                    drop(last_block);
+                    tokio::time::sleep(Duration::from_secs(1)).await;
+                    continue;
+                }
+            };
 
-            *last_block = Some(current_block);
+            *last_block = Some(to_block);
 
             let event = TangleEvent {
-                block_number: current_block,
+                block_number: to_block,
                 block_hash: block.header.hash,
                 timestamp: block.header.timestamp,
                 logs,
@@ -675,24 +791,30 @@ impl TangleClient {
         &self,
         encoded_definition: Vec<u8>,
     ) -> Result<(TransactionResult, u64)> {
+        use crate::contracts::ITangle::createBlueprintCall;
+
         let definition = ITangleTypes::BlueprintDefinition::abi_decode(encoded_definition.as_ref())
             .map_err(|err| {
                 Error::Contract(format!("failed to decode blueprint definition: {err}"))
             })?;
 
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
-        let contract = ITangle::new(self.tangle_address, &provider);
-        let pending_tx = contract
-            .createBlueprint(definition)
-            .send()
-            .await
-            .map_err(|e| Error::Contract(e.to_string()))?;
-        let receipt = pending_tx.get_receipt().await?;
+        let tx_request = TransactionRequest::default()
+            .to(self.tangle_address)
+            .input(createBlueprintCall { definition }.abi_encode().into());
+        let receipt = send_transaction_with_fallback_gas(
+            &provider,
+            from_address,
+            tx_request,
+            CREATE_BLUEPRINT_MIN_GAS_LIMIT,
+        )
+        .await?;
         let blueprint_id = self.extract_blueprint_id(&receipt)?;
 
         Ok((transaction_result_from_receipt(&receipt), blueprint_id))
@@ -806,13 +928,15 @@ impl TangleClient {
         rpc_endpoint: impl Into<String>,
         registration_inputs: Option<Bytes>,
     ) -> Result<TransactionResult> {
+        use crate::contracts::ITangle::{registerOperator_0Call, registerOperator_1Call};
+
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
-        let contract = ITangle::new(self.tangle_address, &provider);
 
         let signing_key = self.ecdsa_signing_key()?;
         let verifying = signing_key.verifying_key();
@@ -823,26 +947,40 @@ impl TangleClient {
         let rpc_endpoint = rpc_endpoint.into();
 
         let receipt = if let Some(inputs) = registration_inputs {
-            contract
-                .registerOperator_0(
-                    blueprint_id,
-                    ecdsa_bytes.clone(),
-                    rpc_endpoint.clone(),
-                    inputs,
-                )
-                .send()
-                .await
-                .map_err(|e| Error::Contract(e.to_string()))?
-                .get_receipt()
-                .await?
+            let tx_request = TransactionRequest::default().to(self.tangle_address).input(
+                registerOperator_0Call {
+                    blueprintId: blueprint_id,
+                    ecdsaPublicKey: ecdsa_bytes.clone(),
+                    rpcAddress: rpc_endpoint.clone(),
+                    registrationInputs: inputs,
+                }
+                .abi_encode()
+                .into(),
+            );
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REGISTER_BLUEPRINT_OPERATOR_MIN_GAS_LIMIT,
+            )
+            .await?
         } else {
-            contract
-                .registerOperator_1(blueprint_id, ecdsa_bytes.clone(), rpc_endpoint.clone())
-                .send()
-                .await
-                .map_err(|e| Error::Contract(e.to_string()))?
-                .get_receipt()
-                .await?
+            let tx_request = TransactionRequest::default().to(self.tangle_address).input(
+                registerOperator_1Call {
+                    blueprintId: blueprint_id,
+                    ecdsaPublicKey: ecdsa_bytes.clone(),
+                    rpcAddress: rpc_endpoint.clone(),
+                }
+                .abi_encode()
+                .into(),
+            );
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REGISTER_BLUEPRINT_OPERATOR_MIN_GAS_LIMIT,
+            )
+            .await?
         };
 
         Ok(transaction_result_from_receipt(&receipt))
@@ -981,7 +1119,12 @@ impl TangleClient {
         &self,
         params: ServiceRequestParams,
     ) -> Result<(TransactionResult, u64)> {
+        use crate::contracts::ITangle::{
+            requestServiceCall, requestServiceWithExposureCall, requestServiceWithSecurityCall,
+        };
+
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
@@ -1063,57 +1206,85 @@ impl TangleClient {
         };
         let pre_count = self.service_request_count().await.ok();
 
-        let pending_tx = if !security_requirements.is_empty() {
-            let mut call = contract.requestServiceWithSecurity(
-                blueprint_id,
-                operators.clone(),
-                security_requirements.clone(),
-                config.clone(),
-                permitted_callers.clone(),
-                ttl,
-                payment_token,
-                payment_amount,
-                confidentiality,
+        let receipt = if !security_requirements.is_empty() {
+            let mut tx_request = TransactionRequest::default().to(self.tangle_address).input(
+                requestServiceWithSecurityCall {
+                    blueprintId: blueprint_id,
+                    operators: operators.clone(),
+                    securityRequirements: security_requirements.clone(),
+                    config: config.clone(),
+                    permittedCallers: permitted_callers.clone(),
+                    ttl,
+                    paymentToken: payment_token,
+                    paymentAmount: payment_amount,
+                    confidentiality,
+                }
+                .abi_encode()
+                .into(),
             );
             if is_native_payment {
-                call = call.value(payment_amount);
+                tx_request = tx_request.value(payment_amount);
             }
-            call.send().await
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REQUEST_SERVICE_MIN_GAS_LIMIT,
+            )
+            .await
         } else if let Some(exposures) = operator_exposures {
-            let mut call = contract.requestServiceWithExposure(
-                blueprint_id,
-                operators.clone(),
-                exposures,
-                config.clone(),
-                permitted_callers.clone(),
-                ttl,
-                payment_token,
-                payment_amount,
-                confidentiality,
+            let mut tx_request = TransactionRequest::default().to(self.tangle_address).input(
+                requestServiceWithExposureCall {
+                    blueprintId: blueprint_id,
+                    operators: operators.clone(),
+                    exposureBps: exposures,
+                    config: config.clone(),
+                    permittedCallers: permitted_callers.clone(),
+                    ttl,
+                    paymentToken: payment_token,
+                    paymentAmount: payment_amount,
+                    confidentiality,
+                }
+                .abi_encode()
+                .into(),
             );
             if is_native_payment {
-                call = call.value(payment_amount);
+                tx_request = tx_request.value(payment_amount);
             }
-            call.send().await
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REQUEST_SERVICE_MIN_GAS_LIMIT,
+            )
+            .await
         } else {
-            let mut call = contract.requestService(
-                blueprint_id,
-                operators.clone(),
-                config.clone(),
-                permitted_callers.clone(),
-                ttl,
-                payment_token,
-                payment_amount,
-                confidentiality,
+            let mut tx_request = TransactionRequest::default().to(self.tangle_address).input(
+                requestServiceCall {
+                    blueprintId: blueprint_id,
+                    operators: operators.clone(),
+                    config: config.clone(),
+                    permittedCallers: permitted_callers.clone(),
+                    ttl,
+                    paymentToken: payment_token,
+                    paymentAmount: payment_amount,
+                    confidentiality,
+                }
+                .abi_encode()
+                .into(),
             );
             if is_native_payment {
-                call = call.value(payment_amount);
+                tx_request = tx_request.value(payment_amount);
             }
-            call.send().await
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REQUEST_SERVICE_MIN_GAS_LIMIT,
+            )
+            .await
         }
         .map_err(|e| Error::Contract(e.to_string()))?;
-
-        let receipt = pending_tx.get_receipt().await?;
         if !receipt.status() {
             return Err(Error::Contract(
                 "requestService transaction reverted".into(),
@@ -1298,21 +1469,30 @@ impl TangleClient {
         request_id: u64,
         restaking_percent: u8,
     ) -> Result<TransactionResult> {
+        use crate::contracts::ITangle::approveServiceCall;
+
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
-        let contract = ITangle::new(self.tangle_address, &provider);
-
-        let receipt = contract
-            .approveService(request_id, restaking_percent)
-            .send()
-            .await
-            .map_err(|e| Error::Contract(e.to_string()))?
-            .get_receipt()
-            .await?;
+        let tx_request = TransactionRequest::default().to(self.tangle_address).input(
+            approveServiceCall {
+                requestId: request_id,
+                stakingPercent: restaking_percent,
+            }
+            .abi_encode()
+            .into(),
+        );
+        let receipt = send_transaction_with_fallback_gas(
+            &provider,
+            from_address,
+            tx_request,
+            APPROVE_SERVICE_MIN_GAS_LIMIT,
+        )
+        .await?;
 
         Ok(transaction_result_from_receipt(&receipt))
     }
@@ -1668,21 +1848,25 @@ impl TangleClient {
         spender: Address,
         amount: U256,
     ) -> Result<TransactionResult> {
+        use crate::client::IERC20::approveCall;
+
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
-        let contract = IERC20::new(token, &provider);
-
-        let receipt = contract
-            .approve(spender, amount)
-            .send()
-            .await
-            .map_err(|e| Error::Contract(e.to_string()))?
-            .get_receipt()
-            .await?;
+        let tx_request = TransactionRequest::default()
+            .to(token)
+            .input(approveCall { spender, amount }.abi_encode().into());
+        let receipt = send_transaction_with_fallback_gas(
+            &provider,
+            from_address,
+            tx_request,
+            ERC20_APPROVE_MIN_GAS_LIMIT,
+        )
+        .await?;
 
         Ok(transaction_result_from_receipt(&receipt))
     }
@@ -2123,6 +2307,10 @@ impl TangleClient {
         &self,
         stake_amount: U256,
     ) -> Result<TransactionResult> {
+        use crate::contracts::IMultiAssetDelegation::{
+            registerOperatorCall, registerOperatorWithAssetCall,
+        };
+
         let bond_token = self.operator_bond_token().await?;
 
         // Auto-approve ERC20 bond token if needed
@@ -2132,32 +2320,43 @@ impl TangleClient {
         }
 
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
-        let contract = IMultiAssetDelegation::new(self.restaking_address, &provider);
 
         let receipt = if bond_token == Address::ZERO {
-            // Native ETH bond
-            contract
-                .registerOperator()
-                .value(stake_amount)
-                .send()
-                .await
-                .map_err(|e| Error::Contract(e.to_string()))?
-                .get_receipt()
-                .await?
+            let tx_request = TransactionRequest::default()
+                .to(self.restaking_address)
+                .input(registerOperatorCall {}.abi_encode().into())
+                .value(stake_amount);
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REGISTER_OPERATOR_RESTAKING_MIN_GAS_LIMIT,
+            )
+            .await?
         } else {
-            // ERC20 bond (e.g., TNT)
-            contract
-                .registerOperatorWithAsset(bond_token, stake_amount)
-                .send()
-                .await
-                .map_err(|e| Error::Contract(e.to_string()))?
-                .get_receipt()
-                .await?
+            let tx_request = TransactionRequest::default()
+                .to(self.restaking_address)
+                .input(
+                    registerOperatorWithAssetCall {
+                        token: bond_token,
+                        amount: stake_amount,
+                    }
+                    .abi_encode()
+                    .into(),
+                );
+            send_transaction_with_fallback_gas(
+                &provider,
+                from_address,
+                tx_request,
+                REGISTER_OPERATOR_RESTAKING_MIN_GAS_LIMIT,
+            )
+            .await?
         };
 
         Ok(transaction_result_from_receipt(&receipt))
@@ -2517,35 +2716,32 @@ impl TangleClient {
         output: Bytes,
     ) -> Result<TransactionResult> {
         use crate::contracts::ITangle::submitResultCall;
-        use alloy_sol_types::SolCall;
 
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
 
-        let call = submitResultCall {
-            serviceId: service_id,
-            callId: call_id,
-            result: output,
-        };
-        let calldata = call.abi_encode();
+        let tx_request = TransactionRequest::default().to(self.tangle_address).input(
+            submitResultCall {
+                serviceId: service_id,
+                callId: call_id,
+                result: output,
+            }
+            .abi_encode()
+            .into(),
+        );
 
-        let tx_request = TransactionRequest::default()
-            .to(self.tangle_address)
-            .input(calldata.into());
-
-        let pending_tx = provider
-            .send_transaction(tx_request)
-            .await
-            .map_err(Error::Transport)?;
-
-        let receipt = pending_tx
-            .get_receipt()
-            .await
-            .map_err(Error::PendingTransaction)?;
+        let receipt = send_transaction_with_fallback_gas(
+            &provider,
+            from_address,
+            tx_request,
+            SUBMIT_RESULT_MIN_GAS_LIMIT,
+        )
+        .await?;
 
         Ok(TransactionResult {
             tx_hash: receipt.transaction_hash,
@@ -2912,5 +3108,71 @@ impl BlueprintServicesClient for TangleClient {
     /// Get the current blueprint ID
     async fn blueprint_id(&self) -> core::result::Result<Self::Id, Self::Error> {
         Ok(self.config.settings.blueprint_id)
+    }
+}
+
+#[cfg(test)]
+mod gas_fallback_tests {
+    use super::{
+        APPROVE_SERVICE_MIN_GAS_LIMIT, CREATE_BLUEPRINT_MIN_GAS_LIMIT, ERC20_APPROVE_MIN_GAS_LIMIT,
+        REGISTER_BLUEPRINT_OPERATOR_MIN_GAS_LIMIT, REGISTER_OPERATOR_RESTAKING_MIN_GAS_LIMIT,
+        REQUEST_SERVICE_MIN_GAS_LIMIT, SUBMIT_RESULT_GAS_BUFFER_DENOMINATOR,
+        SUBMIT_RESULT_GAS_BUFFER_NUMERATOR, SUBMIT_RESULT_MIN_GAS_LIMIT, buffered_gas_limit,
+    };
+
+    #[test]
+    fn fallback_to_min_when_estimation_unavailable() {
+        assert_eq!(
+            buffered_gas_limit(None, SUBMIT_RESULT_MIN_GAS_LIMIT),
+            SUBMIT_RESULT_MIN_GAS_LIMIT
+        );
+    }
+
+    #[test]
+    fn buffered_estimate_applied_when_above_min() {
+        let estimate = SUBMIT_RESULT_MIN_GAS_LIMIT * 2;
+        let expected = estimate.saturating_mul(SUBMIT_RESULT_GAS_BUFFER_NUMERATOR)
+            / SUBMIT_RESULT_GAS_BUFFER_DENOMINATOR;
+        assert_eq!(
+            buffered_gas_limit(Some(estimate), SUBMIT_RESULT_MIN_GAS_LIMIT),
+            expected
+        );
+        assert!(expected > estimate, "buffer must increase estimate");
+    }
+
+    #[test]
+    fn min_floor_applied_when_buffered_estimate_is_small() {
+        // Tiny estimate still gets bumped to min_gas_limit.
+        assert_eq!(
+            buffered_gas_limit(Some(1), SUBMIT_RESULT_MIN_GAS_LIMIT),
+            SUBMIT_RESULT_MIN_GAS_LIMIT
+        );
+        assert_eq!(
+            buffered_gas_limit(Some(21_000), ERC20_APPROVE_MIN_GAS_LIMIT),
+            ERC20_APPROVE_MIN_GAS_LIMIT
+        );
+    }
+
+    #[test]
+    fn saturating_math_never_overflows() {
+        // Degenerate estimate near u64::MAX must not wrap.
+        let out = buffered_gas_limit(Some(u64::MAX), SUBMIT_RESULT_MIN_GAS_LIMIT);
+        assert!(out >= SUBMIT_RESULT_MIN_GAS_LIMIT);
+    }
+
+    #[test]
+    fn min_limits_are_nonzero_sanity() {
+        // Fail-open floors must be non-zero for every call-site constant.
+        for min in [
+            SUBMIT_RESULT_MIN_GAS_LIMIT,
+            CREATE_BLUEPRINT_MIN_GAS_LIMIT,
+            REGISTER_BLUEPRINT_OPERATOR_MIN_GAS_LIMIT,
+            REQUEST_SERVICE_MIN_GAS_LIMIT,
+            APPROVE_SERVICE_MIN_GAS_LIMIT,
+            ERC20_APPROVE_MIN_GAS_LIMIT,
+            REGISTER_OPERATOR_RESTAKING_MIN_GAS_LIMIT,
+        ] {
+            assert!(min > 21_000, "gas floor {min} below 21k base tx cost");
+        }
     }
 }

--- a/crates/manager/src/metrics.rs
+++ b/crates/manager/src/metrics.rs
@@ -234,19 +234,44 @@ mod tests {
 
     #[test]
     fn all_metrics_register_on_default_registry() {
-        // Force lazy init of every static.
-        let _ = &*INIT_DURATION;
-        let _ = &*CONTRACT_SCAN_DURATION;
-        let _ = &*SERVICE_STARTUP_DURATION;
-        let _ = &*SOURCE_ATTEMPT_DURATION;
-        let _ = &*BLOCK_PROCESSING_DURATION;
-        let _ = &*SERVICE_DISCOVERY;
-        let _ = &*SOURCE_ATTEMPTS;
+        // Force lazy init AND materialize a child for each Vec metric —
+        // `prometheus::gather()` only emits a MetricFamily for a `*Vec` after
+        // a labeled child has been observed. Scalar types (IntGauge, bare
+        // Histogram) show up on registration alone.
+        INIT_DURATION
+            .with_label_values(&["register_check"])
+            .observe(0.0);
+        CONTRACT_SCAN_DURATION
+            .with_label_values::<&str>(&[])
+            .observe(0.0);
+        SERVICE_STARTUP_DURATION
+            .with_label_values(&["register_check", "github", "ok"])
+            .observe(0.0);
+        SOURCE_ATTEMPT_DURATION
+            .with_label_values(&["github", "/register/check", "ok"])
+            .observe(0.0);
+        BLOCK_PROCESSING_DURATION
+            .with_label_values::<&str>(&[])
+            .observe(0.0);
+        SERVICE_DISCOVERY
+            .with_label_values(&["register_check"])
+            .inc();
+        SOURCE_ATTEMPTS
+            .with_label_values(&["register_check", "success"])
+            .inc();
         let _ = &*ACTIVE_SERVICES;
-        let _ = &*REMOTE_PROVISION_DURATION;
-        let _ = &*JOB_EXECUTION_DURATION;
-        let _ = &*JOB_COST_USD;
-        let _ = &*JOBS_TOTAL;
+        REMOTE_PROVISION_DURATION
+            .with_label_values(&["register_check", "ok"])
+            .observe(0.0);
+        JOB_EXECUTION_DURATION
+            .with_label_values(&["register_check", "0", "ok"])
+            .observe(0.0);
+        JOB_COST_USD
+            .with_label_values(&["register_check", "0"])
+            .observe(0.0);
+        JOBS_TOTAL
+            .with_label_values(&["register_check", "0", "success"])
+            .inc();
         let _ = &*COMPUTE_COST_USD;
 
         let families = prometheus::gather();

--- a/crates/tangle-extra/src/producer.rs
+++ b/crates/tangle-extra/src/producer.rs
@@ -24,6 +24,8 @@ use tokio::time::sleep;
 
 use crate::extract;
 
+const MAX_LOG_RANGE_BLOCKS: u64 = 10;
+
 /// Error type for the producer
 #[derive(Debug, thiserror::Error)]
 pub enum ProducerError {
@@ -217,15 +219,24 @@ async fn poll_for_jobs(
             }
         };
 
-        if latest_block < from_block {
+        let effective_from_block = if from_block == 0 {
+            latest_block.saturating_sub(MAX_LOG_RANGE_BLOCKS.saturating_sub(1))
+        } else {
+            from_block
+        };
+
+        if latest_block < effective_from_block {
             sleep(Duration::from_millis(250)).await;
             continue;
         }
 
+        let to_block = latest_block
+            .min(effective_from_block.saturating_add(MAX_LOG_RANGE_BLOCKS.saturating_sub(1)));
+
         let filter = Filter::new()
             .address(client.tangle_address())
-            .from_block(from_block)
-            .to_block(latest_block);
+            .from_block(effective_from_block)
+            .to_block(to_block);
 
         let mut logs = match client.get_logs(&filter).await {
             Ok(logs) => {
@@ -234,8 +245,8 @@ async fn poll_for_jobs(
                         target: "tangle-producer",
                         rpc = "eth_getLogs",
                         attempts = get_logs_failures,
-                        from = from_block,
-                        to = latest_block,
+                        from = effective_from_block,
+                        to = to_block,
                         "RPC recovered after retries"
                     );
                     get_logs_failures = 0;
@@ -250,8 +261,8 @@ async fn poll_for_jobs(
                         target: "tangle-producer",
                         rpc = "eth_getLogs",
                         attempts = get_logs_failures,
-                        from = from_block,
-                        to = latest_block,
+                        from = effective_from_block,
+                        to = to_block,
                         delay_ms = delay.as_millis() as u64,
                         "Failed to fetch logs: {err}"
                     );
@@ -260,8 +271,8 @@ async fn poll_for_jobs(
                         target: "tangle-producer",
                         rpc = "eth_getLogs",
                         attempts = get_logs_failures,
-                        from = from_block,
-                        to = latest_block,
+                        from = effective_from_block,
+                        to = to_block,
                         delay_ms = delay.as_millis() as u64,
                         "Failed to fetch logs: {err}; retrying"
                     );
@@ -282,10 +293,10 @@ async fn poll_for_jobs(
             logs.into_iter()
                 .filter(|log| {
                     let block_number = log.block_number.unwrap_or_default();
-                    if block_number < from_block {
+                    if block_number < effective_from_block {
                         return false;
                     }
-                    if block_number > from_block {
+                    if block_number > effective_from_block {
                         return true;
                     }
                     let log_index = log.log_index.unwrap_or_default();
@@ -297,11 +308,11 @@ async fn poll_for_jobs(
         };
 
         let (last_block, last_log_index) = if let Some(last) = filtered_logs.last() {
-            (last.block_number.unwrap_or(latest_block), last.log_index)
-        } else if latest_block == from_block {
-            (from_block, from_log_index)
+            (last.block_number.unwrap_or(to_block), last.log_index)
+        } else if to_block == effective_from_block {
+            (effective_from_block, from_log_index)
         } else {
-            (latest_block, None)
+            (to_block, None)
         };
 
         let mut jobs = Vec::new();
@@ -412,8 +423,8 @@ async fn poll_for_jobs(
         if jobs.is_empty() {
             blueprint_core::trace!(
                 target: "tangle-producer",
-                from = from_block,
-                to = latest_block,
+                from = effective_from_block,
+                to = to_block,
                 "No jobs discovered during this poll"
             );
         } else {

--- a/examples/incredible-squaring-eigenlayer/Cargo.toml
+++ b/examples/incredible-squaring-eigenlayer/Cargo.toml
@@ -27,7 +27,7 @@ alloy-provider = { workspace = true }
 alloy-pubsub = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-rpc-types-eth = { workspace = true }
-alloy-rpc-client = { workspace = true }
+alloy-rpc-client = { workspace = true, features = ["reqwest"] }
 alloy-signer = { workspace = true }
 alloy-signer-local = { workspace = true }
 alloy-sol-types = { workspace = true, features = ["json"] }

--- a/workspace-hack/Cargo.toml
+++ b/workspace-hack/Cargo.toml
@@ -23,20 +23,20 @@ alloy-contract = { version = "1", default-features = false, features = ["pubsub"
 alloy-core = { version = "1", features = ["dyn-abi", "json-abi", "k256", "rlp"] }
 alloy-dyn-abi = { version = "1", features = ["eip712"] }
 alloy-eip7702 = { version = "0.6", default-features = false, features = ["k256", "serde", "std"] }
-alloy-eips = { version = "1", default-features = false, features = ["k256", "kzg", "serde", "std"] }
+alloy-eips = { version = "2", default-features = false, features = ["k256", "kzg", "serde", "std"] }
 alloy-json-abi = { version = "1", features = ["serde_json"] }
 alloy-network = { version = "1", default-features = false, features = ["k256"] }
 alloy-primitives = { version = "1", features = ["k256", "rlp", "serde"] }
 alloy-provider = { version = "1", features = ["anvil-api", "debug-api", "ipc", "trace-api", "txpool-api", "ws"] }
 alloy-rlp = { version = "0.3", features = ["arrayvec", "core-error", "core-net", "derive"] }
-alloy-rpc-client = { version = "1", default-features = false, features = ["ipc", "reqwest", "ws"] }
+alloy-rpc-client = { version = "2", default-features = false, features = ["ipc", "reqwest", "ws"] }
 alloy-rpc-types = { version = "1", default-features = false, features = ["anvil", "debug", "eth", "k256", "kzg", "trace", "txpool"] }
 alloy-rpc-types-eth = { version = "1", features = ["k256"] }
 alloy-signer = { version = "1", default-features = false, features = ["eip712"] }
 alloy-signer-local = { version = "1", default-features = false, features = ["mnemonic"] }
 alloy-sol-type-parser = { version = "1", default-features = false, features = ["eip712", "serde", "std"] }
 alloy-sol-types = { version = "1", features = ["eip712-serde", "json"] }
-alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-default-tls", "reqwest-rustls-tls"] }
+alloy-transport-http = { version = "2", default-features = false, features = ["reqwest", "reqwest-default-tls", "reqwest-rustls-tls"] }
 anyhow = { version = "1" }
 argon2 = { version = "0.5", default-features = false, features = ["std"] }
 ark-bn254 = { version = "0.5", default-features = false, features = ["curve", "std"] }
@@ -217,13 +217,13 @@ alloy-contract = { version = "1", default-features = false, features = ["pubsub"
 alloy-core = { version = "1", features = ["dyn-abi", "json-abi", "k256", "rlp"] }
 alloy-dyn-abi = { version = "1", features = ["eip712"] }
 alloy-eip7702 = { version = "0.6", default-features = false, features = ["k256", "serde", "std"] }
-alloy-eips = { version = "1", default-features = false, features = ["k256", "kzg", "serde", "std"] }
+alloy-eips = { version = "2", default-features = false, features = ["k256", "kzg", "serde", "std"] }
 alloy-json-abi = { version = "1", features = ["serde_json"] }
 alloy-network = { version = "1", default-features = false, features = ["k256"] }
 alloy-primitives = { version = "1", features = ["k256", "rlp", "serde"] }
 alloy-provider = { version = "1", features = ["anvil-api", "debug-api", "ipc", "trace-api", "txpool-api", "ws"] }
 alloy-rlp = { version = "0.3", features = ["arrayvec", "core-error", "core-net", "derive"] }
-alloy-rpc-client = { version = "1", default-features = false, features = ["ipc", "reqwest", "ws"] }
+alloy-rpc-client = { version = "2", default-features = false, features = ["ipc", "reqwest", "ws"] }
 alloy-rpc-types = { version = "1", default-features = false, features = ["anvil", "debug", "eth", "k256", "kzg", "trace", "txpool"] }
 alloy-rpc-types-eth = { version = "1", features = ["k256"] }
 alloy-signer = { version = "1", default-features = false, features = ["eip712"] }
@@ -233,7 +233,7 @@ alloy-sol-macro-expander = { version = "1", default-features = false, features =
 alloy-sol-macro-input = { version = "1", default-features = false, features = ["json"] }
 alloy-sol-type-parser = { version = "1", default-features = false, features = ["eip712", "serde", "std"] }
 alloy-sol-types = { version = "1", features = ["eip712-serde", "json"] }
-alloy-transport-http = { version = "1", default-features = false, features = ["reqwest", "reqwest-default-tls", "reqwest-rustls-tls"] }
+alloy-transport-http = { version = "2", default-features = false, features = ["reqwest", "reqwest-default-tls", "reqwest-rustls-tls"] }
 anyhow = { version = "1" }
 argon2 = { version = "0.5", default-features = false, features = ["std"] }
 ark-bn254 = { version = "0.5", default-features = false, features = ["curve", "std"] }


### PR DESCRIPTION
## Summary

- Bound Tangle log polling to small block windows so hosted RPC providers with `eth_getLogs` range limits do not fail historical or near-realtime polling.
- Added fallback gas sizing for key Tangle client transactions so contract calls still submit reliably when gas estimation is unavailable or too low.
- Affected flows: Tangle event polling, producer job discovery, service approval/request flows, ERC20 approval, operator registration, and result submission.

## Change Class

- `Class A` (docs/tooling only)
- `Class B` (single-crate behavior)
- `Class C` (cross-crate/runtime behavior)
- `Class D` (protocol/security/metadata semantics)
- Selected class: `Class C`
- Why this class: the change spans the Tangle client and `tangle-extra` producer runtime behavior, but does not intentionally change protocol semantics or metadata formats.

## Behavior Contract

- Current behavior: broad `eth_getLogs` scans can fail on RPC plans that cap block ranges, and some transactions rely on gas estimation succeeding exactly.
- Intended behavior: polling stays within bounded log windows, initial catch-up only scans a recent window, and critical transactions use buffered estimated gas with a conservative minimum fallback.
- Invariants that must hold: event polling continues to make forward progress, older active services remain discoverable via existing manager fallback paths, and transaction submission remains possible even when estimation is flaky.
- Failure mode choice (`fail-closed` or `fail-open`) and rationale: `fail-open` for transaction gas sizing by falling back to safe minimum limits, and bounded retry/poll behavior for log fetching to preserve liveness under constrained RPC providers.

## Risk and Scope

- Security impact: no intended security model change; this is a reliability-focused runtime adjustment.
- Compatibility impact (APIs, metadata format, configs): no API or metadata format changes expected.
- Migration notes (if any): none.
- Rollback plan: revert this PR to restore the previous unbounded log polling and direct transaction send behavior.

## Verification

List the exact commands you ran and outcomes.

```bash
# Passed: no whitespace or patch-format issues in the diff
 git diff --check

# Fetched latest main and confirmed a clean merge from this branch into origin/main
 git fetch origin main
 # then a temporary worktree merge check with `git merge --no-commit --no-ff origin/main` -> merge succeeded

# Not clean yet: rustfmt reported formatting diffs in the touched files,
# and `cargo fmt` is currently blocked by an existing rustfmt parser issue in
# crates/clients/tangle/src/client.rs (`let`-chain parsing)
 cargo fmt --all --check
```

## Harness Evidence

- Reproducer added/updated: none in this change.
- Negative-path coverage added: none in this change.
- Key assertions that prove the fix: not covered by new automated tests in this draft.

## Checklist

- [ ] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [ ] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [ ] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [ ] I added or updated tests that reproduce the original issue.
- [ ] I added or updated negative-path tests for invalid/missing/conflicting input.
- [ ] I documented behavior or interface changes in docs/examples when needed.
- [x] I evaluated compatibility/migration impact explicitly.
- [ ] I validated local formatting, clippy, and relevant tests.
