### PR TITLE
chore: release

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2846,7 +2846,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-anvil-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-eips 2.0.0",
@@ -2956,7 +2956,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-chain-setup-anvil",
  "workspace-hack",
@@ -2964,7 +2964,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup-anvil"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-provider",
@@ -2996,7 +2996,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-eigenlayer"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -3057,7 +3057,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-tangle"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -3092,7 +3092,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-clients"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-client-core",
  "blueprint-client-eigenlayer",
@@ -3123,7 +3123,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-contexts"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-client-tangle",
  "blueprint-clients",
@@ -3154,7 +3154,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-auth",
  "blueprint-clients",
@@ -3306,7 +3306,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3341,7 +3341,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -3364,7 +3364,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-evm-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-network 1.8.3",
@@ -3448,7 +3448,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-keystore"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3504,7 +3504,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3716,7 +3716,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-pricing-engine"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3807,7 +3807,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-qos"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3858,7 +3858,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-remote-providers"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3936,7 +3936,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-runner"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3981,7 +3981,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-sdk"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy",
  "alloy-json-abi",
@@ -4059,7 +4059,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -4091,7 +4091,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy",
  "alloy-network 1.8.3",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
@@ -4176,7 +4176,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-webhooks"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "axum",
  "blueprint-core",
@@ -4204,7 +4204,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-x402"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,25 +125,25 @@ broken_intra_doc_links = "deny"
 
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
-blueprint-sdk = { version = "0.2.0-alpha.3", path = "./crates/sdk", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
 tnt-core-bindings = { version = "0.10.7", git = "https://github.com/tangle-network/tnt-core.git", tag = "v0.10.7" }
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }
 blueprint-router = { version = "0.2.0-alpha.3", path = "crates/router", default-features = false }
-blueprint-runner = { version = "0.2.0-alpha.3", path = "crates/runner", default-features = false }
+blueprint-runner = { version = "0.2.0-alpha.4", path = "crates/runner", default-features = false }
 
 # Extras
-blueprint-tangle-extra = { version = "0.2.0-alpha.3", path = "crates/tangle-extra", features = ["std"] }
-blueprint-evm-extra = { version = "0.2.0-alpha.3", path = "crates/evm-extra", default-features = false }
-blueprint-eigenlayer-extra = { version = "0.2.0-alpha.3", path = "crates/eigenlayer-extra", default-features = false }
+blueprint-tangle-extra = { version = "0.2.0-alpha.4", path = "crates/tangle-extra", features = ["std"] }
+blueprint-evm-extra = { version = "0.2.0-alpha.4", path = "crates/evm-extra", default-features = false }
+blueprint-eigenlayer-extra = { version = "0.2.0-alpha.4", path = "crates/eigenlayer-extra", default-features = false }
 blueprint-producers-extra = { version = "0.2.0-alpha.3", path = "crates/producers-extra", default-features = false }
-blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.3", path = "crates/tangle-aggregation-svc", default-features = false }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.4", path = "crates/tangle-aggregation-svc", default-features = false }
 
 # Blueprint utils
-blueprint-manager = { version = "0.4.0-alpha.2", path = "./crates/manager", default-features = false }
+blueprint-manager = { version = "0.4.0-alpha.3", path = "./crates/manager", default-features = false }
 blueprint-manager-bridge = { version = "0.2.0-alpha.3", path = "./crates/manager/bridge", default-features = false }
-blueprint-remote-providers = { version = "0.2.0-alpha.3", path = "./crates/blueprint-remote-providers", default-features = false }
+blueprint-remote-providers = { version = "0.2.0-alpha.4", path = "./crates/blueprint-remote-providers", default-features = false }
 blueprint-faas = { version = "0.2.0-alpha.3", path = "./crates/blueprint-faas", default-features = false }
 blueprint-profiling = { version = "0.2.0-alpha.3", path = "./crates/blueprint-profiling", default-features = false }
 
