### PR TITLE
chore(deps): bump tnt-core-bindings 0.11.0 (git) -> 0.11.1 (crates.io)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4947,7 +4947,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5637,7 +5637,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7788,7 +7788,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -8258,7 +8258,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10481,7 +10481,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12607,7 +12607,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12709,7 +12709,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13847,7 +13847,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13876,7 +13876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14099,8 +14099,9 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.10.9"
-source = "git+https://github.com/tangle-network/tnt-core.git?tag=v0.10.9#19887b5d8e7475195fd38df2e0f81b032b81818e"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64e9f2317a2114fea16cf751974bbb9c0121416d56bd12cf342506548642ae18"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -15345,7 +15346,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,10 +126,7 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-tnt-core-bindings = { version = "0.11.0", git = "https://github.com/tangle-network/tnt-core.git", branch = "drew/bindings-v0.11.0-unified-approval" }
-# NOTE: switch back to `tag = "bindings-v0.11.0"` once tnt-core PR #120 merges and the
-# release tag is published. The branch pin keeps the workspace buildable while the
-# binding regen + dapp + this PR land as a coordinated set.
+tnt-core-bindings = "0.11.1"
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }

--- a/cli/src/command/operator.rs
+++ b/cli/src/command/operator.rs
@@ -1,10 +1,10 @@
 use std::time::{SystemTime, UNIX_EPOCH};
 
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, keccak256};
+use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types_eth::TransactionRequest;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{Eip712Domain, SolCall, SolStruct, sol};
 use blueprint_client_tangle::{IOperatorStatusRegistry, OperatorStatusSnapshot};
 use blueprint_crypto::k256::K256SigningKey;
 use color_eyre::eyre::{Result, eyre};
@@ -13,7 +13,18 @@ use serde_json::json;
 
 use IOperatorStatusRegistry::submitHeartbeatCall;
 
-const ETH_MESSAGE_PREFIX: &[u8] = b"\x19Ethereum Signed Message:\n32";
+// EIP-712 typed struct mirroring `OperatorStatusRegistry.HEARTBEAT_TYPEHASH`.
+sol! {
+    #[allow(missing_docs)]
+    struct Heartbeat {
+        address operator;
+        uint64 serviceId;
+        uint64 blueprintId;
+        uint8 statusCode;
+        bytes32 metricsHash;
+        uint64 timestamp;
+    }
+}
 
 /// Heartbeat status payload
 #[derive(Clone, Debug)]
@@ -98,17 +109,11 @@ pub async fn submit_heartbeat(
     };
 
     let metrics_bytes = payload.encode();
-    let signature = sign_heartbeat_payload(
-        signing_key,
-        service_id,
-        blueprint_id,
-        status_code,
-        &metrics_bytes,
-    )?;
 
     let local_signer = signing_key
         .alloy_key()
         .map_err(|e| eyre!("Failed to prepare wallet signer: {e}"))?;
+    let operator_address = local_signer.address();
     let wallet = EthereumWallet::from(local_signer);
 
     let provider = ProviderBuilder::new()
