### PR TITLE
chore: use released tnt-core bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14099,8 +14099,8 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.10.8"
-source = "git+https://github.com/tangle-network/tnt-core.git?rev=3c6a17ac24bfc1cb3c757bd6c327aee690f4ddde#3c6a17ac24bfc1cb3c757bd6c327aee690f4ddde"
+version = "0.10.9"
+source = "git+https://github.com/tangle-network/tnt-core.git?tag=v0.10.9#19887b5d8e7475195fd38df2e0f81b032b81818e"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-tnt-core-bindings = { version = "0.10.8", git = "https://github.com/tangle-network/tnt-core.git", rev = "3c6a17ac24bfc1cb3c757bd6c327aee690f4ddde" }
+tnt-core-bindings = { version = "0.10.9", git = "https://github.com/tangle-network/tnt-core.git", tag = "v0.10.9" }
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }


### PR DESCRIPTION
## Summary

Replaces the temporary raw `tnt-core` commit rev pin with the released `v0.10.9` tag.

The `v0.10.9` tag points at `tangle-network/tnt-core@19887b5d8e7475195fd38df2e0f81b032b81818e`, which includes `tnt-core-bindings v0.10.9` and the blueprint metadata hash bindings generated from `3c6a17ac24bfc1cb3c757bd6c327aee690f4ddde`.

## Changes

- Updates the workspace `tnt-core-bindings` dependency to `version = "0.10.9"` and `tag = "v0.10.9"`.
- Updates `Cargo.lock` to resolve `tnt-core-bindings v0.10.9` from `v0.10.9#19887b5d`.

## Validation

- `cargo fmt --check`
- `cargo test -p blueprint-client-tangle --test anvil -- --nocapture`
- `cargo test -p cargo-tangle command::deploy::definition::tests --lib`
- `cargo check -p blueprint-client-tangle`
- Repo pre-push hook: format, clippy changed-crate detection, changed-crate tests