@@ -153,8 +153,8 @@ blueprint-build-utils = { version = "0.2.0-alpha.3", path = "./crates/build-util
 blueprint-auth = { version = "0.2.0-alpha.3", path = "./crates/auth", default-features = false }
 
 # Chain Setup
-blueprint-chain-setup = { version = "0.2.0-alpha.3", path = "./crates/chain-setup", default-features = false }
-blueprint-chain-setup-anvil = { version = "0.2.0-alpha.3", path = "./crates/chain-setup/anvil", default-features = false }
+blueprint-chain-setup = { version = "0.2.0-alpha.4", path = "./crates/chain-setup", default-features = false }
+blueprint-chain-setup-anvil = { version = "0.2.0-alpha.4", path = "./crates/chain-setup/anvil", default-features = false }
 
 # Crypto
 blueprint-crypto-core = { version = "0.2.0-alpha.3", path = "./crates/crypto/core", default-features = false }
@@ -167,31 +167,31 @@ blueprint-crypto-bn254 = { version = "0.2.0-alpha.3", path = "./crates/crypto/bn
 blueprint-crypto = { version = "0.2.0-alpha.3", path = "./crates/crypto", default-features = false }
 
 # Clients
-blueprint-clients = { version = "0.2.0-alpha.3", path = "./crates/clients", default-features = false }
+blueprint-clients = { version = "0.2.0-alpha.4", path = "./crates/clients", default-features = false }
 blueprint-client-core = { version = "0.2.0-alpha.3", path = "./crates/clients/core", default-features = false }
-blueprint-client-eigenlayer = { version = "0.2.0-alpha.3", path = "./crates/clients/eigenlayer", default-features = false }
+blueprint-client-eigenlayer = { version = "0.2.0-alpha.4", path = "./crates/clients/eigenlayer", default-features = false }
 blueprint-client-evm = { version = "0.2.0-alpha.3", path = "./crates/clients/evm", default-features = false }
-blueprint-client-tangle = { version = "0.2.0-alpha.3", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-contexts = { version = "0.2.0-alpha.3", path = "./crates/contexts", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.4", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-contexts = { version = "0.2.0-alpha.4", path = "./crates/contexts", default-features = false }
 
 # Pricing Engine
-blueprint-pricing-engine = { version = "0.3.0-alpha.2", path = "./crates/pricing-engine", default-features = false }
+blueprint-pricing-engine = { version = "0.3.0-alpha.3", path = "./crates/pricing-engine", default-features = false }
 
 # TEE Support
 blueprint-tee = { version = "0.2.0-alpha.3", path = "./crates/tee", default-features = false }
 
 # x402 Payment Gateway
-blueprint-x402 = { version = "0.2.0-alpha.3", path = "./crates/x402", default-features = false }
+blueprint-x402 = { version = "0.2.0-alpha.4", path = "./crates/x402", default-features = false }
 
 # Webhook Producer
-blueprint-webhooks = { version = "0.2.0-alpha.3", path = "./crates/webhooks", default-features = false }
+blueprint-webhooks = { version = "0.2.0-alpha.4", path = "./crates/webhooks", default-features = false }
 
 # Macros
 blueprint-macros = { version = "0.2.0-alpha.3", path = "./crates/macros", default-features = false }
 blueprint-context-derive = { version = "0.2.0-alpha.3", path = "./crates/macros/context-derive", default-features = false }
 
 # Quality of Service
-blueprint-qos = { version = "0.2.0-alpha.3", path = "./crates/qos", default-features = false }
+blueprint-qos = { version = "0.2.0-alpha.4", path = "./crates/qos", default-features = false }
 
 # Stores
 blueprint-stores = { version = "0.2.0-alpha.3", path = "./crates/stores", default-features = false }
@@ -199,7 +199,7 @@ blueprint-store-local-database = { version = "0.2.0-alpha.3", path = "./crates/s
 rocksdb = { version = "0.21.0", default-features = false }
 
 # SDK
-blueprint-keystore = { version = "0.2.0-alpha.3", path = "./crates/keystore", default-features = false }
+blueprint-keystore = { version = "0.2.0-alpha.4", path = "./crates/keystore", default-features = false }
 blueprint-std = { version = "0.2.0-alpha.3", path = "./crates/std", default-features = false }
 
 # P2P
@@ -209,10 +209,10 @@ blueprint-networking-agg-sig-gossip-extension = { version = "0.2.0-alpha.3", pat
 blueprint-gossip-primitives = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
 
 # Testing utilities
-blueprint-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils", default-features = false }
-blueprint-core-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils/core", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils/anvil", default-features = false }
-blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.3", path = "./crates/testing-utils/eigenlayer", default-features = false }
+blueprint-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils", default-features = false }
+blueprint-core-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils/core", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils/anvil", default-features = false }
+blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils/eigenlayer", default-features = false }
 
 # Metrics
 blueprint-metrics = { version = "0.2.0-alpha.3", path = "./crates/metrics", default-features = false }

--- a/cli/CHANGELOG.md
+++ b/cli/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0-alpha.3](https://github.com/tangle-network/blueprint/compare/cargo-tangle-v0.4.0-alpha.22...cargo-tangle-v0.5.0-alpha.3) - 2026-04-22
+
+### Other
+
+- Rename staking contract CLI surface from restaking (#1381)
+
 ## [0.4.0-alpha.23](https://github.com/tangle-network/blueprint/compare/cargo-tangle-v0.4.0-alpha.22...cargo-tangle-v0.4.0-alpha.23) - 2025-10-02
 
 ### Other

--- a/crates/blueprint-remote-providers/CHANGELOG.md
+++ b/crates/blueprint-remote-providers/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-remote-providers-v0.2.0-alpha.3...blueprint-remote-providers-v0.2.0-alpha.4) - 2026-04-22
+
+### Fixed
+
+- *(tangle)* cap log queries and add gas fallbacks (#1382)

--- a/crates/blueprint-remote-providers/Cargo.toml
+++ b/crates/blueprint-remote-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-remote-providers"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Remote service providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/CHANGELOG.md
+++ b/crates/chain-setup/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-chain-setup-v0.2.0-alpha.3...blueprint-chain-setup-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-chain-setup-anvil
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-chain-setup-v0.1.0-alpha.20...blueprint-chain-setup-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/chain-setup/Cargo.toml
+++ b/crates/chain-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Chain setup utilities for use with Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/anvil/CHANGELOG.md
+++ b/crates/chain-setup/anvil/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-chain-setup-anvil-v0.2.0-alpha.3...blueprint-chain-setup-anvil-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-keystore, blueprint-core-testing-utils
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-chain-setup-anvil-v0.1.0-alpha.20...blueprint-chain-setup-anvil-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/chain-setup/anvil/Cargo.toml
+++ b/crates/chain-setup/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup-anvil"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Anvil-specific chain setup utilities"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/CHANGELOG.md
+++ b/crates/clients/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-clients-v0.2.0-alpha.3...blueprint-clients-v0.2.0-alpha.4) - 2026-04-22
+
+### Fixed
+
+- *(tangle)* cap log queries and add gas fallbacks (#1382)
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-clients-v0.1.0-alpha.20...blueprint-clients-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/clients/Cargo.toml
+++ b/crates/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-clients"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Metapackage for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/eigenlayer/CHANGELOG.md
+++ b/crates/clients/eigenlayer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-client-eigenlayer-v0.2.0-alpha.3...blueprint-client-eigenlayer-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-evm-extra, blueprint-runner
+
 ## [0.1.0-alpha.20](https://github.com/tangle-network/blueprint/compare/blueprint-client-eigenlayer-v0.1.0-alpha.19...blueprint-client-eigenlayer-v0.1.0-alpha.20) - 2025-10-30
 
 ### Other

--- a/crates/clients/eigenlayer/Cargo.toml
+++ b/crates/clients/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-eigenlayer"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Eigenlayer client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/tangle/CHANGELOG.md
+++ b/crates/clients/tangle/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-client-tangle-v0.2.0-alpha.3...blueprint-client-tangle-v0.2.0-alpha.4) - 2026-04-22
+
+### Fixed
+
+- *(tangle)* cap log queries and add gas fallbacks (#1382)

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-tangle"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/contexts/CHANGELOG.md
+++ b/crates/contexts/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-contexts-v0.2.0-alpha.3...blueprint-contexts-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-keystore, blueprint-client-tangle, blueprint-clients, blueprint-runner
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-contexts-v0.1.0-alpha.20...blueprint-contexts-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-contexts"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Context providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/eigenlayer-extra/CHANGELOG.md
+++ b/crates/eigenlayer-extra/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-eigenlayer-extra-v0.2.0-alpha.3...blueprint-eigenlayer-extra-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-evm-extra, blueprint-keystore, blueprint-runner, blueprint-client-eigenlayer
+
 ## [0.1.0-alpha.13](https://github.com/tangle-network/blueprint/compare/blueprint-eigenlayer-extra-v0.1.0-alpha.12...blueprint-eigenlayer-extra-v0.1.0-alpha.13) - 2025-10-02
 
 ### Other

--- a/crates/eigenlayer-extra/Cargo.toml
+++ b/crates/eigenlayer-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Eigenlayer extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/evm-extra/CHANGELOG.md
+++ b/crates/evm-extra/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-evm-extra-v0.2.0-alpha.3...blueprint-evm-extra-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.0-alpha.8](https://github.com/tangle-network/blueprint/compare/blueprint-evm-extra-v0.1.0-alpha.7...blueprint-evm-extra-v0.1.0-alpha.8) - 2025-10-02
 
 ### Other

--- a/crates/evm-extra/Cargo.toml
+++ b/crates/evm-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-evm-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "EVM extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/keystore/CHANGELOG.md
+++ b/crates/keystore/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-keystore-v0.2.0-alpha.3...blueprint-keystore-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- update Cargo.toml dependencies
+
 ### Removed
 
 - drop Substrate keystore backend and legacy `tangle` feature flag in favor of the new `tangle` stack (EVM-only)

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-keystore"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Keystore for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/CHANGELOG.md
+++ b/crates/manager/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0-alpha.3](https://github.com/tangle-network/blueprint/compare/blueprint-manager-v0.4.0-alpha.2...blueprint-manager-v0.4.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- harness system + x402 E2E + chain target flags (#1379)
+- *(cargo-tangle)* dev up/down workspace + fix silent Hetzner/Crusoe provider bug (#1376)
+- one-click local Tangle stack script
+
+### Fixed
+
+- *(tangle)* cap log queries and add gas fallbacks (#1382)
+
 ## [0.3.0-alpha.23](https://github.com/tangle-network/blueprint/compare/blueprint-manager-v0.3.0-alpha.22...blueprint-manager-v0.3.0-alpha.23) - 2025-11-03
 
 ### Other

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager"
-version = "0.4.0-alpha.2"
+version = "0.4.0-alpha.3"
 description = "Tangle Blueprint manager and Runner"
 authors.workspace = true
 edition.workspace = true

--- a/crates/pricing-engine/CHANGELOG.md
+++ b/crates/pricing-engine/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0-alpha.3](https://github.com/tangle-network/blueprint/compare/blueprint-pricing-engine-v0.3.0-alpha.2...blueprint-pricing-engine-v0.3.0-alpha.3) - 2026-04-22
+
+### Added
+
+- harness system + x402 E2E + chain target flags (#1379)
+- *(cargo-tangle)* dev up/down workspace + fix silent Hetzner/Crusoe provider bug (#1376)
+- one-click local Tangle stack script
+
 ## [0.2.5](https://github.com/tangle-network/blueprint/compare/blueprint-pricing-engine-v0.2.4...blueprint-pricing-engine-v0.2.5) - 2025-10-02
 
 ### Other

--- a/crates/pricing-engine/Cargo.toml
+++ b/crates/pricing-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-pricing-engine"
-version = "0.3.0-alpha.2"
+version = "0.3.0-alpha.3"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/qos/CHANGELOG.md
+++ b/crates/qos/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-qos-v0.2.0-alpha.3...blueprint-qos-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-keystore, blueprint-remote-providers
+
 ## [0.1.0-alpha.6](https://github.com/tangle-network/blueprint/compare/blueprint-qos-v0.1.0-alpha.5...blueprint-qos-v0.1.0-alpha.6) - 2025-10-02
 
 ### Other

--- a/crates/qos/Cargo.toml
+++ b/crates/qos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-qos"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Quality of Service (QoS) module for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/runner/CHANGELOG.md
+++ b/crates/runner/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-runner-v0.2.0-alpha.3...blueprint-runner-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-evm-extra, blueprint-keystore, blueprint-client-tangle, blueprint-qos
+
 ## [0.1.0-alpha.20](https://github.com/tangle-network/blueprint/compare/blueprint-runner-v0.1.0-alpha.19...blueprint-runner-v0.1.0-alpha.20) - 2025-10-30
 
 ### Other

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-runner"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Runner for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/sdk/CHANGELOG.md
+++ b/crates/sdk/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-sdk-v0.2.0-alpha.3...blueprint-sdk-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-evm-extra, blueprint-keystore, blueprint-tangle-extra, blueprint-remote-providers, blueprint-clients, blueprint-qos, blueprint-runner, blueprint-chain-setup, blueprint-contexts, blueprint-eigenlayer-extra, blueprint-testing-utils, blueprint-webhooks, blueprint-x402
+
 ## [0.1.0-alpha.22](https://github.com/tangle-network/blueprint/compare/blueprint-sdk-v0.1.0-alpha.21...blueprint-sdk-v0.1.0-alpha.22) - 2025-11-03
 
 ### Other

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-sdk"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Blueprint SDK for building decentralized and distributed services."
 authors.workspace = true
 edition.workspace = true

--- a/crates/tangle-aggregation-svc/CHANGELOG.md
+++ b/crates/tangle-aggregation-svc/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-tangle-aggregation-svc-v0.2.0-alpha.3...blueprint-tangle-aggregation-svc-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-client-tangle

--- a/crates/tangle-aggregation-svc/Cargo.toml
+++ b/crates/tangle-aggregation-svc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition = "2021"
 description = "BLS signature aggregation service for Tangle v2"
 license = "MIT OR Apache-2.0"

--- a/crates/tangle-extra/CHANGELOG.md
+++ b/crates/tangle-extra/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-tangle-extra-v0.2.0-alpha.3...blueprint-tangle-extra-v0.2.0-alpha.4) - 2026-04-22
+
+### Fixed
+
+- *(tangle)* cap log queries and add gas fallbacks (#1382)

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Producer/Consumer extras for Tangle blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/CHANGELOG.md
+++ b/crates/testing-utils/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-testing-utils-v0.2.0-alpha.3...blueprint-testing-utils-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-anvil-testing-utils, blueprint-core-testing-utils, blueprint-eigenlayer-testing-utils
+
 ## [0.1.0-alpha.20](https://github.com/tangle-network/blueprint/compare/blueprint-testing-utils-v0.1.0-alpha.19...blueprint-testing-utils-v0.1.0-alpha.20) - 2025-10-02
 
 ### Other

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Testing utilities metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/anvil/CHANGELOG.md
+++ b/crates/testing-utils/anvil/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-anvil-testing-utils-v0.2.0-alpha.3...blueprint-anvil-testing-utils-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- update Cargo.toml dependencies
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-anvil-testing-utils-v0.1.0-alpha.20...blueprint-anvil-testing-utils-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/testing-utils/anvil/Cargo.toml
+++ b/crates/testing-utils/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-anvil-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Anvil testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/core/CHANGELOG.md
+++ b/crates/testing-utils/core/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-core-testing-utils-v0.2.0-alpha.3...blueprint-core-testing-utils-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-keystore, blueprint-clients, blueprint-qos, blueprint-runner
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-core-testing-utils-v0.1.0-alpha.20...blueprint-core-testing-utils-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/testing-utils/core/Cargo.toml
+++ b/crates/testing-utils/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Core primitives for testing Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/eigenlayer/CHANGELOG.md
+++ b/crates/testing-utils/eigenlayer/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-eigenlayer-testing-utils-v0.2.0-alpha.3...blueprint-eigenlayer-testing-utils-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-evm-extra, blueprint-runner, blueprint-core-testing-utils, blueprint-chain-setup
+
 ## [0.1.0-alpha.21](https://github.com/tangle-network/blueprint/compare/blueprint-eigenlayer-testing-utils-v0.1.0-alpha.20...blueprint-eigenlayer-testing-utils-v0.1.0-alpha.21) - 2025-10-30
 
 ### Other

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "EigenLayer-specific testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/webhooks/CHANGELOG.md
+++ b/crates/webhooks/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-webhooks-v0.2.0-alpha.3...blueprint-webhooks-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-runner

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-webhooks"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Webhook producer for Blueprint SDK — trigger jobs from external HTTP events"
 authors.workspace = true
 edition.workspace = true

--- a/crates/x402/CHANGELOG.md
+++ b/crates/x402/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-x402-v0.2.0-alpha.3...blueprint-x402-v0.2.0-alpha.4) - 2026-04-22
+
+### Other
+
+- updated the following local packages: blueprint-runner

--- a/crates/x402/Cargo.toml
+++ b/crates/x402/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-x402"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "x402 payment gateway for Blueprint SDK — cross-chain EVM settlement for job execution"
 authors.workspace = true
 edition.workspace = true

--- a/examples/apikey-blueprint/apikey-blueprint-bin/CHANGELOG.md
+++ b/examples/apikey-blueprint/apikey-blueprint-bin/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/apikey-blueprint-bin-v0.2.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- one-click local Tangle stack script

--- a/examples/apikey-blueprint/apikey-blueprint-lib/CHANGELOG.md
+++ b/examples/apikey-blueprint/apikey-blueprint-lib/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/apikey-blueprint-lib-v0.2.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- one-click local Tangle stack script

--- a/examples/incredible-squaring/incredible-squaring-bin/CHANGELOG.md
+++ b/examples/incredible-squaring/incredible-squaring-bin/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/incredible-squaring-blueprint-bin-v0.2.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- one-click local Tangle stack script

--- a/examples/incredible-squaring/incredible-squaring-lib/CHANGELOG.md
+++ b/examples/incredible-squaring/incredible-squaring-lib/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/incredible-squaring-blueprint-lib-v0.2.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- one-click local Tangle stack script

--- a/examples/oauth-blueprint/oauth-blueprint-bin/CHANGELOG.md
+++ b/examples/oauth-blueprint/oauth-blueprint-bin/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/oauth-blueprint-bin-v0.2.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- one-click local Tangle stack script

--- a/examples/oauth-blueprint/oauth-blueprint-lib/CHANGELOG.md
+++ b/examples/oauth-blueprint/oauth-blueprint-lib/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/oauth-blueprint-lib-v0.2.0-alpha.3) - 2026-04-22
+
+### Added
+
+- security hardening + staking_contract rename + alpha.3 (#1380)
+- one-click local Tangle stack script


### PR DESCRIPTION



## 🤖 New release

* `blueprint-evm-extra`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-keystore`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-client-tangle`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-tangle-extra`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-pricing-engine`: 0.3.0-alpha.2 -> 0.3.0-alpha.3
* `blueprint-remote-providers`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-clients`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-anvil-testing-utils`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-manager`: 0.4.0-alpha.2 -> 0.4.0-alpha.3
* `cargo-tangle`: 0.4.0-alpha.22 -> 0.5.0-alpha.3
* `oauth-blueprint-lib`: 0.2.0-alpha.3
* `oauth-blueprint-bin`: 0.2.0-alpha.3
* `apikey-blueprint-lib`: 0.2.0-alpha.3
* `apikey-blueprint-bin`: 0.2.0-alpha.3
* `incredible-squaring-blueprint-lib`: 0.2.0-alpha.3
* `incredible-squaring-blueprint-bin`: 0.2.0-alpha.3
* `blueprint-tangle-aggregation-svc`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-qos`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-runner`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-client-eigenlayer`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-core-testing-utils`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-chain-setup-anvil`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-chain-setup`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-contexts`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-eigenlayer-extra`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-eigenlayer-testing-utils`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-testing-utils`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-webhooks`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-x402`: 0.2.0-alpha.3 -> 0.2.0-alpha.4
* `blueprint-sdk`: 0.2.0-alpha.3 -> 0.2.0-alpha.4

<details><summary><i><b>Changelog</b></i></summary><p>

## `blueprint-evm-extra`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-evm-extra-v0.2.0-alpha.3...blueprint-evm-extra-v0.2.0-alpha.4) - 2026-04-22

### Other

- update Cargo.toml dependencies
</blockquote>

## `blueprint-keystore`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-keystore-v0.2.0-alpha.3...blueprint-keystore-v0.2.0-alpha.4) - 2026-04-22

### Other

- update Cargo.toml dependencies

### Removed

- drop Substrate keystore backend and legacy `tangle` feature flag in favor of the new `tangle` stack (EVM-only)
</blockquote>

## `blueprint-client-tangle`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-client-tangle-v0.2.0-alpha.3...blueprint-client-tangle-v0.2.0-alpha.4) - 2026-04-22

### Fixed

- *(tangle)* cap log queries and add gas fallbacks (#1382)
</blockquote>

## `blueprint-tangle-extra`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-tangle-extra-v0.2.0-alpha.3...blueprint-tangle-extra-v0.2.0-alpha.4) - 2026-04-22

### Fixed

- *(tangle)* cap log queries and add gas fallbacks (#1382)
</blockquote>

## `blueprint-pricing-engine`

<blockquote>

## [0.3.0-alpha.3](https://github.com/tangle-network/blueprint/compare/blueprint-pricing-engine-v0.3.0-alpha.2...blueprint-pricing-engine-v0.3.0-alpha.3) - 2026-04-22

### Added

- harness system + x402 E2E + chain target flags (#1379)
- *(cargo-tangle)* dev up/down workspace + fix silent Hetzner/Crusoe provider bug (#1376)
- one-click local Tangle stack script
</blockquote>

## `blueprint-remote-providers`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-remote-providers-v0.2.0-alpha.3...blueprint-remote-providers-v0.2.0-alpha.4) - 2026-04-22

### Fixed

- *(tangle)* cap log queries and add gas fallbacks (#1382)
</blockquote>

## `blueprint-clients`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-clients-v0.2.0-alpha.3...blueprint-clients-v0.2.0-alpha.4) - 2026-04-22

### Fixed

- *(tangle)* cap log queries and add gas fallbacks (#1382)
</blockquote>

## `blueprint-anvil-testing-utils`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-anvil-testing-utils-v0.2.0-alpha.3...blueprint-anvil-testing-utils-v0.2.0-alpha.4) - 2026-04-22

### Other

- update Cargo.toml dependencies
</blockquote>

## `blueprint-manager`

<blockquote>

## [0.4.0-alpha.3](https://github.com/tangle-network/blueprint/compare/blueprint-manager-v0.4.0-alpha.2...blueprint-manager-v0.4.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- harness system + x402 E2E + chain target flags (#1379)
- *(cargo-tangle)* dev up/down workspace + fix silent Hetzner/Crusoe provider bug (#1376)
- one-click local Tangle stack script

### Fixed

- *(tangle)* cap log queries and add gas fallbacks (#1382)
</blockquote>

## `cargo-tangle`

<blockquote>

## [0.5.0-alpha.3](https://github.com/tangle-network/blueprint/compare/cargo-tangle-v0.4.0-alpha.22...cargo-tangle-v0.5.0-alpha.3) - 2026-04-22

### Other

- Rename staking contract CLI surface from restaking (#1381)
</blockquote>

## `oauth-blueprint-lib`

<blockquote>

## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/oauth-blueprint-lib-v0.2.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- one-click local Tangle stack script
</blockquote>

## `oauth-blueprint-bin`

<blockquote>

## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/oauth-blueprint-bin-v0.2.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- one-click local Tangle stack script
</blockquote>

## `apikey-blueprint-lib`

<blockquote>

## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/apikey-blueprint-lib-v0.2.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- one-click local Tangle stack script
</blockquote>

## `apikey-blueprint-bin`

<blockquote>

## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/apikey-blueprint-bin-v0.2.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- one-click local Tangle stack script
</blockquote>

## `incredible-squaring-blueprint-lib`

<blockquote>

## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/incredible-squaring-blueprint-lib-v0.2.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- one-click local Tangle stack script
</blockquote>

## `incredible-squaring-blueprint-bin`

<blockquote>

## [0.2.0-alpha.3](https://github.com/tangle-network/blueprint/releases/tag/incredible-squaring-blueprint-bin-v0.2.0-alpha.3) - 2026-04-22

### Added

- security hardening + staking_contract rename + alpha.3 (#1380)
- one-click local Tangle stack script
</blockquote>

## `blueprint-tangle-aggregation-svc`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-tangle-aggregation-svc-v0.2.0-alpha.3...blueprint-tangle-aggregation-svc-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-client-tangle
</blockquote>

## `blueprint-qos`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-qos-v0.2.0-alpha.3...blueprint-qos-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-keystore, blueprint-remote-providers
</blockquote>

## `blueprint-runner`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-runner-v0.2.0-alpha.3...blueprint-runner-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-evm-extra, blueprint-keystore, blueprint-client-tangle, blueprint-qos
</blockquote>

## `blueprint-client-eigenlayer`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-client-eigenlayer-v0.2.0-alpha.3...blueprint-client-eigenlayer-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-evm-extra, blueprint-runner
</blockquote>

## `blueprint-core-testing-utils`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-core-testing-utils-v0.2.0-alpha.3...blueprint-core-testing-utils-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-keystore, blueprint-clients, blueprint-qos, blueprint-runner
</blockquote>

## `blueprint-chain-setup-anvil`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-chain-setup-anvil-v0.2.0-alpha.3...blueprint-chain-setup-anvil-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-keystore, blueprint-core-testing-utils
</blockquote>

## `blueprint-chain-setup`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-chain-setup-v0.2.0-alpha.3...blueprint-chain-setup-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-chain-setup-anvil
</blockquote>

## `blueprint-contexts`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-contexts-v0.2.0-alpha.3...blueprint-contexts-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-keystore, blueprint-client-tangle, blueprint-clients, blueprint-runner
</blockquote>

## `blueprint-eigenlayer-extra`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-eigenlayer-extra-v0.2.0-alpha.3...blueprint-eigenlayer-extra-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-evm-extra, blueprint-keystore, blueprint-runner, blueprint-client-eigenlayer
</blockquote>

## `blueprint-eigenlayer-testing-utils`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-eigenlayer-testing-utils-v0.2.0-alpha.3...blueprint-eigenlayer-testing-utils-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-evm-extra, blueprint-runner, blueprint-core-testing-utils, blueprint-chain-setup
</blockquote>

## `blueprint-testing-utils`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-testing-utils-v0.2.0-alpha.3...blueprint-testing-utils-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-anvil-testing-utils, blueprint-core-testing-utils, blueprint-eigenlayer-testing-utils
</blockquote>

## `blueprint-webhooks`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-webhooks-v0.2.0-alpha.3...blueprint-webhooks-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-runner
</blockquote>

## `blueprint-x402`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-x402-v0.2.0-alpha.3...blueprint-x402-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-runner
</blockquote>

## `blueprint-sdk`

<blockquote>

## [0.2.0-alpha.4](https://github.com/tangle-network/blueprint/compare/blueprint-sdk-v0.2.0-alpha.3...blueprint-sdk-v0.2.0-alpha.4) - 2026-04-22

### Other

- updated the following local packages: blueprint-evm-extra, blueprint-keystore, blueprint-tangle-extra, blueprint-remote-providers, blueprint-clients, blueprint-qos, blueprint-runner, blueprint-chain-setup, blueprint-contexts, blueprint-eigenlayer-extra, blueprint-testing-utils, blueprint-webhooks, blueprint-x402
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).