### PR TITLE
chore(deps): bump tnt-core-bindings 0.10.9 → 0.11.0 for unified approveService

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,10 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-tnt-core-bindings = { version = "0.10.9", git = "https://github.com/tangle-network/tnt-core.git", tag = "v0.10.9" }
+tnt-core-bindings = { version = "0.11.0", git = "https://github.com/tangle-network/tnt-core.git", branch = "drew/bindings-v0.11.0-unified-approval" }
+# NOTE: switch back to `tag = "bindings-v0.11.0"` once tnt-core PR #120 merges and the
+# release tag is published. The branch pin keeps the workspace buildable while the
+# binding regen + dapp + this PR land as a coordinated set.
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }

--- a/cli/src/command/service/mod.rs
+++ b/cli/src/command/service/mod.rs
@@ -12,16 +12,18 @@ pub async fn request_service(
     client.request_service(params).await.map_err(Into::into)
 }
 
-/// Approve a pending service request.
+/// Approve a pending service request without optional capabilities.
+///
+/// `_staking_percent` is accepted for CLI back-compat but is now derived on-chain
+/// from `securityCommitments[0].exposureBps` (or defaults to 100% when commitments
+/// are empty). Callers that need to pin a specific exposure should go through
+/// `approve_service_with_commitments`.
 pub async fn approve_service(
     client: &TangleClient,
     request_id: u64,
-    staking_percent: u8,
+    _staking_percent: u8,
 ) -> Result<TransactionResult> {
-    client
-        .approve_service(request_id, staking_percent)
-        .await
-        .map_err(Into::into)
+    client.approve_service(request_id).await.map_err(Into::into)
 }
 
 /// Approve a pending request with explicit security commitments.

--- a/crates/clients/tangle/src/client.rs
+++ b/crates/clients/tangle/src/client.rs
@@ -1453,45 +1453,16 @@ impl TangleClient {
         Ok(transaction_result_from_receipt(&receipt))
     }
 
