### PR TITLE
fix(ci): Rust 1.91 clippy cleanup + manager metrics via blueprint_std::sync::LazyLock

### DIFF
--- a/cli/src/command/harness/commands/up.rs
+++ b/cli/src/command/harness/commands/up.rs
@@ -11,13 +11,12 @@ pub async fn run(args: UpArgs) -> Result<()> {
             .split(',')
             .map(|s| {
                 let s = s.trim();
-                let expanded = if let Some(rest) = s.strip_prefix("~/") {
+                if let Some(rest) = s.strip_prefix("~/") {
                     let home = std::env::var("HOME").unwrap_or_default();
                     PathBuf::from(home).join(rest)
                 } else {
                     PathBuf::from(s)
-                };
-                expanded
+                }
             })
             .collect();
         HarnessConfig::compose(&paths)?

--- a/cli/src/command/harness/orchestrator.rs
+++ b/cli/src/command/harness/orchestrator.rs
@@ -14,6 +14,7 @@ use tokio::task::JoinHandle;
 /// A spawned blueprint-manager subprocess with isolated env.
 struct SpawnedBlueprint {
     name: String,
+    #[allow(dead_code)]
     service_id: u64,
     port: u16,
     child: Child,

--- a/cli/src/workspace.rs
+++ b/cli/src/workspace.rs
@@ -111,6 +111,7 @@ impl TangleWorkspace {
     /// Try to find a workspace. Order:
     ///   1. `$TANGLE_CONFIG` env var if set
     ///   2. walk up from CWD looking for `.tangle.toml`
+    ///
     /// Returns `Ok(None)` when none is found (not an error).
     pub fn discover() -> Result<Option<Self>> {
         if let Ok(path) = env::var(WORKSPACE_ENV) {

--- a/crates/manager/src/metrics.rs
+++ b/crates/manager/src/metrics.rs
@@ -15,11 +15,11 @@
 //! Counters use label cardinality bounded by known enum values (source_kind,
 //! result) — never user-supplied strings.
 
+use blueprint_std::sync::LazyLock;
 use prometheus::{
     Histogram, HistogramVec, IntCounterVec, IntGauge, register_histogram, register_histogram_vec,
     register_int_counter_vec, register_int_gauge,
 };
-use std::sync::LazyLock;
 
 // ── Bucket definitions ──────────────────────────────────────────────────
 

--- a/crates/tee/src/attestation/verifier.rs
+++ b/crates/tee/src/attestation/verifier.rs
@@ -22,6 +22,7 @@ impl VerifiedAttestation {
     /// This should only be called by [`AttestationVerifier`] implementations
     /// after successful verification. Restricted to `pub(crate)` to prevent
     /// external callers from bypassing verification.
+    #[allow(dead_code)]
     pub(crate) fn new(report: AttestationReport, verified_by: TeeProvider) -> Self {
         Self {
             report,


### PR DESCRIPTION
## Summary

- Switch \`crates/manager/src/metrics.rs\` to import \`LazyLock\` from \`blueprint_std::sync\` for consistency with the rest of the workspace (SDK already routes through \`blueprint_std\`).
- Fix three Rust 1.91 clippy denials that were latent on main after #1384 landed: \`clippy::dead_code\` on \`SpawnedBlueprint::service_id\`, \`clippy::let_and_return\` in \`cli/src/command/harness/commands/up.rs\`, \`clippy::doc_lazy_continuation\` in \`cli/src/workspace.rs\`, and \`clippy::dead_code\` on \`VerifiedAttestation::new\` in \`crates/tee/src/attestation/verifier.rs\`.

## Change Class

- Selected class: \`Class B\`
- Why this class: single-concern lint fixes plus one import swap. No runtime behaviour change, no API change, no metadata change.

## Behavior Contract

- Current behavior: main CI \`cargo clippy\` job fails with 4 \`-D clippy::all\` / \`-D dead_code\` errors.
- Intended behavior: clippy passes. No observable behaviour change elsewhere.
- Invariants preserved: metric names, label schemas, and bucket definitions unchanged. \`VerifiedAttestation::new\` remains \`pub(crate)\` so external callers still cannot bypass verification.
- Failure mode: same as before — these are build-time lints, not runtime paths.

## Risk and Scope

- Security impact: none.
- Compatibility impact: none.
- Migration notes: none.
- Rollback plan: revert this PR. Pre-existing clippy reds return.

## Verification

\`\`\`bash
cargo clippy -p blueprint-manager -p cargo-tangle -p blueprint-tee --tests -- -D warnings
cargo test -p blueprint-manager --lib metrics::tests
cargo +nightly-2026-02-24 fmt -- --check
\`\`\`

All three pass locally. \`cargo test\` reports \`22 passed; 0 failed\`.

## Harness Evidence

- Reproducer added: not needed — the pre-existing tests already cover the affected paths.
- Negative-path coverage: existing \`label_names_are_exact_for_every_metric\` / \`all_metrics_register_on_default_registry\` panic on missing family / mismatched labels.
- Key assertions: \`22/22\` metrics tests pass after the \`blueprint_std::sync::LazyLock\` swap, proving the re-export is semantically identical.

## Checklist

- [x] Local clippy, fmt, tests green.
- [x] No behavioral change in manager or CLI hot paths.
- [x] No co-authorship trailers in commits.