### PR TITLE
chore(deps): bump tnt-core-bindings to v0.15.0 (Round 4)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4947,7 +4947,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5426,7 +5426,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5637,7 +5637,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6347,7 +6347,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7753,7 +7753,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -7788,7 +7788,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -8258,7 +8258,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -10481,7 +10481,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11745,7 +11745,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.38",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -11783,7 +11783,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.59.0",
 ]
@@ -12607,7 +12607,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12709,7 +12709,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13847,7 +13847,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13876,7 +13876,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix 1.1.4",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14099,8 +14099,8 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.13.0"
-source = "git+https://github.com/tangle-network/tnt-core?branch=main#5201cf08bbe64238f0533d113840d7280afdaa08"
+version = "0.15.0"
+source = "git+https://github.com/tangle-network/tnt-core?rev=d3db884#d3db8846477b350c3b7f0e03ab36265761980422"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -15345,7 +15345,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4947,7 +4947,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -7788,7 +7788,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -14100,7 +14100,8 @@ dependencies = [
 [[package]]
 name = "tnt-core-bindings"
 version = "0.15.0"
-source = "git+https://github.com/tangle-network/tnt-core?rev=d3db884#d3db8846477b350c3b7f0e03ab36265761980422"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a35e8238e237b049136c6cbf8698efb4481b18b8520df0304d8928272d39592a"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -15345,7 +15346,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,11 +126,13 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-# tnt-core v0.13.0 binds quotes to the requester address (audit Round 2 economic F1).
-# Upstream tnt-core PRs #124 and #125 land the change. Bindings 0.13.0 is not yet on
-# crates.io, so we pin to the `main` branch in git until the publish lands. Flip this
-# back to a versioned crates.io dep (`"0.13.0"`) once published.
-tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", branch = "main" }
+# tnt-core v0.15.0 ships the audit Round 4 hardening pass: TWAP subscription billing,
+# UUPS-upgradeable L2 receivers, ValidatorPodManager share-pool accounting, dispute-bond
+# pull pattern, and disabled TangleToken.burn. Upstream tnt-core PR #126 (merge commit
+# d3db884) lands the change. Bindings 0.15.0 is not yet on crates.io, so we pin to that
+# revision in git until the publish lands.
+# TODO: flip back to a versioned crates.io dep (`"0.15.0"`) once published.
+tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", rev = "d3db884" }
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,13 +126,11 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-# tnt-core v0.15.0 ships the audit Round 4 hardening pass: TWAP subscription billing,
-# UUPS-upgradeable L2 receivers, ValidatorPodManager share-pool accounting, dispute-bond
-# pull pattern, and disabled TangleToken.burn. Upstream tnt-core PR #126 (merge commit
-# d3db884) lands the change. Bindings 0.15.0 is not yet on crates.io, so we pin to that
-# revision in git until the publish lands.
-# TODO: flip back to a versioned crates.io dep (`"0.15.0"`) once published.
-tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", rev = "d3db884" }
+# tnt-core 0.15.0 ships TWAP-fair subscription billing, UUPS-upgradeable L2
+# slashing receivers, share-pool ValidatorPodManager, the dispute-bond pull
+# pattern (cancelSlash no longer auto-refunds), and disabled TangleToken.burn.
+# https://crates.io/crates/tnt-core-bindings/0.15.0
+tnt-core-bindings = "0.15.0"
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }


### PR DESCRIPTION
## Summary

Bumps `tnt-core-bindings` from `0.13.0` (the prior `main`-branch git pin) to `0.15.0` (pinned to upstream tnt-core merge commit `d3db884`). This brings in the Round 4 audit hardening pass that landed in tnt-core PR #126.

Pinned to git rev rather than crates.io because `tnt-core-bindings 0.15.0` is not yet published. A `TODO` comment in `Cargo.toml` calls out the flip-back once the publish lands.

## Breaking changes in v0.14.0 + v0.15.0 (and how blueprint is affected)

| Upstream change | Impact on blueprint |
| --- | --- |
| `Tangle.billSubscription(uint64)` math changed to TWAP-fair (`rate × cumDelta / (baseline × interval)`). Signature preserved. | `billSubscriptionBatch` is the only entry point used here (`crates/tangle-extra/src/services/billing.rs`); signature unchanged, no code change required. |
| `IStaking.getCumStakeSeconds(operator, asset)` added; exposed via `IMultiAssetDelegation` for Rust callers. | Additive; no existing call site references it. |
| `PaymentLib.ServiceEscrow` gains trailing `__reservedAggregateCursor` and `subscriptionBaselineStake` fields. | Append-only struct change; no Rust call site decodes this struct. |
| `L2SlashingReceiver` + 4 bridge receivers (Arbitrum/Base/Hyperlane/LayerZero) are now UUPS upgradeable — deploys require `proxy + initialize(slasher, messenger, owner)`. Owner-gated reverts use `OwnableUnauthorizedAccount(account)` instead of `"Only owner"`. | No call site in blueprint deploys these or matches their revert strings. |
| `ValidatorPodManager.recordBeaconChainEthBalanceUpdate` removed; split into `recordBeaconChainDeposit` (mints shares for new principal) and `recordBeaconChainRebase` (moves totalAssets only). New `getSharesUint` companion; `getShares -> int256` preserved. | No call site in blueprint. |
| New `BeaconRebase` event; `SharesUpdated` and `WithdrawalQueued`/`WithdrawalCompleted` events gain trailing fields. | No event decoder in blueprint subscribes to these. |
| Dispute-bond refunds switched to pull-pattern: `claimDisputeBond()` + `pendingDisputeBondRefund(address)` added; `cancelSlash` no longer pushes refunds. | No `cancelSlash` callers in blueprint. |
| `TangleToken.burn` / `burnFrom` now revert with `BurnDisabled()`. | No call site in blueprint. |
| `TangleGovernor.MAX_PROPOSAL_ACTIONS` lowered 50→10; `MAX_ACTION_VALUE` lowered 100k→10k ETH. | No governance-proposal builders in blueprint. |
| Quote payment ingress + direct ERC20 deposits reject fee-on-transfer tokens. | Not exercised by blueprint code paths. |
| `ArbitrumCrossChainMessenger.setL2RefundAddress(address)` added. | Additive; not used. |

Net effect on blueprint: no source changes required. Only the `Cargo.toml` pin and `Cargo.lock` resolution move.

## Test plan

- [x] `cargo check --workspace` passes against `tnt-core-bindings 0.15.0`
- [x] `cargo test --workspace --lib --no-fail-fast` — three failures reproduce on `origin/main` and are unrelated to this bump:
  - `blueprint_remote_providers::monitoring::health::tests::test_application_health_checker`
  - `blueprint_remote_providers::tests::discovery::test_peer_discovery_kademlia` / `test_peer_info_updates`
  - `blueprint_manager::services::metrics::tests::active_services_gauge_reflects_mutations`
- [x] `cargo fmt --all --check` clean
- [ ] CI passes
- [ ] Once `tnt-core-bindings 0.15.0` is published to crates.io, follow up to flip the git pin back to a versioned crates.io dep (TODO noted in `Cargo.toml`)