### PR TITLE
feat(tnt-core-v0.13.0): bind quotes to requester, end live operator-tooling outage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14099,9 +14099,8 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a24593cbb5dcacdc6cbbf5918389d629f32fdc3bdd134e9bb9c38fd3a6cb2c0c"
+version = "0.13.0"
+source = "git+https://github.com/tangle-network/tnt-core?branch=main#5201cf08bbe64238f0533d113840d7280afdaa08"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,11 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-tnt-core-bindings = "0.11.3"
+# tnt-core v0.13.0 binds quotes to the requester address (audit Round 2 economic F1).
+# Upstream tnt-core PRs #124 and #125 land the change. Bindings 0.13.0 is not yet on
+# crates.io, so we pin to the `main` branch in git until the publish lands. Flip this
+# back to a versioned crates.io dep (`"0.13.0"`) once published.
+tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", branch = "main" }
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }

--- a/crates/pricing-engine/README.md
+++ b/crates/pricing-engine/README.md
@@ -21,10 +21,16 @@ Price is computed from the operator's resource pricing config (`default_pricing.
 Used with `submitJobFromQuote()` on the Tangle contract. The operator quotes a specific price for a single job execution.
 
 ```
-Consumer → GetJobPrice(service_id, job_index) → Operator
-Operator → signs JobQuoteDetails{serviceId, jobIndex, price, timestamp, expiry}
+Consumer → GetJobPrice(service_id, job_index, requester) → Operator
+Operator → signs JobQuoteDetails{requester, serviceId, jobIndex, price, timestamp, expiry, confidentiality}
 Consumer → submitJobFromQuote(serviceId, jobIndex, inputs, [signedQuotes])
 ```