@@ -117,11 +122,29 @@ pub async fn submit_heartbeat(
         .await
         .map_err(|e| eyre!("Failed to connect to RPC endpoint: {e}"))?;
 
+    let chain_id = provider
+        .get_chain_id()
+        .await
+        .map_err(|e| eyre!("Failed to query chain id: {e}"))?;
+
+    let signature = sign_heartbeat_eip712(
+        signing_key,
+        chain_id,
+        status_registry_address,
+        operator_address,
+        service_id,
+        blueprint_id,
+        status_code,
+        &metrics_bytes,
+        timestamp,
+    )?;
+
     let heartbeat_call = submitHeartbeatCall {
         serviceId: service_id,
         blueprintId: blueprint_id,
         statusCode: status_code,
         metrics: metrics_bytes.into(),
+        timestamp,
         signature: signature.into(),
     };
 
@@ -171,34 +194,40 @@ pub async fn submit_heartbeat(
     Ok(())
 }
 
-/// Sign heartbeat payload: keccak256(abi.encodePacked(serviceId, blueprintId, statusCode, metrics))
-/// with Ethereum signed message prefix. Must match OperatorStatusRegistry.sol verification.
-fn sign_heartbeat_payload(
+/// Build an EIP-712 typed-data signature for `OperatorStatusRegistry.submitHeartbeat`.
+/// See `crates/qos/src/heartbeat.rs::sign_heartbeat_eip712` for the canonical impl.
+#[allow(clippy::too_many_arguments)]
+fn sign_heartbeat_eip712(
     signing_key: &mut K256SigningKey,
+    chain_id: u64,
+    verifying_contract: Address,
+    operator: Address,
     service_id: u64,
     blueprint_id: u64,
     status_code: u8,
     metrics: &[u8],
+    timestamp: u64,
 ) -> Result<Vec<u8>> {
-    let mut payload = Vec::with_capacity(17 + metrics.len());
-    payload.extend_from_slice(&service_id.to_be_bytes());
-    payload.extend_from_slice(&blueprint_id.to_be_bytes());
-    payload.push(status_code);
-    payload.extend_from_slice(metrics);
-
-    let message_hash = keccak256(&payload);
-
-    let mut prefixed = Vec::with_capacity(ETH_MESSAGE_PREFIX.len() + message_hash.len());
-    prefixed.extend_from_slice(ETH_MESSAGE_PREFIX);
-    prefixed.extend_from_slice(message_hash.as_slice());
-
-    let prefixed_hash = keccak256(&prefixed);
-    let mut digest = [0u8; 32];
-    digest.copy_from_slice(prefixed_hash.as_slice());
+    let domain = Eip712Domain {
+        name: Some("OperatorStatusRegistry".into()),
+        version: Some("1".into()),
+        chain_id: Some(U256::from(chain_id)),
+        verifying_contract: Some(verifying_contract),
+        salt: None,
+    };
+    let heartbeat = Heartbeat {
+        operator,
+        serviceId: service_id,
+        blueprintId: blueprint_id,
+        statusCode: status_code,
+        metricsHash: keccak256(metrics),
+        timestamp,
+    };
+    let digest: B256 = heartbeat.eip712_signing_hash(&domain);
 
     let (signature, recovery_id) = signing_key
         .0
-        .sign_prehash_recoverable(&digest)
+        .sign_prehash_recoverable(digest.as_slice())
         .map_err(|e| eyre!("Failed to sign heartbeat payload: {e}"))?;
 
     let mut signature_bytes = Vec::with_capacity(65);

--- a/crates/clients/tangle/src/client.rs
+++ b/crates/clients/tangle/src/client.rs
@@ -1464,21 +1464,30 @@ impl TangleClient {
         &self,
         params: ITangleTypes::ApprovalParams,
     ) -> Result<TransactionResult> {
+        use ITangle::approveServiceCall;
+
         let wallet = self.wallet()?;
+        let from_address = wallet.default_signer().address();
         let provider = ProviderBuilder::new()
             .wallet(wallet)
             .connect(self.config.http_rpc_endpoint.as_str())
             .await
             .map_err(Error::Transport)?;
-        let contract = ITangle::new(self.tangle_address, &provider);
 
-        let receipt = contract
-            .approveService(params)
-            .send()
-            .await
-            .map_err(|e| Error::Contract(e.to_string()))?
-            .get_receipt()
-            .await?;
+        let calldata = approveServiceCall { params }.abi_encode();
+        let tx_request = TransactionRequest::default()
+            .to(self.tangle_address)
+            .input(Bytes::from(calldata).into());
+
+        // Approval gas is operator-linear under the v0.11+ root storage; the floor
+        // covers the no-estimate fallback (e.g. node returning estimateGas error).
+        let receipt = send_transaction_with_fallback_gas(
+            &provider,
+            from_address,
+            tx_request,
+            APPROVE_SERVICE_MIN_GAS_LIMIT,
+        )
+        .await?;
 
         Ok(transaction_result_from_receipt(&receipt))
     }

--- a/crates/pricing-engine/src/signer.rs
+++ b/crates/pricing-engine/src/signer.rs
@@ -292,6 +292,11 @@ fn build_abi_quote_details(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(ITangleTypes::QuoteDetails {
+        // `requester == address(0)` is the contract's "open quote" mode (any
+        // address may redeem). Until the proto + RPC surface threads the
+        // requester from `GetPriceRequest` through to here (PR #118 added the
+        // binding on-chain), open-quote is the only safe default.
+        requester: alloy_primitives::Address::ZERO,
         blueprintId: details.blueprint_id,
         ttlBlocks: details.ttl_blocks,
         totalCost: decimal_to_scaled_amount(total_cost)?,

--- a/crates/qos/src/heartbeat.rs
+++ b/crates/qos/src/heartbeat.rs
@@ -1,9 +1,9 @@
 use crate::error::{Error, Result};
 use alloy_network::EthereumWallet;
-use alloy_primitives::{Address, keccak256};
+use alloy_primitives::{Address, B256, U256, keccak256};
 use alloy_provider::{Provider, ProviderBuilder};
 use alloy_rpc_types::TransactionRequest;
-use alloy_sol_types::SolCall;
+use alloy_sol_types::{Eip712Domain, SolCall, SolStruct, sol};
 use blueprint_core::{info, warn};
 use blueprint_crypto::k256::{K256Ecdsa, K256SigningKey};
 use blueprint_keystore::backends::Backend;
@@ -19,7 +19,22 @@ use std::{
 use tnt_core_bindings::bindings::r#i_operator_status_registry::IOperatorStatusRegistry::submitHeartbeatCall;
 use tokio::{sync::Mutex, task::JoinHandle};
 
-const ETH_MESSAGE_PREFIX: &[u8] = b"\x19Ethereum Signed Message:\n32";
+// EIP-712 typed struct mirroring `OperatorStatusRegistry.HEARTBEAT_TYPEHASH` in
+// tnt-core. Signed digest:
+//   keccak256(0x19 0x01 || domainSeparator || keccak256(abi.encode(typehash, ...)))
+// where domainSeparator binds chainId + verifyingContract to defeat cross-fork
+// and cross-deployment replay.
+sol! {
+    #[allow(missing_docs)]
+    struct Heartbeat {
+        address operator;
+        uint64 serviceId;
+        uint64 blueprintId;
+        uint8 statusCode;
+        bytes32 metricsHash;
+        uint64 timestamp;
+    }
+}
 
 /// Configuration for the heartbeat service that sends periodic liveness signals to the chain.
 ///
@@ -217,17 +232,11 @@ impl<C: HeartbeatConsumer + Send + Sync + 'static> HeartbeatService<C> {
             crate::metrics::abi::encode_metric_pairs(&custom_metrics)
         };
         let status_code = u8::try_from(status.status_code).unwrap_or(u8::MAX);
-        let signature = sign_heartbeat_payload(
-            &mut signing_key,
-            status.service_id,
-            status.blueprint_id,
-            status_code,
-            &metrics_bytes,
-        )?;
 
         let local_signer = operator_ecdsa_secret
             .alloy_key()
             .map_err(|e| Error::Other(format!("Failed to prepare wallet signer: {e}")))?;
+        let operator_address = local_signer.address();
         let wallet = EthereumWallet::from(local_signer);
 
         let provider = ProviderBuilder::new()
@@ -236,11 +245,37 @@ impl<C: HeartbeatConsumer + Send + Sync + 'static> HeartbeatService<C> {
             .await
             .map_err(|e| Error::Other(format!("Failed to connect to RPC endpoint: {e}")))?;
 
+        let chain_id = provider
+            .get_chain_id()
+            .await
+            .map_err(|e| Error::Other(format!("Failed to query chain id: {e}")))?;
+
+        // EIP-712 `timestamp` field — must be within `HEARTBEAT_MAX_AGE` (5 min)
+        // of `block.timestamp` on-chain. Sign at submission time, not at status
+        // capture time, so the contract's freshness check has the maximum slack.
+        let signing_timestamp = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map_err(|e| Error::Other(format!("System clock before UNIX epoch: {e}")))?
+            .as_secs();
+
+        let (signature, _digest) = sign_heartbeat_eip712(
+            &mut signing_key,
+            chain_id,
+            runtime.status_registry_address,
+            operator_address,
+            status.service_id,
+            status.blueprint_id,
+            status_code,
+            &metrics_bytes,
+            signing_timestamp,
+        )?;
+
         let heartbeat_call = submitHeartbeatCall {
             serviceId: status.service_id,
             blueprintId: status.blueprint_id,
             statusCode: status_code,
             metrics: metrics_bytes.into(),
+            timestamp: signing_timestamp,
             signature: signature.into(),
         };
 
@@ -454,38 +489,48 @@ impl<C: HeartbeatConsumer + Send + Sync + 'static> Drop for HeartbeatService<C> 
     }
 }
 
-/// Sign heartbeat payload: keccak256(abi.encodePacked(serviceId, blueprintId, statusCode, metrics))
-/// with Ethereum signed message prefix. Must match OperatorStatusRegistry.sol verification.
-fn sign_heartbeat_payload(
+/// Build an EIP-712 typed-data signature for `OperatorStatusRegistry.submitHeartbeat`.
+///
+/// The contract recovers `signer == msg.sender` from the EIP-712 digest using the
+/// `Heartbeat` typed struct above. The domain separator binds chainId + verifying
+/// contract so signatures cannot replay across forks or deployments, and the
+/// `timestamp` field gives the contract a 5-minute freshness window.
+#[allow(clippy::too_many_arguments)]
+fn sign_heartbeat_eip712(
     signing_key: &mut K256SigningKey,
+    chain_id: u64,
+    verifying_contract: Address,
+    operator: Address,
     service_id: u64,
     blueprint_id: u64,
     status_code: u8,
     metrics: &[u8],
-) -> Result<Vec<u8>> {
-    let mut payload = Vec::with_capacity(17 + metrics.len());
-    payload.extend_from_slice(&service_id.to_be_bytes());
-    payload.extend_from_slice(&blueprint_id.to_be_bytes());
-    payload.push(status_code);
-    payload.extend_from_slice(metrics);
-
-    let message_hash = keccak256(&payload);
-
-    let mut prefixed = Vec::with_capacity(ETH_MESSAGE_PREFIX.len() + message_hash.len());
-    prefixed.extend_from_slice(ETH_MESSAGE_PREFIX);
-    prefixed.extend_from_slice(message_hash.as_slice());
-
-    let prefixed_hash = keccak256(&prefixed);
-    let mut digest = [0u8; 32];
-    digest.copy_from_slice(prefixed_hash.as_slice());
+    timestamp: u64,
+) -> Result<(Vec<u8>, B256)> {
+    let domain = Eip712Domain {
+        name: Some("OperatorStatusRegistry".into()),
+        version: Some("1".into()),
+        chain_id: Some(U256::from(chain_id)),
+        verifying_contract: Some(verifying_contract),
+        salt: None,
+    };
+    let heartbeat = Heartbeat {
+        operator,
+        serviceId: service_id,
+        blueprintId: blueprint_id,
+        statusCode: status_code,
+        metricsHash: keccak256(metrics),
+        timestamp,
+    };
+    let digest = heartbeat.eip712_signing_hash(&domain);
 
     let (signature, recovery_id) = signing_key
         .0
-        .sign_prehash_recoverable(&digest)
+        .sign_prehash_recoverable(digest.as_slice())
         .map_err(|e| Error::Other(format!("Failed to sign heartbeat payload: {e}")))?;
 
     let mut signature_bytes = Vec::with_capacity(65);
     signature_bytes.extend_from_slice(&signature.to_bytes());
     signature_bytes.push(recovery_id.to_byte() + 27);
-    Ok(signature_bytes)
+    Ok((signature_bytes, digest))
 }


### PR DESCRIPTION
Picks up tnt-core PRs #118 + #121 by flipping the workspace pin from the git/branch shim to the published `tnt-core-bindings = \"0.11.1\"` crate. Two real downstream client changes were forced by PR #118.

## EIP-712 heartbeat signature

`OperatorStatusRegistry.submitHeartbeat` now takes an explicit `timestamp: uint64` and verifies an EIP-712 typed-data signature with a 5-minute freshness window (`HEARTBEAT_MAX_AGE`). The prior prefixed-keccak-of-bytes-concat signing scheme would have been rejected by every contract call after the upgrade with \"Invalid signature.\"

- New \`Heartbeat\` typed struct (\`alloy_sol_types::sol!\`) in both \`crates/qos/src/heartbeat.rs\` and \`cli/src/command/operator.rs\`.
- Domain separator binds chainId + verifying contract — defeats cross-fork / cross-deployment replay.
- Both call sites now query \`provider.get_chain_id()\` and stamp current Unix time at submission so the contract's freshness check has maximum slack.

## Quote `requester` field

`Types.QuoteDetails` gained a `requester: address` that binds a quote to a single redeemer (`address(0)` = open). `build_abi_quote_details` defaults to `address(0)` until the proto + RPC surface threads the requester from `GetPriceRequest` through to here — proper fix is a follow-up that touches `pricing.proto` + server endpoints.

## Tangle-client `approve_service` gas-floor

The dead-code warning on `APPROVE_SERVICE_MIN_GAS_LIMIT` (kept by tests, not used in prod after the unified-entrypoint refactor) was actually pointing at a regression: `approve_service_with_params` was bypassing `send_transaction_with_fallback_gas` and would silently succeed on `eth_estimateGas` failures. Restored the floor by routing through the same helper every other write uses.

## Verification

- `cargo check --workspace` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p blueprint-qos --lib` 10/10 passing

## Cargo.toml

Dropped the branch pin (\`drew/bindings-v0.11.0-unified-approval\`) in favor of plain \`tnt-core-bindings = \"0.11.1\"\`. Lockfile now resolves to the registry-published v0.11.1 (no more git source).

## Follow-ups (out of scope)

- Thread `requester` through `pricing.proto` + RPC server endpoints so EIP-712 quotes carry a real binding.