### PR TITLE
fix(ci): make soldeer non-fatal in release.yml (cargo-tangle doesn't need it)

### DIFF
--- a/.github/workflows/build-setup.yml
+++ b/.github/workflows/build-setup.yml
@@ -9,10 +9,22 @@
     echo "Forge version check completed"
 
 - name: Install Solidity Dependencies
+  # This fragment is consumed ONLY by cargo-dist's release.yml (see
+  # dist-workspace.toml's `github-build-setup`), which builds the cli/
+  # crate (cargo-tangle). cargo-tangle has no build.rs and no dependency
+  # on solidity contracts, so soldeer is vestigial for this workflow.
+  #
+  # The soldeer registry intermittently refuses GitHub Actions runner
+  # IPs ("error during IO operation: not connected" in <10ms) — a
+  # network-level block, not a transient flake. We retry 5× with
+  # backoff in case it was transient, then exit 0 with a loud warning
+  # so the release build continues. Any downstream step that genuinely
+  # needs the contracts will fail on its own cargo build with a clear
+  # missing-dep error; cargo-tangle itself compiles fine without them.
+  #
+  # cargo-dist strips `continue-on-error` from inlined fragments, so we
+  # express this tolerance inside the `run` script instead.
   run: |
-    # Soldeer registry flakes frequently from GitHub Actions IPs —
-    # retry with exponential backoff before failing the whole build.
-    # No sleep after the final attempt so we exit as soon as we give up.
     attempts=5
     delay=10
     for attempt in $(seq 1 $attempts); do
@@ -26,8 +38,8 @@
         delay=$((delay * 2))
       fi
     done
-    echo "soldeer failed after $attempts attempts" >&2
-    exit 1
+    echo "::warning::soldeer failed after $attempts attempts; continuing without solidity deps (release build does not require them)" >&2
+    exit 0
 
 - name: install protobuf and gmp (Linux)
   if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,9 +136,6 @@ jobs:
           echo "Forge version check completed"
       - name: "Install Solidity Dependencies"
         run: |
-          # Soldeer registry flakes frequently from GitHub Actions IPs —
-          # retry with exponential backoff before failing the whole build.
-          # No sleep after the final attempt so we exit as soon as we give up.
           attempts=5
           delay=10
           for attempt in $(seq 1 $attempts); do
@@ -152,8 +149,8 @@ jobs:
               delay=$((delay * 2))
             fi
           done
-          echo "soldeer failed after $attempts attempts" >&2
-          exit 1
+          echo "::warning::soldeer failed after $attempts attempts; continuing without solidity deps (release build does not require them)" >&2
+          exit 0
       - name: "install protobuf and gmp (Linux)"
         if: "runner.os == 'Linux'"
         run: |


### PR DESCRIPTION
## Summary

The soldeer registry intermittently refuses GitHub Actions runner IPs with `error during IO operation: not connected` in <10ms — a network-level block, not a transient flake. Retries alone can't fix it. Reproduction: `forge soldeer update -d` works in ~3s locally with identical forge 1.5.1; runs 24862457949 and 24861906873 both died in <1s per attempt across all 5 retries.

**Key fact:** `build-setup.yml` is referenced ONLY from `dist-workspace.toml` (`github-build-setup`), so it runs ONLY in `release.yml`. `release.yml` only builds `cli/` (cargo-tangle), which has no `build.rs`, no `.sol` reference, and no transitive dependency on solidity contracts. The Install Solidity Dependencies step is purely vestigial for this workflow.

Keep the 5× exponential-backoff retry (so successful runs still install the deps when soldeer is reachable), but on final failure emit a `::warning::` and `exit 0`. Any downstream step that genuinely needs the contracts would fail on its own `cargo build` with a clear missing-dep error — not masking real failures, only the vestigial dependency.

`cargo-dist` strips `continue-on-error` from inlined fragments (verified), so the tolerance has to live inside the `run` script itself.

## Change Class

- Selected class: Class B
- Why this class: CI-only. No production code, no runtime behaviour, no binary surface change.

## Behavior Contract

- Current: soldeer network failure → release build hard-fails → cargo-tangle installer never ships.
- Intended: soldeer network failure → `::warning::` annotation → release build continues → cargo-tangle installer ships.
- Invariants: when soldeer IS reachable, behaviour is unchanged (retry succeeds, deps installed).
- Failure mode: if cargo-tangle ever adds a real solidity dep, the downstream `cargo build` fails loudly with a missing-dep error — not silently masked.

## Risk And Scope

- Blast radius: `release.yml` only. `build-setup.yml` is not imported by any other workflow (`grep -rn build-setup .github/` → only hit is `dist-workspace.toml`).
- Security impact: none. Soldeer deps aren't used by the released binary.
- Compatibility impact: none.
- Rollback plan: revert. Release goes back to hard-failing on soldeer outages.

## Verification

```bash
# 1. Confirm build-setup.yml isn't shared:
grep -rn build-setup .github/                 # only match: dist-workspace.toml

# 2. Confirm cli/ has no solidity deps:
ls cli/build.rs                                # not found
grep -rE 'tnt-core|soldeer|\.sol' cli/         # no hits

# 3. Regenerate release.yml (cargo-dist 0.28.7-prerelease.1):
dist generate                                  # clean; release.yml matches

# 4. Local soldeer works today (confirms registry is up; GH IPs are blocked):
cd examples/apikey-blueprint && forge soldeer update -d    # succeeds ~3s
```

## Harness Evidence

- Reproducer: release.yml runs 24862457949 + 24861906873 both failed with all 5 retries hitting `error during IO operation: not connected` in <1s each — confirming network refusal, not flake. Local `forge soldeer update -d` at identical forge version succeeded in ~3s on the same branch.
- Post-fix behaviour: the same run would emit a `::warning::` and let the cargo-tangle build proceed; installer would reach the GitHub Release.

## Checklist

- [x] No production behaviour change.
- [x] `dist generate` ran; `release.yml` regenerated from `build-setup.yml`.
- [x] Scope verified: `build-setup.yml` used only by `release.yml`, which builds only `cli/`, which has no solidity deps.
- [x] Warning annotation emitted on failure so outages remain visible.
- [x] No co-authorship trailers.