+
+Since tnt-core v0.13.0, every quote is bound to a specific `requester`
+address (audit Round 2 economic F1, PRs #124 and #125). The on-chain
+verifier rejects `requester == address(0)` and rejects any submitter
+whose `msg.sender` doesn't match. The gRPC layer enforces non-zero
+`requester` at the boundary.
 
 Price is looked up from the operator's per-job pricing config: a `(service_id, job_index) → price_in_wei` map.
 
@@ -154,15 +160,19 @@ chainId:           <chain_id>
 verifyingContract: <tangle_proxy_address>
 ```
 
-**Service quotes** use `QUOTE_TYPEHASH`:
+**Service quotes** use `QUOTE_TYPEHASH` (tnt-core v0.13.0+):
 ```
-QuoteDetails(uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)
+QuoteDetails(address requester,uint64 blueprintId,uint64 ttlBlocks,uint256 totalCost,uint64 timestamp,uint64 expiry,uint8 confidentiality,AssetSecurityCommitment[] securityCommitments,ResourceCommitment[] resourceCommitments)
 ```
 
-**Job quotes** use `JOB_QUOTE_TYPEHASH`:
+**Job quotes** use `JOB_QUOTE_TYPEHASH` (tnt-core v0.13.0+):
 ```
-JobQuoteDetails(uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry)
+JobQuoteDetails(address requester,uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry,uint8 confidentiality)
 ```
+
+`requester` MUST be non-zero — wildcard quotes are rejected by the
+on-chain verifier. The address is bound into the EIP-712 signature so a
+quote can only be redeemed by the buyer it was issued to.
 
 For standalone signing without the full pricing engine, use `JobQuoteSigner` from `blueprint-tangle-extra`:
 
@@ -171,11 +181,13 @@ use blueprint_tangle_extra::job_quote::{JobQuoteSigner, JobQuoteDetails, QuoteSi
 
 let signer = JobQuoteSigner::new(keypair, QuoteSigningDomain { chain_id, verifying_contract });
 let signed = signer.sign(&JobQuoteDetails {
+    requester: buyer_address, // MUST be non-zero
     service_id: 1,
     job_index: 7,
     price: U256::from(250_000_000_000_000_000u64),
     timestamp: now,
     expiry: now + 3600,
+    confidentiality: 0,
 });
 ```
 

--- a/crates/pricing-engine/proto/pricing.proto
+++ b/crates/pricing-engine/proto/pricing.proto
@@ -77,6 +77,10 @@ message GetPriceRequest {
   PricingModelHint pricing_model = 7;
   // Whether the customer requires TEE-attested service execution.
   bool require_tee = 8;
+  // Requester address (20 bytes). Must be non-zero — wildcard quotes are
+  // rejected by the on-chain verifier in tnt-core v0.13.0+. Bound into the
+  // EIP-712 signature so a quote can only be redeemed by this address.
+  bytes requester = 9;
 }
 
 // Resource requirement for a specific resource type
@@ -119,6 +123,10 @@ message QuoteDetails {
   repeated ResourcePricing resources = 6;
   // Security commitments for assets
   repeated AssetSecurityCommitment security_commitments = 7;
+  // Requester address (20 bytes). Must be non-zero — wildcard quotes are
+  // rejected by the on-chain verifier in tnt-core v0.13.0+. Bound into the
+  // EIP-712 signature so a quote can only be redeemed by this address.
+  bytes requester = 8;
 }
 
 // Pricing for a specific resource type
@@ -147,6 +155,10 @@ message GetJobPriceRequest {
   uint64 challenge_timestamp = 4;
   // Whether the customer requires TEE-attested service execution.
   bool require_tee = 5;
+  // Requester address (20 bytes). Must be non-zero — wildcard quotes are
+  // rejected by the on-chain verifier in tnt-core v0.13.0+. Bound into the
+  // EIP-712 signature so a quote can only be redeemed by this address.
+  bytes requester = 6;
 }
 
 // Response message for GetJobPrice RPC
@@ -189,7 +201,7 @@ message SettlementOption {
   string scheme = 6;
 }
 
-// Per-job quote details matching tnt-core Types.JobQuoteDetails
+// Per-job quote details matching tnt-core Types.JobQuoteDetails (v0.13.0+)
 message JobQuoteDetails {
   // The service instance ID
   uint64 service_id = 1;
@@ -205,4 +217,8 @@ message JobQuoteDetails {
   // Bound into the EIP-712 signature to prevent replay of
   // a non-TEE quote for a TEE-required service.
   uint32 confidentiality = 6;
+  // Requester address (20 bytes). Must be non-zero — wildcard quotes are
+  // rejected by the on-chain verifier in tnt-core v0.13.0+. Bound into the
+  // EIP-712 signature so a quote can only be redeemed by this address.
+  bytes requester = 7;
 }

--- a/crates/pricing-engine/src/service/rpc/server.rs
+++ b/crates/pricing-engine/src/service/rpc/server.rs
@@ -220,6 +220,11 @@ impl PricingEngine for PricingEngineService {
         let proof_of_work = req.proof_of_work;
         let pricing_model = req.pricing_model; // 0=PayOnce, 1=Subscription, 2=EventDriven
 
+        // Validate the requester address up-front: tnt-core v0.13.0+ rejects
+        // wildcard (`address(0)`) quotes on-chain, so emitting one would just
+        // produce an unredeemable quote. Reject at the gRPC boundary.
+        let requester = parse_requester(&req.requester)?;
+
         info!(
             "Received GetPrice request for blueprint ID: {} (pricing_model={})",
             blueprint_id, pricing_model
@@ -409,6 +414,7 @@ impl PricingEngine for PricingEngineService {
             expiry: expiry_time,
             resources: proto_resources,
             security_commitments: vec![security_commitment],
+            requester: requester.0.to_vec(),
         };
 
         let confidentiality = if require_tee {
@@ -416,15 +422,19 @@ impl PricingEngine for PricingEngineService {
         } else {
             crate::signer::Confidentiality::Any
         };
-        let signable_quote =
-            SignableQuote::with_confidentiality(quote_details, total_cost, confidentiality)
-                .map_err(|e| {
-                    error!(
-                        "Failed to prepare signable quote for blueprint ID {}: {}",
-                        blueprint_id, e
-                    );
-                    Status::internal("Failed to build signable quote")
-                })?;
+        let signable_quote = SignableQuote::with_confidentiality(
+            quote_details,
+            total_cost,
+            confidentiality,
+            requester,
+        )
+        .map_err(|e| {
+            error!(
+                "Failed to prepare signable quote for blueprint ID {}: {}",
+                blueprint_id, e
+            );
+            Status::internal("Failed to build signable quote")
+        })?;
 
         // Generate proof of work for the response
         let response_pow = generate_proof(&challenge, self.pow_difficulty)
@@ -471,6 +481,11 @@ impl PricingEngine for PricingEngineService {
         let req = request.into_inner();
         let service_id = req.service_id;
         let job_index = req.job_index;
+
+        // Validate the requester address up-front: tnt-core v0.13.0+ rejects
+        // wildcard (`address(0)`) quotes on-chain. Reject at the gRPC boundary
+        // so downstream signing code can rely on a non-zero `requester`.
+        let requester = parse_requester(&req.requester)?;
 
         info!(
             "Received GetJobPrice request for service {} job index {}",
@@ -560,6 +575,7 @@ impl PricingEngine for PricingEngineService {
             timestamp,
             expiry,
             confidentiality,
+            requester: requester.0.to_vec(),
         };
 
         // Generate proof of work for response
@@ -622,6 +638,36 @@ impl PricingEngine for PricingEngineService {
         );
         Ok(Response::new(response))
     }
+}
+
+/// Parse and validate the proto `requester` bytes into an `Address`.
+///
+/// Rejects with `Status::invalid_argument` if the field is empty, the wrong
+/// length, or the zero address. tnt-core v0.13.0+ refuses to verify quotes
+/// signed for `address(0)` (audit Round 2 economic F1, PRs #124/#125), so
+/// emitting one would just produce an unredeemable quote — fail fast at the
+/// gRPC boundary so downstream signing code can rely on a non-zero requester.
+fn parse_requester(bytes: &[u8]) -> std::result::Result<alloy_primitives::Address, Status> {
+    if bytes.is_empty() {
+        return Err(Status::invalid_argument(
+            "requester required and must be non-zero",
+        ));
+    }
+    if bytes.len() != 20 {
+        return Err(Status::invalid_argument(format!(
+            "requester must be a 20-byte address, got {} bytes",
+            bytes.len()
+        )));
+    }
+    let mut buf = [0u8; 20];
+    buf.copy_from_slice(bytes);
+    let addr = alloy_primitives::Address::from(buf);
+    if addr.is_zero() {
+        return Err(Status::invalid_argument(
+            "requester required and must be non-zero",
+        ));
+    }
+    Ok(addr)
 }
 
 /// Internal settlement option (pre-proto conversion).
@@ -798,6 +844,17 @@ mod tests {
     /// Trivial difficulty for test PoW — avoids 30s+ proof generation on slow CI.
     const TEST_POW_DIFFICULTY: u32 = 1;
 
+    /// Non-zero placeholder requester address for tests.
+    /// Production callers MUST send the real buyer address; the gRPC layer
+    /// rejects `address(0)` (tnt-core v0.13.0+ reject wildcard quotes).
+    fn test_requester_bytes() -> Vec<u8> {
+        // 0x000000000000000000000000000000000000bEEF
+        let mut bytes = vec![0u8; 20];
+        bytes[18] = 0xbe;
+        bytes[19] = 0xef;
+        bytes
+    }
+
     fn make_service(job_entries: Vec<((u64, u32), U256)>) -> PricingEngineService {
         let mut svc = PricingEngineService::new_with_configs(
             test_config(),
@@ -835,6 +892,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -864,6 +922,7 @@ mod tests {
                 proof_of_work: pow,
                 challenge_timestamp: ts,
                 require_tee: false,
+                requester: test_requester_bytes(),
             });
             let resp = svc.get_job_price(req).await.unwrap().into_inner();
             let details = resp.quote_details.unwrap();
@@ -888,6 +947,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -908,6 +968,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -927,6 +988,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -944,6 +1006,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -962,6 +1025,7 @@ mod tests {
             proof_of_work: vec![],
             challenge_timestamp: 0, // 0 = missing
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -980,6 +1044,7 @@ mod tests {
             proof_of_work: vec![],
             challenge_timestamp: old_ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -998,6 +1063,7 @@ mod tests {
             proof_of_work: vec![],
             challenge_timestamp: future_ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -1018,6 +1084,7 @@ mod tests {
             proof_of_work: vec![0u8; 32], // garbage PoW
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -1036,6 +1103,7 @@ mod tests {
             proof_of_work: vec![], // empty PoW
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -1066,6 +1134,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -1098,6 +1167,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -1181,6 +1251,7 @@ mod tests {
             }),
             pricing_model: 1, // SUBSCRIPTION
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_price(req).await.unwrap().into_inner();
@@ -1220,6 +1291,7 @@ mod tests {
             }),
             pricing_model: 1, // SUBSCRIPTION
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         // Should succeed despite no benchmark profile
@@ -1263,6 +1335,7 @@ mod tests {
             }),
             pricing_model: 1, // SUBSCRIPTION
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_price(req).await.unwrap_err();
@@ -1294,6 +1367,7 @@ mod tests {
             }),
             pricing_model: 0, // PAY_ONCE (default)
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         // Should fail because no benchmark profile exists
@@ -1325,6 +1399,7 @@ mod tests {
             }),
             pricing_model: 2, // EVENT_DRIVEN
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_price(req).await.unwrap().into_inner();
@@ -1360,6 +1435,7 @@ mod tests {
             }),
             pricing_model: 99, // Unknown
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_price(req).await.unwrap_err();
@@ -1399,6 +1475,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: true,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -1424,6 +1501,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: true,
+            requester: test_requester_bytes(),
         });
 
         let err = svc.get_job_price(req).await.unwrap_err();
@@ -1446,6 +1524,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: true,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -1467,6 +1546,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: true,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();
@@ -1488,6 +1568,7 @@ mod tests {
             proof_of_work: pow,
             challenge_timestamp: ts,
             require_tee: false,
+            requester: test_requester_bytes(),
         });
 
         let resp = svc.get_job_price(req).await.unwrap().into_inner();

--- a/crates/pricing-engine/src/service/rpc/server.rs
+++ b/crates/pricing-engine/src/service/rpc/server.rs
@@ -1578,4 +1578,129 @@ mod tests {
             "confidentiality should be 0 when require_tee=false"
         );
     }
+
+    // ── Requester validation (audit Round 2 economic F1) ───────────────
+
+    #[tokio::test]
+    async fn test_get_job_price_rejects_zero_requester() {
+        // tnt-core v0.13.0+ rejects wildcard quotes; the gRPC layer must
+        // reject `requester == address(0)` before signing anything.
+        let svc = make_service(vec![((1, 0), U256::from(100u64))]);
+        let (ts, pow) = valid_pow(1).await;
+
+        let req = Request::new(GetJobPriceRequest {
+            service_id: 1,
+            job_index: 0,
+            proof_of_work: pow,
+            challenge_timestamp: ts,
+            require_tee: false,
+            requester: vec![0u8; 20], // zero address
+        });
+
+        let err = svc.get_job_price(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("non-zero"),
+            "error must mention non-zero requirement: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_job_price_rejects_empty_requester() {
+        let svc = make_service(vec![((1, 0), U256::from(100u64))]);
+        let (ts, pow) = valid_pow(1).await;
+
+        let req = Request::new(GetJobPriceRequest {
+            service_id: 1,
+            job_index: 0,
+            proof_of_work: pow,
+            challenge_timestamp: ts,
+            require_tee: false,
+            requester: vec![], // missing
+        });
+
+        let err = svc.get_job_price(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn test_get_job_price_rejects_short_requester() {
+        let svc = make_service(vec![((1, 0), U256::from(100u64))]);
+        let (ts, pow) = valid_pow(1).await;
+
+        let req = Request::new(GetJobPriceRequest {
+            service_id: 1,
+            job_index: 0,
+            proof_of_work: pow,
+            challenge_timestamp: ts,
+            require_tee: false,
+            requester: vec![0xbe; 19], // 19 bytes, not 20
+        });
+
+        let err = svc.get_job_price(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("20-byte"),
+            "error must mention length: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_price_rejects_zero_requester() {
+        let svc = make_service(vec![]);
+        let (ts, pow) = valid_price_pow(1).await;
+        let req = Request::new(GetPriceRequest {
+            blueprint_id: 1,
+            ttl_blocks: 100,
+            proof_of_work: pow,
+            challenge_timestamp: ts,
+            resource_requirements: vec![],
+            security_requirements: Some(crate::pricing_engine::AssetSecurityRequirements {
+                asset: Some(crate::pricing_engine::Asset {
+                    asset_type: Some(crate::pricing_engine::asset::AssetType::Erc20(vec![
+                        0u8;
+                        20
+                    ])),
+                }),
+                minimum_exposure_percent: 10,
+                maximum_exposure_percent: 100,
+            }),
+            pricing_model: 0,
+            require_tee: false,
+            requester: vec![0u8; 20], // zero address
+        });
+
+        let err = svc.get_price(req).await.unwrap_err();
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+        assert!(
+            err.message().contains("non-zero"),
+            "error must mention non-zero requirement: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_job_price_echoes_requester_in_response() {
+        let svc = make_service(vec![((1, 0), U256::from(100u64))]);
+        let (ts, pow) = valid_pow(1).await;
+
+        let req = Request::new(GetJobPriceRequest {
+            service_id: 1,
+            job_index: 0,
+            proof_of_work: pow,
+            challenge_timestamp: ts,
+            require_tee: false,
+            requester: test_requester_bytes(),
+        });
+
+        let resp = svc.get_job_price(req).await.unwrap().into_inner();
+        let details = resp.quote_details.unwrap();
+        assert_eq!(
+            details.requester,
+            test_requester_bytes(),
+            "response must echo the requester so the client can verify the binding"
+        );
+    }
 }

--- a/crates/pricing-engine/src/signer.rs
+++ b/crates/pricing-engine/src/signer.rs
@@ -52,17 +52,30 @@ pub enum Confidentiality {
 
 impl SignableQuote {
     /// Create a new signable quote with default confidentiality (Any = 0).
-    pub fn new(details: pricing_engine::QuoteDetails, total_cost: Decimal) -> Result<Self> {
-        Self::with_confidentiality(details, total_cost, Confidentiality::Any)
+    ///
+    /// `requester` MUST be non-zero — wildcard quotes are rejected by the on-chain
+    /// verifier in tnt-core v0.13.0+. The gRPC layer enforces this; downstream
+    /// callers may rely on the invariant.
+    pub fn new(
+        details: pricing_engine::QuoteDetails,
+        total_cost: Decimal,
+        requester: Address,
+    ) -> Result<Self> {
+        Self::with_confidentiality(details, total_cost, Confidentiality::Any, requester)
     }
 
     /// Create a new signable quote with explicit confidentiality level.
+    ///
+    /// `requester` MUST be non-zero — wildcard quotes are rejected by the on-chain
+    /// verifier in tnt-core v0.13.0+.
     pub fn with_confidentiality(
         details: pricing_engine::QuoteDetails,
         total_cost: Decimal,
         confidentiality: Confidentiality,
+        requester: Address,
     ) -> Result<Self> {
-        let abi_details = build_abi_quote_details(&details, total_cost, confidentiality as u8)?;
+        let abi_details =
+            build_abi_quote_details(&details, total_cost, confidentiality as u8, requester)?;
         Ok(Self {
             proto_details: details,
             abi_details,
@@ -225,6 +238,9 @@ impl OperatorSigner {
 }
 
 /// Convert proto `JobQuoteDetails` (bytes price) → native `job_quote::JobQuoteDetails` (U256 price).
+///
+/// The proto's `requester` field is parsed as a 20-byte address; the gRPC entry
+/// point validates non-zero before reaching this path.
 fn proto_to_native_job_quote(
     details: &crate::pricing_engine::JobQuoteDetails,
 ) -> Result<jq::JobQuoteDetails> {
@@ -241,7 +257,23 @@ fn proto_to_native_job_quote(
         ))
     })?;
 
+    if details.requester.len() != 20 {
+        return Err(PricingError::Signing(format!(
+            "requester must be 20 bytes, got {}",
+            details.requester.len()
+        )));
+    }
+    let mut requester_bytes = [0u8; 20];
+    requester_bytes.copy_from_slice(&details.requester);
+    let requester = Address::from(requester_bytes);
+    if requester.is_zero() {
+        return Err(PricingError::Signing(
+            "requester must be non-zero (tnt-core v0.13.0 rejects wildcard quotes)".to_string(),
+        ));
+    }
+
     Ok(jq::JobQuoteDetails {
+        requester,
         service_id: details.service_id,
         job_index,
         price,
@@ -275,11 +307,21 @@ pub fn job_quote_digest_eip712(
     Ok(jq::job_quote_digest_eip712(&native, to_jq_domain(domain)))
 }
 
+/// Build the on-chain ABI `QuoteDetails` from the proto details and a validated requester.
+///
+/// `requester` MUST be non-zero — the gRPC entry point validates this before
+/// reaching here, since tnt-core v0.13.0+ rejects wildcard quotes on-chain.
 fn build_abi_quote_details(
     details: &pricing_engine::QuoteDetails,
     total_cost: Decimal,
     confidentiality: u8,
+    requester: Address,
 ) -> Result<ITangleTypes::QuoteDetails> {
+    debug_assert!(
+        !requester.is_zero(),
+        "build_abi_quote_details called with zero requester (gRPC layer should have rejected)"
+    );
+
     let security_commitments = details
         .security_commitments
         .iter()
@@ -292,11 +334,10 @@ fn build_abi_quote_details(
         .collect::<Result<Vec<_>>>()?;
 
     Ok(ITangleTypes::QuoteDetails {
-        // `requester == address(0)` is the contract's "open quote" mode (any
-        // address may redeem). Until the proto + RPC surface threads the
-        // requester from `GetPriceRequest` through to here (PR #118 added the
-        // binding on-chain), open-quote is the only safe default.
-        requester: alloy_primitives::Address::ZERO,
+        // Bound to a specific buyer per tnt-core v0.13.0 (audit Round 2
+        // economic F1, PRs #124/#125). `requester == address(0)` is rejected
+        // by the on-chain verifier; the gRPC layer enforces non-zero.
+        requester,
         blueprintId: details.blueprint_id,
         ttlBlocks: details.ttl_blocks,
         totalCost: decimal_to_scaled_amount(total_cost)?,

--- a/crates/pricing-engine/tests/evm_listener.rs
+++ b/crates/pricing-engine/tests/evm_listener.rs
@@ -70,17 +70,15 @@ mod evm_listener_tests {
     /// Address derived from `SERVICE_OWNER_PRIVATE_KEY` (anvil account #0).
     /// This is the buyer/requester for tests that submit quotes on-chain — every
     /// quote in v0.13.0+ binds to a non-zero requester via EIP-712.
-    const SERVICE_OWNER_ADDRESS: alloy_primitives::Address = alloy_primitives::address!(
-        "f39Fd6e51aad88F6F4ce6aB8827279cfFFb92266"
-    );
+    const SERVICE_OWNER_ADDRESS: alloy_primitives::Address =
+        alloy_primitives::address!("f39Fd6e51aad88F6F4ce6aB8827279cfFFb92266");
     /// Non-zero throwaway requester for fixtures that exercise revert paths
     /// (invalid signature, expired quote, mismatched blueprint, etc.). Any
     /// non-zero address works because the on-chain check fires before the
     /// requester binding for these failures, but using a deterministic value
     /// makes the fixtures self-documenting.
-    const REJECTION_PATH_REQUESTER: alloy_primitives::Address = alloy_primitives::address!(
-        "000000000000000000000000000000000000bEEF"
-    );
+    const REJECTION_PATH_REQUESTER: alloy_primitives::Address =
+        alloy_primitives::address!("000000000000000000000000000000000000bEEF");
     const BLUEPRINT_ID: u64 = 0;
     const SERVICE_ID: u64 = 0;
 

--- a/crates/pricing-engine/tests/evm_listener.rs
+++ b/crates/pricing-engine/tests/evm_listener.rs
@@ -67,6 +67,20 @@ mod evm_listener_tests {
         "5de4111afa1a4b94908f83103eb1f1706367c2e68ca870fc3fb9a804cdab365a";
     const SERVICE_OWNER_PRIVATE_KEY: &str =
         "ac0974bec39a17e36ba4a6b4d238ff944bacb478cbed5efcae784d7bf4f2ff80";
+    /// Address derived from `SERVICE_OWNER_PRIVATE_KEY` (anvil account #0).
+    /// This is the buyer/requester for tests that submit quotes on-chain — every
+    /// quote in v0.13.0+ binds to a non-zero requester via EIP-712.
+    const SERVICE_OWNER_ADDRESS: alloy_primitives::Address = alloy_primitives::address!(
+        "f39Fd6e51aad88F6F4ce6aB8827279cfFFb92266"
+    );
+    /// Non-zero throwaway requester for fixtures that exercise revert paths
+    /// (invalid signature, expired quote, mismatched blueprint, etc.). Any
+    /// non-zero address works because the on-chain check fires before the
+    /// requester binding for these failures, but using a deterministic value
+    /// makes the fixtures self-documenting.
+    const REJECTION_PATH_REQUESTER: alloy_primitives::Address = alloy_primitives::address!(
+        "000000000000000000000000000000000000bEEF"
+    );
     const BLUEPRINT_ID: u64 = 0;
     const SERVICE_ID: u64 = 0;
 
@@ -219,6 +233,7 @@ mod evm_listener_tests {
             challenge_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         let response = client.get_price(request).await?.into_inner();
@@ -234,7 +249,8 @@ mod evm_listener_tests {
 
         let total_cost = rust_decimal::Decimal::from_f64(quote_details.total_cost_rate)
             .ok_or_else(|| anyhow::anyhow!("invalid total cost"))?;
-        let signable = SignableQuote::new(quote_details.clone(), total_cost)?;
+        let signable =
+            SignableQuote::new(quote_details.clone(), total_cost, SERVICE_OWNER_ADDRESS)?;
         assert_eq!(
             response.signature.len(),
             65,
@@ -442,6 +458,7 @@ mod evm_listener_tests {
                 challenge_timestamp,
                 pricing_model: 0,
                 require_tee: false,
+                requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
             };
 
             let response = grpc_client.get_price(request).await?.into_inner();
@@ -476,7 +493,8 @@ mod evm_listener_tests {
             let verifier = signer.lock().await.verifying_key();
             let total_cost = rust_decimal::Decimal::from_f64(quote_details.total_cost_rate)
                 .ok_or_else(|| anyhow::anyhow!("invalid total cost"))?;
-            let signable = SignableQuote::new(quote_details.clone(), total_cost)?;
+            let signable =
+                SignableQuote::new(quote_details.clone(), total_cost, SERVICE_OWNER_ADDRESS)?;
             assert_eq!(
                 response.signature.len(),
                 65,
@@ -576,6 +594,7 @@ mod evm_listener_tests {
             challenge_timestamp: expired_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         let result = client.get_price(request).await;
@@ -660,6 +679,7 @@ mod evm_listener_tests {
             challenge_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         let result = client.get_price(request).await;
@@ -742,6 +762,7 @@ mod evm_listener_tests {
             challenge_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         let result = client.get_price(request).await;
@@ -816,6 +837,7 @@ mod evm_listener_tests {
                 challenge_timestamp,
                 pricing_model: 0,
                 require_tee: false,
+                requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
             };
 
             let response = grpc_client.get_price(request).await?.into_inner();
@@ -826,8 +848,11 @@ mod evm_listener_tests {
 
             println!("✓ Received signed quote from pricing engine");
 
-            // Convert to on-chain format
-            let on_chain_quote = convert_to_onchain_quote(&response, &signer).await?;
+            // Convert to on-chain format. The buyer (`SERVICE_OWNER_ADDRESS`)
+            // is the requester bound into the quote — tnt-core v0.13.0+ rejects
+            // any submitter whose `msg.sender` doesn't match.
+            let on_chain_quote =
+                convert_to_onchain_quote(&response, &signer, SERVICE_OWNER_ADDRESS).await?;
 
             println!("✓ Converted quote to on-chain format");
 
@@ -895,9 +920,12 @@ mod evm_listener_tests {
             };
             log_testnet_endpoints(&deployment);
 
-            // Create a quote with an invalid signature (random bytes)
+            // Create a quote with an invalid signature (random bytes).
+            // Use a non-zero requester so we exercise the signature-rejection
+            // path rather than the wildcard-quote rejection path.
             let invalid_quote = ITangleServicesTypes::SignedQuote {
                 details: ITangleServicesTypes::QuoteDetails {
+                    requester: REJECTION_PATH_REQUESTER,
                     blueprintId: BLUEPRINT_ID,
                     ttlBlocks: 100,
                     totalCost: U256::from(1000000u64),
@@ -963,10 +991,12 @@ mod evm_listener_tests {
             };
             log_testnet_endpoints(&deployment);
 
-            // Create a quote that's already expired
+            // Create a quote that's already expired. Non-zero requester so
+            // the expiry check fires before the wildcard-quote check.
             let now = chrono::Utc::now().timestamp() as u64;
             let expired_quote = ITangleServicesTypes::SignedQuote {
                 details: ITangleServicesTypes::QuoteDetails {
+                    requester: REJECTION_PATH_REQUESTER,
                     blueprintId: BLUEPRINT_ID,
                     ttlBlocks: 100,
                     totalCost: U256::from(1000000u64),
@@ -1057,8 +1087,12 @@ mod evm_listener_tests {
             );
 
             // Convert both to on-chain format
-            let on_chain_quote1 = convert_to_onchain_quote(&quote1, &signer1).await?;
-            let on_chain_quote2 = convert_to_onchain_quote(&quote2, &signer2).await?;
+            // Both quotes are submitted by the same SERVICE_OWNER buyer, so
+            // they must both bind to that address as the requester.
+            let on_chain_quote1 =
+                convert_to_onchain_quote(&quote1, &signer1, SERVICE_OWNER_ADDRESS).await?;
+            let on_chain_quote2 =
+                convert_to_onchain_quote(&quote2, &signer2, SERVICE_OWNER_ADDRESS).await?;
 
             println!("✓ Converted both quotes to on-chain format");
 
@@ -1123,9 +1157,12 @@ mod evm_listener_tests {
             };
             log_testnet_endpoints(&deployment);
 
-            // Create a quote for blueprint ID 999 but submit it for blueprint ID 0
+            // Create a quote for blueprint ID 999 but submit it for blueprint ID 0.
+            // Non-zero requester so the blueprint-mismatch check fires before
+            // the wildcard-quote check.
             let mismatched_quote = ITangleServicesTypes::SignedQuote {
                 details: ITangleServicesTypes::QuoteDetails {
+                    requester: REJECTION_PATH_REQUESTER,
                     blueprintId: 999, // Different from submission
                     ttlBlocks: 100,
                     totalCost: U256::from(1000000u64),
@@ -1234,6 +1271,7 @@ mod evm_listener_tests {
             challenge_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         let result = client.get_price(request).await;
@@ -1320,6 +1358,7 @@ mod evm_listener_tests {
             challenge_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         // Zero TTL should still be handled (quote can have zero TTL)
@@ -1423,15 +1462,22 @@ mod evm_listener_tests {
             challenge_timestamp,
             pricing_model: 0,
             require_tee: false,
+            requester: SERVICE_OWNER_ADDRESS.0.to_vec(),
         };
 
         Ok(client.get_price(request).await?.into_inner())
     }
 
-    /// Convert a gRPC quote response to on-chain format
+    /// Convert a gRPC quote response to on-chain format.
+    ///
+    /// `requester` MUST match the address bound into the EIP-712 quote when it
+    /// was signed (typically the buyer's `tx.origin` / `msg.sender`). Since
+    /// tnt-core v0.13.0+, the on-chain verifier rejects `requester == address(0)`
+    /// and rejects any submitter whose `msg.sender` doesn't match.
     async fn convert_to_onchain_quote(
         response: &blueprint_pricing_engine_lib::pricing_engine::GetPriceResponse,
         _signer: &Arc<Mutex<OperatorSigner>>,
+        requester: Address,
     ) -> Result<ITangleServicesTypes::SignedQuote> {
         let quote_details = response
             .quote_details
@@ -1475,6 +1521,7 @@ mod evm_listener_tests {
             .collect::<Vec<_>>();
 
         let details = ITangleServicesTypes::QuoteDetails {
+            requester,
             blueprintId: quote_details.blueprint_id,
             ttlBlocks: quote_details.ttl_blocks,
             totalCost: U256::from(total_cost_scaled),

--- a/crates/pricing-engine/tests/signer_test.rs
+++ b/crates/pricing-engine/tests/signer_test.rs
@@ -31,6 +31,7 @@ async fn test_sign_and_verify_quote() -> Result<()> {
         quote_details.clone(),
         rust_decimal::Decimal::from_f64(quote_details.total_cost_rate)
             .ok_or_else(|| PricingError::Other("invalid decimal".to_string()))?,
+        utils::test_requester_address(),
     )?;
 
     // Create proof of work
@@ -91,6 +92,7 @@ async fn test_service_quote_digest_changes_with_resource_commitments() -> Result
         quote_details,
         rust_decimal::Decimal::from_f64(0.0001)
             .ok_or_else(|| PricingError::Other("invalid decimal".to_string()))?,
+        utils::test_requester_address(),
     )?;
     let signed_quote = signer.sign_quote(signable_quote, vec![1, 2, 3, 4])?;
 

--- a/crates/pricing-engine/tests/utils.rs
+++ b/crates/pricing-engine/tests/utils.rs
@@ -44,7 +44,29 @@ pub fn create_test_quote_details() -> pricing_engine::QuoteDetails {
         expiry: 1_650_001_000,
         resources: vec![resource],
         security_commitments: vec![security_commitment],
+        // Non-zero placeholder; tnt-core v0.13.0+ rejects wildcard quotes.
+        requester: test_requester_bytes(),
     }
+}
+
+/// Non-zero placeholder requester for tests that don't care about the
+/// specific buyer address. Production callers MUST pass the real buyer.
+#[allow(dead_code)]
+pub fn test_requester_bytes() -> Vec<u8> {
+    // 0x000000000000000000000000000000000000bEEF
+    let mut bytes = vec![0u8; 20];
+    bytes[18] = 0xbe;
+    bytes[19] = 0xef;
+    bytes
+}
+
+/// Same address as `test_requester_bytes` but as `alloy_primitives::Address`.
+#[allow(dead_code)]
+pub fn test_requester_address() -> alloy_primitives::Address {
+    let mut bytes = [0u8; 20];
+    bytes[18] = 0xbe;
+    bytes[19] = 0xef;
+    alloy_primitives::Address::from(bytes)
 }
 
 #[allow(dead_code)]

--- a/crates/tangle-extra/src/job_quote.rs
+++ b/crates/tangle-extra/src/job_quote.rs
@@ -4,6 +4,13 @@
 //! via `submitJobFromQuote`. The EIP-712 structured data matches
 //! `tnt-core/src/libraries/SignatureLib.sol`'s `JOB_QUOTE_TYPEHASH`.
 //!
+//! # v0.13.0 binding to `requester`
+//!
+//! Since tnt-core v0.13.0 (audit Round 2 economic F1, tnt-core PRs #124/#125),
+//! every quote is bound to a specific `requester` address. The on-chain verifier
+//! rejects `requester == address(0)` (wildcard quotes are no longer permitted),
+//! and the `address requester` field is the first member of the EIP-712 struct.
+//!
 //! # Usage
 //!
 //! ```rust,ignore
@@ -14,6 +21,7 @@
 //! let mut signer = JobQuoteSigner::new(keypair, domain)?;
 //!
 //! let details = JobQuoteDetails {
+//!     requester: buyer_addr, // MUST be non-zero — wildcard quotes are rejected on-chain
 //!     service_id: 1,
 //!     job_index: 0,
 //!     price: U256::from(1_000_000_000_000_000_000u128), // 1 ETH
@@ -76,9 +84,10 @@ impl TryFrom<u8> for Confidentiality {
 
 /// Per-job quote details that get EIP-712 signed
 ///
-/// Matches `Types.JobQuoteDetails` in tnt-core:
+/// Matches `Types.JobQuoteDetails` in tnt-core (v0.13.0+):
 /// ```solidity
 /// struct JobQuoteDetails {
+///     address requester;
 ///     uint64 serviceId;
 ///     uint8 jobIndex;
 ///     uint256 price;
@@ -89,6 +98,9 @@ impl TryFrom<u8> for Confidentiality {
 /// ```
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct JobQuoteDetails {
+    /// Address allowed to redeem this quote on-chain. MUST be non-zero —
+    /// the contract rejects wildcard (`address(0)`) quotes since v0.13.0.
+    pub requester: Address,
     pub service_id: u64,
     pub job_index: u8,
     pub price: U256,
@@ -249,18 +261,20 @@ fn compute_domain_separator(domain: QuoteSigningDomain) -> B256 {
 
 /// Hash job quote details per the JOB_QUOTE_TYPEHASH
 ///
-/// Matches `SignatureLib.hashJobQuote()`:
+/// Matches `SignatureLib.hashJobQuote()` in tnt-core v0.13.0+:
 /// ```text
-/// keccak256(abi.encode(JOB_QUOTE_TYPEHASH, serviceId, jobIndex, price, timestamp, expiry, confidentiality))
+/// keccak256(abi.encode(JOB_QUOTE_TYPEHASH, requester, serviceId, jobIndex, price, timestamp, expiry, confidentiality))
 /// ```
 fn hash_job_quote_details(details: &JobQuoteDetails) -> B256 {
-    const JOB_QUOTE_TYPEHASH_STR: &str = "JobQuoteDetails(uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry,uint8 confidentiality)";
+    const JOB_QUOTE_TYPEHASH_STR: &str = "JobQuoteDetails(address requester,uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry,uint8 confidentiality)";
 
     let typehash = keccak256(JOB_QUOTE_TYPEHASH_STR.as_bytes());
 
-    // abi.encode pads each field to 32 bytes, matching Solidity's abi.encode behavior
+    // abi.encode pads each field to 32 bytes, matching Solidity's abi.encode behavior.
+    // `requester` is the first field after the typehash (v0.13.0 binding).
     let encoded = (
         typehash,
+        details.requester,
         U256::from(details.service_id),
         U256::from(details.job_index),
         details.price,
@@ -286,6 +300,7 @@ impl From<SignedJobQuote> for blueprint_client_tangle::contracts::ITangleTypes::
         sig_bytes.push(27 + quote.recovery_id);
         Self {
             details: blueprint_client_tangle::contracts::ITangleTypes::JobQuoteDetails {
+                requester: quote.details.requester,
                 serviceId: quote.details.service_id,
                 jobIndex: quote.details.job_index,
                 price: quote.details.price,
@@ -320,9 +335,15 @@ mod tests {
         assert_eq!(sep1, sep2);
     }
 
+    /// Non-zero placeholder for tests that don't assert against cross-repo vectors.
+    fn placeholder_requester() -> Address {
+        address!("000000000000000000000000000000000000bEEF")
+    }
+
     #[test]
     fn test_hash_job_quote_deterministic() {
         let details = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 0,
             price: U256::from(1_000_000_000_000_000_000u128),
@@ -338,6 +359,7 @@ mod tests {
     #[test]
     fn test_different_quotes_produce_different_hashes() {
         let details1 = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 0,
             price: U256::from(100u64),
@@ -346,6 +368,7 @@ mod tests {
             confidentiality: 0,
         };
         let details2 = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 1, // different job
             price: U256::from(100u64),
@@ -360,8 +383,32 @@ mod tests {
     }
 
     #[test]
+    fn test_requester_changes_hash() {
+        // A quote bound to one requester must NOT verify as a quote for another.
+        let base = JobQuoteDetails {
+            requester: placeholder_requester(),
+            service_id: 1,
+            job_index: 0,
+            price: U256::from(100u64),
+            timestamp: 1700000000,
+            expiry: 1700003600,
+            confidentiality: 0,
+        };
+        let other = JobQuoteDetails {
+            requester: address!("00000000000000000000000000000000DeadBeef"),
+            ..base.clone()
+        };
+        assert_ne!(
+            hash_job_quote_details(&base),
+            hash_job_quote_details(&other),
+            "different requester must yield different struct hash"
+        );
+    }
+
+    #[test]
     fn test_confidentiality_changes_hash() {
         let base = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 0,
             price: U256::from(100u64),
@@ -383,6 +430,7 @@ mod tests {
     #[test]
     fn test_digest_differs_across_domains() {
         let details = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 0,
             price: U256::from(100u64),
@@ -412,6 +460,7 @@ mod tests {
         let mut signer = JobQuoteSigner::new(keypair, domain).unwrap();
 
         let details = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 42,
             job_index: 3,
             price: U256::from(500_000_000_000_000_000u128), // 0.5 ETH
@@ -436,6 +485,7 @@ mod tests {
 
         let mut signer = JobQuoteSigner::new(keypair, domain).unwrap();
         let details = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 0,
             price: U256::from(100u64),
@@ -457,6 +507,7 @@ mod tests {
 
         let mut signer = JobQuoteSigner::new(keypair, domain).unwrap();
         let details = JobQuoteDetails {
+            requester: placeholder_requester(),
             service_id: 1,
             job_index: 0,
             price: U256::from(100u64),
@@ -507,6 +558,7 @@ mod tests {
     fn test_eip712_compat_vector1_basic() {
         let domain = compat_domain();
         let details = JobQuoteDetails {
+            requester: address!("000000000000000000000000000000000000bEEF"),
             service_id: 42,
             job_index: 3,
             price: U256::from(1_000_000_000_000_000_000u128), // 1 ether
@@ -519,16 +571,16 @@ mod tests {
         assert_eq!(
             struct_hash,
             B256::from(hex_literal::hex!(
-                "b5ad63b2aafeb693bc7fb591fb0cba712fff4cfafaccfb4bf97de29f069da660"
+                "81efa1579f66bc16802d9c482eb23561fa1a86e1288cb65902b4619005a04a87"
             )),
-            "struct hash must match Solidity Vector 1 (with confidentiality field)"
+            "struct hash must match Solidity Vector 1 (v0.13.0 typehash with requester)"
         );
 
         let digest = job_quote_digest_eip712(&details, domain);
         assert_eq!(
             digest,
-            hex_literal::hex!("e13955facb4fcba51dce076d019e9509fc5d3c028a269e17e5ea1b78ca41fd26"),
-            "EIP-712 digest must match Solidity Vector 1 (with confidentiality field)"
+            hex_literal::hex!("fd2339fda45c2e7e30f8d5dbcc062f82af12757ad80175cbdd6972627fb3c54c"),
+            "EIP-712 digest must match Solidity Vector 1 (v0.13.0 typehash with requester)"
         );
     }
 
@@ -536,6 +588,7 @@ mod tests {
     fn test_eip712_compat_vector2_zero_price() {
         let domain = compat_domain();
         let details = JobQuoteDetails {
+            requester: address!("0000000000000000000000000000000000C0FFEE"),
             service_id: 1,
             job_index: 0,
             price: U256::ZERO,
@@ -547,8 +600,8 @@ mod tests {
         let digest = job_quote_digest_eip712(&details, domain);
         assert_eq!(
             digest,
-            hex_literal::hex!("681b55c8c7602d2069ba2d5503cbec4f25e6067270e5e57bc310a0bb2f4ed7ff"),
-            "zero-price digest must match Solidity Vector 2 (with confidentiality field)"
+            hex_literal::hex!("c21c630f71383acd4d8f5465a13264f9e376dfb323acfe97d5202bc9a5baa221"),
+            "zero-price digest must match Solidity Vector 2 (v0.13.0 typehash with requester)"
         );
     }
 
@@ -556,6 +609,7 @@ mod tests {
     fn test_eip712_compat_vector3_large_price() {
         let domain = compat_domain();
         let details = JobQuoteDetails {
+            requester: address!("000000000000000000000000000000000000bEEF"),
             service_id: 999,
             job_index: 7,
             price: U256::from(u128::MAX), // type(uint128).max
@@ -567,8 +621,8 @@ mod tests {
         let digest = job_quote_digest_eip712(&details, domain);
         assert_eq!(
             digest,
-            hex_literal::hex!("bdb556510beb8c8e04fac3e8f2edcaa98ef9d8a6afe0048554919af68cc2e603"),
-            "large-price digest must match Solidity Vector 3 (with confidentiality field)"
+            hex_literal::hex!("ebd98b504cfdbe392ddf9813148e2f7808bb6f7ef85c376315fe0446c2ffc9ee"),
+            "large-price digest must match Solidity Vector 3 (v0.13.0 typehash with requester)"
         );
     }
 
@@ -581,6 +635,7 @@ mod tests {
         let domain = compat_domain();
 
         let details = JobQuoteDetails {
+            requester: address!("000000000000000000000000000000000000bEEF"),
             service_id: 42,
             job_index: 3,
             price: U256::from(1_000_000_000_000_000_000u128),
@@ -588,8 +643,6 @@ mod tests {
             expiry: 1700003600,
             confidentiality: 0,
         };
-
-        let _digest = job_quote_digest_eip712(&details, domain);
 
         // Sign and verify the digest recovers to the expected address
         let mut signer = JobQuoteSigner::new(keypair, domain).unwrap();
@@ -600,6 +653,19 @@ mod tests {
             signed.operator,
             address!("7E5F4552091A69125d5DfCb7b8C2659029395Bdf"),
             "signer address must match Solidity Vector 4"
+        );
+
+        // The first 32 bytes of the signature must match Solidity Vector 4's `r`
+        // (load-bearing cross-repo digest pin: same private key + same digest =>
+        // identical canonical (r, s) under deterministic ECDSA).
+        use blueprint_crypto::BytesEncoding;
+        let sig_bytes = signed.signature.to_bytes();
+        let mut r = [0u8; 32];
+        r.copy_from_slice(&sig_bytes[..32]);
+        assert_eq!(
+            r,
+            hex_literal::hex!("9d22c9909f6ebbcadc4ec85467c487e3d29afa8409f058371894af17f176db4c"),
+            "signature `r` must match Solidity Vector 4 (v0.13.0 with requester)"
         );
 
         let valid = verify_job_quote(&signed, &signer.verifying_key(), domain).unwrap();


### PR DESCRIPTION
## Headline

**The pricing engine has been emitting invalid quotes against any tnt-core v0.12.0+ deployment since the v0.12.0 contract upgrade.** Every quote is signed with `requester: Address::ZERO` (hardcoded in `crates/pricing-engine/src/signer.rs::build_abi_quote_details`), and the on-chain `verifyQuoteBatch` rejects wildcard quotes — making every operator-issued quote unredeemable.

This PR threads a non-zero `requester` end-to-end (proto → gRPC → signer → EIP-712 digest → on-chain submission), restoring correctness against tnt-core `main` (PRs [tnt-core#124](https://github.com/tangle-network/tnt-core/pull/124) and [tnt-core#125](https://github.com/tangle-network/tnt-core/pull/125), audit Round 2 economic finding F1).

## Migration spec

### 1. Cargo dep bump

`Cargo.toml:129` flipped from `tnt-core-bindings = "0.11.3"` to a git dep on tnt-core's `main`. Reason: bindings v0.13.0 isn't on crates.io yet. **Action item for the merger:** flip to a versioned crates.io dep (`tnt-core-bindings = "0.13.0"`) once the publish lands.

### 2. `crates/tangle-extra/src/job_quote.rs` — full struct migration

- Added `requester: Address` as the first field of `JobQuoteDetails`.
- Updated `JOB_QUOTE_TYPEHASH_STR` to `"JobQuoteDetails(address requester,uint64 serviceId,uint8 jobIndex,uint256 price,uint64 timestamp,uint64 expiry,uint8 confidentiality)"`.
- Updated `hash_job_quote_details` to abi-encode `requester` immediately after the typehash.
- Updated the `From<SignedJobQuote>` → `ITangleTypes::SignedJobQuote` impl.
- Refreshed the 4 cross-repo EIP-712 deterministic test vectors against `tnt-core/test/tangle/EIP712Compatibility.t.sol`:
  - Vector 1 struct hash: `0x81efa1579f66bc16802d9c482eb23561fa1a86e1288cb65902b4619005a04a87`
  - Vector 1 digest:      `0xfd2339fda45c2e7e30f8d5dbcc062f82af12757ad80175cbdd6972627fb3c54c`
  - Vector 2 digest:      `0xc21c630f71383acd4d8f5465a13264f9e376dfb323acfe97d5202bc9a5baa221`
  - Vector 3 digest:      `0xebd98b504cfdbe392ddf9813148e2f7808bb6f7ef85c376315fe0446c2ffc9ee`
  - Vector 4 r:           `0x9d22c9909f6ebbcadc4ec85467c487e3d29afa8409f058371894af17f176db4c`
- Added `test_requester_changes_hash` regression: rebinding to a different requester produces a different struct hash.

Domain separator (`0x14a60a86c57fe72bdcbdc59af9a05606ca542a7ed2eeb732756b210d3306f149`) is unchanged.

### 3. `crates/pricing-engine/src/signer.rs` — thread requester end-to-end

This is **the live-outage fix.** `build_abi_quote_details` no longer hardcodes `Address::ZERO`; it now takes a `requester: Address` parameter, which propagates through `SignableQuote::new` and `SignableQuote::with_confidentiality`. `proto_to_native_job_quote` parses + validates the proto bytes (length 20, non-zero) before delegating to `blueprint_tangle_extra::job_quote`.

### 4. `crates/pricing-engine/proto/pricing.proto` — schema additions

Added `bytes requester` to:
- `GetPriceRequest` (field 9)
- `GetJobPriceRequest` (field 6)
- `QuoteDetails` (field 8)
- `JobQuoteDetails` (field 7)

### 5. `crates/pricing-engine/src/service/rpc/server.rs` — gRPC validation

New `parse_requester` helper rejects empty / wrong-length / zero-address inputs at the gRPC boundary with `Status::invalid_argument`. The validated `Address` is forwarded into the signer and echoed into the proto response so clients can verify the bound address. Both `get_price` and `get_job_price` are wired up.

### 6. `crates/pricing-engine/tests/evm_listener.rs` — integration fixtures

- 5 `GetPriceRequest` / 4 `GetJobPriceRequest` callers updated to send the buyer's address (`SERVICE_OWNER_ADDRESS`, anvil account #0).
- 3 inline `ITangleServicesTypes::QuoteDetails` revert-path fixtures updated with a non-zero `REJECTION_PATH_REQUESTER = 0xbEEF` so the intended rejection (invalid sig / expired / mismatched blueprint) fires before the new wildcard-quote rejection.
- `convert_to_onchain_quote` helper takes a `requester: Address` parameter, threaded into the on-chain `QuoteDetails`.

After this commit, the e2e flow signs a quote with `requester = SERVICE_OWNER_ADDRESS` and submits the on-chain transaction from the same address, round-tripping the v0.13.0 verifier.

### 7. `crates/pricing-engine/README.md`

Updated typehash strings + flow diagram to reflect the v0.13.0 layout.

### 8. Vendored example BSMs (deferred)

`examples/oauth-blueprint/contracts/`, `examples/incredible-squaring/contracts/`, `examples/apikey-blueprint/contracts/` still pin `dependencies/tnt-core-0.10.4/` via soldeer. Bumping these picks up unrelated tnt-core changes (e.g. `forceRemoveAllowsBelowMin` default) — out of scope for this PR's correctness fix and best handled in a follow-up.

## Process / quality

- **7 logical commits**, each tagged with the audit finding (Round 2 economic F1) and tnt-core PRs #124 / #125. Conventional commits.
- **Type-safe propagation:** `requester: Address` flows as `Address`, with conversion only at the proto boundary.
- **Validation at the boundary:** rejected once at gRPC entry; downstream code asserts non-zero with `debug_assert`.
- **No `.unwrap()` on user input** — gRPC validation returns typed `Status::invalid_argument`; signer-layer parsing returns `PricingError::Signing`.
- **Cross-repo digest pins are LOAD-BEARING.** All 4 Solidity test vectors in `tnt-core/test/tangle/EIP712Compatibility.t.sol` are reproduced byte-for-byte by the Rust SDK.

## Test plan

- [x] `cargo check --workspace --all-targets` — clean
- [x] `cargo test -p blueprint-tangle-extra --lib --features keepers job_quote` — 14 tests pass (incl. all 4 v0.13.0 cross-repo vectors + new `test_requester_changes_hash`)
- [x] `cargo test -p blueprint-pricing-engine --lib` — 63 unit tests pass (incl. 5 new requester validation tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [ ] `cargo test -p blueprint-pricing-engine --test evm_listener --features pricing-engine-e2e-tests` — requires anvil + tnt-core artifacts; recommended to run on CI / locally before merge to confirm `verifyQuoteBatch` round-trip