### PR TITLE
fix(ci): unblock main — x402 test lints + manager label-test ACTIVE_SERVICES

### DIFF
--- a/crates/manager/src/metrics.rs
+++ b/crates/manager/src/metrics.rs
@@ -665,6 +665,11 @@ mod tests {
         JOBS_TOTAL
             .with_label_values(&["label_names_bp4", "0", "success"])
             .inc();
+        // Scalar metrics must also be touched so their Lazy is forced within
+        // this nextest process; otherwise prometheus::gather() omits them.
+        // set(0)/observe(0.0) instead of a deref so the optimiser can't skip.
+        ACTIVE_SERVICES.set(0);
+        COMPUTE_COST_USD.observe(OVERFLOW);
 
         let families = prometheus::gather();
 

--- a/examples/x402-blueprint/tests/x402_e2e_anvil.rs
+++ b/examples/x402-blueprint/tests/x402_e2e_anvil.rs
@@ -35,7 +35,7 @@ mod e2e {
 
     // x402 EIP-3009 client + facilitator
     use x402_chain_eip155::chain::{
-        Eip155ChainProvider, Eip155ChainReference,
+        Eip155ChainReference,
         config::{Eip155ChainConfig, Eip155ChainConfigInner, RpcConfig},
     };
     use x402_chain_eip155::v1_eip155_exact::{
@@ -466,7 +466,7 @@ mod e2e {
         let (fac_h, fac_port) = start_real_facilitator(&fork.rpc_url()).await;
 
         // 3. Start gateway pointing at real facilitator
-        let (gw_h, gw_port, mut producer) = start_gateway(fac_port).await;
+        let (gw_h, gw_port, _producer) = start_gateway(fac_port).await;
 
         // 4. Record balances BEFORE
         let payer_before = usdc_balance(&fork.rpc_url(), PAYER).await;


### PR DESCRIPTION
## Summary

Main CI is red on three Rust 1.91 clippy errors in the x402 e2e test and a still-panicking manager metric test. This PR surgically unblocks both.

- Drop unused \`Eip155ChainProvider\` import; rename the gateway tuple's third binding to \`_producer\` and remove the \`mut\` (no mutable use, no reads).
- Touch \`ACTIVE_SERVICES\` and \`COMPUTE_COST_USD\` inside \`label_names_are_exact_for_every_metric\` so their \`LazyLock\` is forced within this nextest process (nextest runs each test in its own process, so scalar \`Lazy\` statics reset).

## Change Class

- Selected class: Class B
- Why this class: single-concern lint + test-local fix. No API, runtime, or metadata change.

## Behavior Contract

- Current behavior: main \`cargo clippy\` job fails with 3 \`-D warnings\` errors in \`x402_e2e_anvil.rs\`; \`cargo test (blueprint-manager)\` fails \`label_names_are_exact_for_every_metric\` with \`missing tangle_active_services\`.
- Intended behavior: both jobs pass. No observable change elsewhere.
- Invariants: metric names, label schemas, and bucket definitions unchanged. x402 test logic unchanged — the unused import removal and binding rename are both lint-only.
- Failure mode choice: \`fail-closed\` for the tests (assertions still panic on real breakage).

## Risk and Scope

- Security impact: none.
- Compatibility impact: none.
- Migration notes: none.
- Rollback plan: revert; main CI goes back to red on these three errors + one test.

## Verification

\`\`\`bash
cargo test -p blueprint-manager --lib metrics::tests::label_names_are_exact_for_every_metric
cargo clippy -p x402-blueprint --tests -- -D warnings
cargo +nightly-2026-02-24 fmt -p blueprint-manager -p x402-blueprint -- --check
\`\`\`

All three pass locally.

## Harness Evidence

- Reproducer already exists in-repo: \`label_names_are_exact_for_every_metric\` panics with \`missing tangle_active_services\` on main HEAD (run 24758100534). After this PR, the test asserts schemas for every metric including the two scalars.
- Negative-path coverage: the \`assert_labels\` helper still panics on missing family / mismatched labels — new touches just make the missing-family case no longer fire for \`ACTIVE_SERVICES\` and \`COMPUTE_COST_USD\`.
- Key assertions: local run reports \`1 passed; 0 failed\`.

## Checklist

- [x] Local clippy, test, and fmt green on touched crates.
- [x] No behavioral change in production code paths.
- [x] No co-authorship trailers.