### PR TITLE
chore: bump tnt-core-bindings to v0.17.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4947,7 +4947,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -7788,7 +7788,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.61.2",
 ]
 
 [[package]]
@@ -14099,9 +14099,8 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.15.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a35e8238e237b049136c6cbf8698efb4481b18b8520df0304d8928272d39592a"
+version = "0.17.0"
+source = "git+https://github.com/tangle-network/tnt-core?branch=chore%2Fbindings-v0.17.0#705b4c08fee9b4ed2f9a39184f6699648c18a528"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -15346,7 +15345,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,11 +126,14 @@ broken_intra_doc_links = "deny"
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
 blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
-# tnt-core 0.15.0 ships TWAP-fair subscription billing, UUPS-upgradeable L2
-# slashing receivers, share-pool ValidatorPodManager, the dispute-bond pull
-# pattern (cancelSlash no longer auto-refunds), and disabled TangleToken.burn.
-# https://crates.io/crates/tnt-core-bindings/0.15.0
-tnt-core-bindings = "0.15.0"
+# tnt-core 0.17.0 introduces the subscription billing rearchitecture
+# (requestService + fundService flow), the payments facet split with
+# self-only distributePayment, RFQ replay / freshness / cumulative TTL
+# hardening, the collapsed approveService(ApprovalParams) entry point,
+# claimRewards / claimRewardsAll griefing isolation, and O(1) operator
+# stake aggregation with VPM share-pool slashing.
+# Pinned to the git branch until 0.17.0 is published to crates.io.
+tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", branch = "chore/bindings-v0.17.0", package = "tnt-core-bindings" }
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }


### PR DESCRIPTION
## Summary

Pin `tnt-core-bindings` to the `chore/bindings-v0.17.0` branch in `tangle-network/tnt-core` (commit 705b4c0) pending the crates.io publish of 0.17.0. This is a temporary git dep; once the version is published we'll flip back to a crates.io pin.

v0.17.0 carries:
- Subscription billing rearchitecture (`requestService` + `fundService` flow).
- Payments facet split with self-only `distributePayment` on `TanglePaymentsDistributionFacet`.
- RFQ replay / freshness / cumulative TTL hardening.
- Collapsed `approveService(ApprovalParams)` entry point — old `approveServiceWithXxx` matrix removed.
- `claimRewards` / `claimRewardsAll` griefing isolation via per-token try/catch.
- O(1) operator stake aggregation with VPM share-pool slashing.
- Multi-asset subscription bill weighting.

Upstream: tangle-network/tnt-core#137.

## Compile / test status

- `cargo check --workspace`: clean.
- `cargo test --workspace --lib`: 1128 passed, 0 failed, 23 ignored.

No source changes were required — the bindings re-exports consumed by `crates/clients/tangle/src/contracts.rs`, `crates/qos/src/heartbeat.rs`, and `crates/x402/src/gateway.rs` are still present in v0.17.0.

## Follow-up

Flip the dep back to `tnt-core-bindings = "0.17.0"` once the crate is published.