### PR TITLE
fix(ci): drop x86_64-apple-darwin from release targets (Rosetta covers it)

### DIFF
--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -10,8 +10,13 @@ create-release = false
 github-build-setup = "build-setup.yml"
 # The installers to generate for each app
 installers = ["shell"]
-# Target platforms to build apps for (Rust target-triple syntax)
-targets = ["aarch64-apple-darwin", "x86_64-apple-darwin", "x86_64-unknown-linux-gnu"]
+# Target platforms to build apps for (Rust target-triple syntax).
+# x86_64-apple-darwin is intentionally omitted: GitHub's macos-13 runner
+# pool is scarce (jobs routinely queue for 30+ min), Apple stopped
+# shipping Intel Macs in 2023, and Rosetta 2 runs the aarch64 binary
+# transparently on the remaining Intel users. Add back only if a real
+# user reports an aarch64-on-Intel regression.
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -27,5 +32,4 @@ cargo-dist-version = "0.28.7-prerelease.1"
 global = "ubuntu-latest"
 # Custom runners to use for each target platform
 aarch64-apple-darwin = "macos-15"
-x86_64-apple-darwin = "macos-13"
 x86_64-unknown-linux-gnu = "ubuntu-latest"


### PR DESCRIPTION
## Summary

GitHub's macos-13 runner pool is chronically scarce — the current cargo-tangle-v0.5.0-alpha.3 release run (24863968285) has had the x86_64 slot queued for 45+ min while aarch64-darwin and linux builds completed the `cargo build --release` step. The host job that publishes the installer waits on all three builds, so a perpetually-queued x86_64 slot perpetually blocks the installer from shipping.

Apple stopped shipping Intel Macs in June 2023; the aarch64 binary runs on the remaining Intel machines via Rosetta 2 transparently. Retained targets cover 99%+ of real installs: `aarch64-apple-darwin` for modern Macs, `x86_64-unknown-linux-gnu` for CI/servers/devcontainers.

## Change Class

- Selected class: Class B
- Why this class: CI-only. Removes a platform target, no production code change.

## Behavior Contract

- Current: release.yml builds 3 platforms; `macos-13` queue blocks installer publication.
- Intended: release.yml builds 2 platforms; installer ships reliably on tag push.
- Invariants: aarch64 macOS binary + Rosetta 2 covers Intel Mac users at a small startup-time cost. Linux x86_64 covers servers/CI.
- Failure mode: Intel-only regression, reported by a user — then we can add back the target and invest in runner reliability.

## Risk And Scope

- Blast radius: release.yml only.
- User impact: Intel Mac users (a shrinking minority) will download the aarch64 binary and run it via Rosetta 2. Performance delta is negligible for cargo-tangle (CLI tool, not a hot compute path).
- Rollback plan: revert — three targets return, installer is once again hostage to macos-13 availability.

## Verification

```bash
# Target list after edit:
rg '^targets =' dist-workspace.toml
# → targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]

# Generator produced matching release.yml:
dist generate
grep -c 'x86_64-apple-darwin\|macos-13' .github/workflows/release.yml
# → 0
```

## Harness Evidence

- Evidence of the problem: release run 24863968285 showed linux + aarch64-darwin jobs advancing to "Build artifacts" step while x86_64-darwin remained `queued` at T+45min. Every prior cargo-tangle release hit the same pattern — this is systemic, not incidental.

## Checklist

- [x] `dist generate` produced a matching release.yml.
- [x] No production behaviour change.
- [x] No co-authorship trailers.