### PR TITLE
fix(ci): address soldeer-retry review — skip final sleep, retry Rust build-utils too

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -12,6 +12,7 @@
   run: |
     # Soldeer registry flakes frequently from GitHub Actions IPs —
     # retry with exponential backoff before failing the whole build.
+    # No sleep after the final attempt so we exit as soon as we give up.
     attempts=5
     delay=10
     for attempt in $(seq 1 $attempts); do
@@ -19,9 +20,11 @@
         echo "Solidity dependencies installed on attempt $attempt"
         exit 0
       fi
-      echo "soldeer attempt $attempt/$attempts failed; sleeping ${delay}s"
-      sleep "$delay"
-      delay=$((delay * 2))
+      if [ "$attempt" -lt "$attempts" ]; then
+        echo "soldeer attempt $attempt/$attempts failed; sleeping ${delay}s"
+        sleep "$delay"
+        delay=$((delay * 2))
+      fi
     done
     echo "soldeer failed after $attempts attempts" >&2
     exit 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,6 +138,7 @@ jobs:
         run: |
           # Soldeer registry flakes frequently from GitHub Actions IPs —
           # retry with exponential backoff before failing the whole build.
+          # No sleep after the final attempt so we exit as soon as we give up.
           attempts=5
           delay=10
           for attempt in $(seq 1 $attempts); do
@@ -145,9 +146,11 @@ jobs:
               echo "Solidity dependencies installed on attempt $attempt"
               exit 0
             fi
-            echo "soldeer attempt $attempt/$attempts failed; sleeping ${delay}s"
-            sleep "$delay"
-            delay=$((delay * 2))
+            if [ "$attempt" -lt "$attempts" ]; then
+              echo "soldeer attempt $attempt/$attempts failed; sleeping ${delay}s"
+              sleep "$delay"
+              delay=$((delay * 2))
+            fi
           done
           echo "soldeer failed after $attempts attempts" >&2
           exit 1

--- a/crates/build-utils/src/lib.rs
+++ b/crates/build-utils/src/lib.rs
@@ -116,29 +116,54 @@ fn workspace_or_manifest_dir() -> PathBuf {
     PathBuf::from(dir)
 }
 
+/// Run a `forge soldeer <subcommand>` with exponential-backoff retries.
+///
+/// The soldeer registry intermittently rejects GitHub Actions runner IPs and
+/// other high-rate clients, so a single dropped connection used to fail the
+/// whole build. Retries 5 times (10s, 20s, 40s, 80s backoff between attempts)
+/// and only panics when every attempt fails.
+fn run_soldeer_with_retry(args: &[&str], label: &str) {
+    let root = workspace_or_manifest_dir();
+    let forge_executable = find_forge_executable();
+    let attempts = 5u32;
+    let mut delay = std::time::Duration::from_secs(10);
+    for attempt in 1..=attempts {
+        let status = Command::new(&forge_executable)
+            .current_dir(&root)
+            .args(args)
+            .status()
+            .unwrap_or_else(|e| panic!("Failed to execute 'forge {label}': {e}"));
+        if status.success() {
+            if attempt > 1 {
+                println!("'forge {label}' succeeded on attempt {attempt}/{attempts}");
+            }
+            return;
+        }
+        if attempt < attempts {
+            println!(
+                "'forge {label}' attempt {attempt}/{attempts} failed; sleeping {}s",
+                delay.as_secs()
+            );
+            std::thread::sleep(delay);
+            delay *= 2;
+        }
+    }
+    panic!("'forge {label}' failed after {attempts} attempts");
+}
+
 /// Run soldeer's 'install' command if the dependencies directory exists and is not empty.
 ///
 /// # Panics
 /// - If the Cargo Manifest directory is not found.
 /// - If the `forge` executable is not found.