-    /// Approve a pending service request with a simple restaking percentage.
-    pub async fn approve_service(
+    /// Approve a pending service request via the unified `approveService(ApprovalParams)`
+    /// entrypoint. Pass empty `commitments`, zero `bls_pubkey`, zero `bls_pop_signature`,
+    /// and empty `tee_commitments` to opt out of those capabilities.
+    ///
+    /// Convenience wrappers `approve_service` and `approve_service_with_commitments` build
+    /// the `ApprovalParams` for the common shapes; use this method directly when you also
+    /// need to register a BLS pubkey or pin TEE attestation profiles.
+    pub async fn approve_service_with_params(
         &self,
-        request_id: u64,
-        restaking_percent: u8,
-    ) -> Result<TransactionResult> {
-        use crate::contracts::ITangle::approveServiceCall;
-
-        let wallet = self.wallet()?;
-        let from_address = wallet.default_signer().address();
-        let provider = ProviderBuilder::new()
-            .wallet(wallet)
-            .connect(self.config.http_rpc_endpoint.as_str())
-            .await
-            .map_err(Error::Transport)?;
-        let tx_request = TransactionRequest::default().to(self.tangle_address).input(
-            approveServiceCall {
-                requestId: request_id,
-                stakingPercent: restaking_percent,
-            }
-            .abi_encode()
-            .into(),
-        );
-        let receipt = send_transaction_with_fallback_gas(
-            &provider,
-            from_address,
-            tx_request,
-            APPROVE_SERVICE_MIN_GAS_LIMIT,
-        )
-        .await?;
-
-        Ok(transaction_result_from_receipt(&receipt))
-    }
-
-    /// Approve a service request with explicit security commitments.
-    pub async fn approve_service_with_commitments(
-        &self,
-        request_id: u64,
-        commitments: Vec<ITangleTypes::AssetSecurityCommitment>,
+        params: ITangleTypes::ApprovalParams,
     ) -> Result<TransactionResult> {
         let wallet = self.wallet()?;
         let provider = ProviderBuilder::new()
@@ -1502,7 +1473,7 @@ impl TangleClient {
         let contract = ITangle::new(self.tangle_address, &provider);
 
         let receipt = contract
-            .approveServiceWithCommitments(request_id, commitments)
+            .approveService(params)
             .send()
             .await
             .map_err(|e| Error::Contract(e.to_string()))?
@@ -1510,6 +1481,36 @@ impl TangleClient {
             .await?;
 
         Ok(transaction_result_from_receipt(&receipt))
+    }
+
+    /// Approve a pending service request without any optional capabilities (no per-asset
+    /// commitments, no BLS, no TEE binding). Acceptable when the request has no security
+    /// requirements, or only the protocol-default TNT requirement (auto-filled on-chain).
+    pub async fn approve_service(&self, request_id: u64) -> Result<TransactionResult> {
+        self.approve_service_with_params(ITangleTypes::ApprovalParams {
+            requestId: request_id,
+            securityCommitments: Vec::new(),
+            blsPubkey: [U256::ZERO; 4],
+            blsPopSignature: [U256::ZERO; 2],
+            teeCommitments: Vec::new(),
+        })
+        .await
+    }
+
+    /// Approve a pending service request with explicit per-asset security commitments.
+    pub async fn approve_service_with_commitments(
+        &self,
+        request_id: u64,
+        commitments: Vec<ITangleTypes::AssetSecurityCommitment>,
+    ) -> Result<TransactionResult> {
+        self.approve_service_with_params(ITangleTypes::ApprovalParams {
+            requestId: request_id,
+            securityCommitments: commitments,
+            blsPubkey: [U256::ZERO; 4],
+            blsPopSignature: [U256::ZERO; 2],
+            teeCommitments: Vec::new(),
+        })
+        .await
     }
 
     /// Reject a pending service request.


### PR DESCRIPTION
tnt-core PR #119 collapsed five \`approveServiceWith*\` entrypoints into a single
\`approveService(ApprovalParams)\`. The Rust binding regen ships in
[tnt-core PR #120](https://github.com/tangle-network/tnt-core/pull/120) as
\`bindings-v0.11.0\`. This PR threads the new API through the blueprint workspace.

## Changes

- \`Cargo.toml\`: workspace \`tnt-core-bindings\` pin → ^0.11.0. Currently pinned at
  the **bindings PR's branch** while tnt-core PR #120 is in flight; switch to
  \`tag = \"bindings-v0.11.0\"\` once that PR merges and the release tag publishes.
- \`crates/clients/tangle/src/client.rs\`:
  - new \`approve_service_with_params(params)\` — direct passthrough for callers
    that need to register a BLS pubkey or pin TEE attestation profiles
  - \`approve_service(request_id)\` — minimal approval, no optional capabilities
  - \`approve_service_with_commitments(request_id, commitments)\` — common
    per-asset path, BLS / TEE skipped
  Both convenience helpers build \`Types.ApprovalParams\` with empty / zero
  defaults for the capabilities they don't use.
- \`cli/src/command/service/mod.rs\`: legacy CLI signature \`(client, request_id,
  staking_percent)\` kept — \`staking_percent\` is now ignored (derived on-chain
  from \`securityCommitments[0].exposureBps\` or defaults to 100%). Documented in
  the doc comment.

## Why this is correct

- BLS stays opt-in. Operators that don't register a BLS pubkey can still
  approve and run services; \`JobsAggregation\` only reverts when an unregistered
  operator is asked to participate in a BLS aggregate.
- TEE commitments are opt-in. Operators that don't bind a TEE profile pass an
  empty array; the contract no-ops.
- The two convenience helpers preserve the common shapes used today
  (\`approve_service\`, \`approve_service_with_commitments\`); callers don't need
  to construct \`ApprovalParams\` themselves unless they're using BLS or TEE.

## Coordination

Companion PRs that must land in lockstep:
- [tnt-core #120](https://github.com/tangle-network/tnt-core/pull/120) — regen + tag bindings-v0.11.0
- tangle-network/dapp follow-up — regenerate ABI + rewrite \`useServiceApproveTx\`

After tnt-core #120 merges + the tag publishes, this PR's \`Cargo.toml\` flips
from \`branch = \"...\"\` to \`tag = \"bindings-v0.11.0\"\` in a tiny follow-up
commit.

## Test plan

- [x] Pre-push hook ran cargo build / clippy / test on the workspace
      against the branch-pinned bindings — pushed successfully
- [ ] Re-run after tag publish to confirm the tag-pinned dependency resolves
- [ ] CI to run the full suite