### PR TITLE
chore(deps): batch bump clap-cargo / ripemd (+3 deferred)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,7 +23,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "generic-array",
 ]
 
@@ -2824,6 +2824,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block-buffer"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd35008169921d80bc60d3d0ab416eecb028c4cd653352907921d95084790be"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "block2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3472,7 +3481,7 @@ dependencies = [
  "hex",
  "k256",
  "parking_lot 0.12.5",
- "ripemd",
+ "ripemd 0.2.0",
  "rust-bls-bn254",
  "schnorrkel",
  "serde",
@@ -4737,7 +4746,7 @@ version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "inout",
  "zeroize",
 ]
@@ -4765,9 +4774,9 @@ dependencies = [
 
 [[package]]
 name = "clap-cargo"
-version = "0.14.1"
+version = "0.18.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23b2ea69cefa96b848b73ad516ad1d59a195cdf9263087d977f648a818c8b43e"
+checksum = "936551935c8258754bb8216aec040957d261f977303754b9bf1a213518388006"
 dependencies = [
  "anstyle",
  "clap",
@@ -4878,7 +4887,7 @@ dependencies = [
  "const-hex",
  "digest 0.10.7",
  "generic-array",
- "ripemd",
+ "ripemd 0.1.3",
  "serde",
  "sha2 0.10.9",
  "sha3",
@@ -5258,6 +5267,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crypto-common"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77727bb15fa921304124b128af125e7e3b968275d1b108b379190264f4423710"
+dependencies = [
+ "hybrid-array",
+]
+
+[[package]]
 name = "ct-codecs"
 version = "1.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5615,8 +5633,18 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "const-oid",
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
+]
+
+[[package]]
+name = "digest"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
+dependencies = [
+ "block-buffer 0.12.0",
+ "crypto-common 0.2.1",
 ]
 
 [[package]]
@@ -7581,6 +7609,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
+name = "hybrid-array"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9155a582abd142abc056962c29e3ce5ff2ad5469f4246b537ed42c5deba857da"
+dependencies = [
+ "typenum",
+]
+
+[[package]]
 name = "hyper"
 version = "0.14.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7788,7 +7825,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -12343,6 +12380,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "ripemd"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd4211456b4172d7e44261920c25acf07367c4f04bb5f5d54fc21b090d9b159"
+dependencies = [
+ "digest 0.11.3",
+]
+
+[[package]]
 name = "rkyv"
 version = "0.7.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -14930,7 +14976,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
 dependencies = [
- "crypto-common",
+ "crypto-common 0.1.7",
  "subtle",
 ]
 
@@ -16002,7 +16048,7 @@ dependencies = [
  "crc32fast",
  "crossbeam-utils",
  "crunchy",
- "crypto-common",
+ "crypto-common 0.1.7",
  "curve25519-dalek",
  "data-encoding",
  "der",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -253,7 +253,7 @@ async-stream = { version = "0.3.6", default-features = false }
 # CLI & Configuration
 cargo-generate = { version = "0.23.7", default-features = false }
 clap = { version = "4.5.60", features = ["derive", "env"] }
-clap-cargo = { version = "0.14", default-features = false }
+clap-cargo = { version = "0.18", default-features = false }
 toml = { version = "1.0", default-features = false, features = ["parse", "display", "serde"] }
 dialoguer = { version = "0.11.0", default-features = false }
 dotenv = { version = "0.15", default-features = false }
@@ -413,7 +413,7 @@ alloy-consensus = { version = "1.8", default-features = false }
 alloy-eips = { version = "2.0", default-features = false }
 alloy-transport = { version = "1.8", default-features = false }
 alloy-transport-http = { version = "2.0", default-features = false }
-ripemd = { version = "0.1.3", default-features = false }
+ripemd = { version = "0.2", default-features = false }
 libsecp256k1 = { version = "0.7.2", default-features = false }
 
 # Remote signing


### PR DESCRIPTION
## Summary

Consolidates dependabot bumps. Two land here; three are documented as blocked and deferred to follow-up PRs.

### Landed

| Crate | From | To | Origin PR |
|---|---|---|---|
| `clap-cargo` | 0.14.1 | 0.18.3 | #1412 |
| `ripemd` | 0.1.3 | 0.2.0 | #1410 |

`ripemd` is declared as an optional dep of `blueprint-keystore` (gated behind the `ecdsa` feature) and is not referenced by any Rust source under `crates/keystore/src/`, so the 0.1 -> 0.2 trait-based `Digest` API change is transparent here.

`clap-cargo` is consumed in `cli/src/main.rs` via `clap_cargo::Manifest` / `clap_cargo::Features`. The 0.14 -> 0.18 range only changes internal `clap` plumbing; the public derive-flatten surface used by cargo-tangle is unchanged.

### Deferred (with reason)

| Crate | Bump | Origin PR | Blocker |
|---|---|---|---|
| `alloy-contract` | 1.8.3 -> 2.0.0 | #1409 | Per the crates.io index, `alloy-contract 2.0.x` requires `alloy-consensus`, `alloy-network`, `alloy-network-primitives`, `alloy-provider`, `alloy-pubsub`, `alloy-rpc-types-eth`, `alloy-signer`, `alloy-signer-local` all at `^2.0.x`. The workspace pins these at `1.8.x` and they are referenced across `crates/runner`, `crates/clients/eigenlayer`, `crates/clients/tangle`, `crates/chain-setup/anvil`, `crates/tangle-aggregation-svc`, `cli`, plus three examples. This is a full-stack `alloy 1.x -> 2.x` migration that needs its own PR. |
| `alloy-signer-ledger` | 1.8.3 -> 2.0.1 | #1411 | Same blocker: `alloy-signer-ledger 2.0.x` requires `alloy-signer ^2.0.x`, `alloy-network ^2.0.x`, `alloy-consensus ^2.0.x`. Lands with the alloy 2.x migration above. |
| `ark-bn254` | 0.5.0 -> 0.6.0 | #1408 | The published external crate `tnt-bls 0.1.8` (consumed via `blueprint-crypto-bls`) pins `ark-bls12-377`, `ark-bls12-381`, `ark-ec`, `ark-ff`, `ark-serialize`, `ark-serialize-derive` at `^0.5.0`. Bumping our ark stack to 0.6 produces two `ark_serialize` versions in the dep graph; the `tnt_bls::SecretKey`/`PublicKey` types only implement the 0.5 `CanonicalSerialize`/`CanonicalDeserialize` traits, so re-exporting them through `crates/crypto/bls` fails to compile against the 0.6 trait bounds. Needs a tnt-bls release re-pinned to ark 0.6 (or a fork) before this can land. Note that `ark-bn254` cannot move alone -- 0.6.0 requires `ark-ec ^0.6.0` and `ark-ff ^0.6.0`, so this is in practice a full ark-bn254/ec/ff/serialize stack bump. |

### Verification

- `cargo check --workspace --all-targets` — clean, no warnings introduced
- `cargo test --workspace --lib --no-fail-fast` — **1128 passed, 0 failed, 23 ignored**
  - `blueprint-keystore` (the ripemd consumer): 8 passed, 0 failed, 3 ignored (hardware-only AWS/GCP/Ledger)
  - `cargo-tangle` (the clap-cargo consumer): 75 passed, 0 failed, 1 ignored

### Closing originals

Will close #1408, #1409, #1410, #1411, #1412 as superseded after this PR is opened. The three deferred bumps remain tracked in this PR body so the next attempt has the blocker context.