-/// - If forge's `soldeer` is not installed.
+/// - If forge's `soldeer` is not installed or fails every retry attempt.
 pub fn soldeer_install() {
-    // Get the project root directory
-    let root = workspace_or_manifest_dir();
-
     // Check if the dependencies directory exists and is not empty
+    let root = workspace_or_manifest_dir();
     let dependencies_dir = root.join("dependencies");
     if !dependencies_dir.exists() || is_directory_empty(&dependencies_dir) {
-        let forge_executable = find_forge_executable();
-
         println!("Populating dependencies directory");
-        let status = Command::new(&forge_executable)
-            .current_dir(&root)
-            .args(["soldeer", "install"])
-            .status()
-            .expect("Failed to execute 'forge soldeer install'");
-
-        assert!(status.success(), "'forge soldeer install' failed");
+        run_soldeer_with_retry(&["soldeer", "install"], "soldeer install");
     } else {
         println!("Dependencies directory exists or is not empty. Skipping soldeer install.");
     }
@@ -149,21 +174,9 @@ pub fn soldeer_install() {
 /// # Panics
 /// - If the Cargo Manifest directory is not found.
 /// - If the `forge` executable is not found.
-/// - If forge's `soldeer` is not installed.
+/// - If forge's `soldeer` is not installed or fails every retry attempt.
 pub fn soldeer_update() {
-    // Get the project root directory
-    let root = workspace_or_manifest_dir();
-
-    // Try to find the `forge` executable dynamically
-    let forge_executable = find_forge_executable();
-
-    let status = Command::new(&forge_executable)
-        .current_dir(&root)
-        .args(["soldeer", "update", "-d"])
-        .status()
-        .expect("Failed to execute 'forge soldeer update'");
-
-    assert!(status.success(), "'forge soldeer update' failed");
+    run_soldeer_with_retry(&["soldeer", "update", "-d"], "soldeer update");
 }
 
 /// Returns a string with the path to the `forge` executable.


### PR DESCRIPTION
## Summary

Follow-up to #1389. Addresses the three findings from the kimi review on the merged PR:

- **Skip sleep after final failed attempt**: the shell loop used to sleep 160s after attempt 5, wasting ~2.5 min of runner time on every hard failure. Now exits immediately.
- **Retry Rust `build-utils` helpers**: `soldeer_install` and `soldeer_update` in `crates/build-utils/src/lib.rs` are called from `examples/incredible-squaring-eigenlayer/build.rs`, so a local or CI `cargo build` touching that example hit the same registry flake the workflow now tolerates. Factored into a shared `run_soldeer_with_retry` helper.
- **release.yml regenerated**: ran `dist generate` with cargo-dist `0.28.7-prerelease.1` (the version pinned in `dist-workspace.toml`) so the generated file stays in sync with `build-setup.yml`.

## Change Class

- Selected class: Class B
- Why this class: CI-script + build-utils helper. No production runtime change.

## Behavior Contract

- Current: final-attempt failure sleeps 160s before exiting; Rust helpers have zero retry.
- Intended: hard-fail exits immediately; Rust helpers retry 5 times with 10/20/40/80s backoff between attempts.
- Invariants: genuine misconfigurations still fail (exit 1 / panic) — retries only mask transient network IO.
- Failure mode: fail-closed after exhausting retries.

## Risk and Scope

- Security impact: none.
- Compatibility impact: none — `soldeer_install` / `soldeer_update` keep their existing signatures and panic contract.
- Migration notes: none.
- Rollback plan: revert — previous behaviour (zero-retry in Rust, 160s trailing sleep in shell) returns.

## Verification

```bash
cargo build -p blueprint-build-utils
cargo clippy -p blueprint-build-utils --tests -- -D warnings
cargo +nightly-2026-02-24 fmt -p blueprint-build-utils -- --check
dist generate  # release.yml is in sync with build-setup.yml
```

All four pass locally.

## Harness Evidence

- Reproducer: run 24861112384 + 24861906873 both died on the single-shot `forge soldeer update -d`. After this PR the same transient failure retries up to 5 times, and the final failure path exits ~160s faster than before.
- Rust-side reproducer is the exact same error — `cargo build` on `examples/incredible-squaring-eigenlayer` with a flaky soldeer registry would have failed once; now retries.

## Checklist

- [x] Local build + clippy + fmt green.
- [x] `dist generate` ran; release.yml matches build-setup.yml.
- [x] No co-authorship trailers.