### PR TITLE
chore(deps): bump tnt-core-bindings 0.17.0 → 0.17.1 (crates.io)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14145,8 +14145,9 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.17.0"
-source = "git+https://github.com/tangle-network/tnt-core?branch=chore%2Fbindings-v0.17.0#705b4c08fee9b4ed2f9a39184f6699648c18a528"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9638c85526f68b60d95bbe660f6f09ab116dfd06a4793f747374646278b82256"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,9 +131,7 @@ blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-feat
 # self-only distributePayment, RFQ replay / freshness / cumulative TTL
 # hardening, the collapsed approveService(ApprovalParams) entry point,
 # claimRewards / claimRewardsAll griefing isolation, and O(1) operator
-# stake aggregation with VPM share-pool slashing.
-# Pinned to the git branch until 0.17.0 is published to crates.io.
-tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", branch = "chore/bindings-v0.17.0", package = "tnt-core-bindings" }
+tnt-core-bindings = "0.17.1"
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }


### PR DESCRIPTION
## What

Bumps the workspace's `tnt-core-bindings` dependency from the git-branch pin (`chore/bindings-v0.17.0`) to the published crates.io release **v0.17.1** (https://crates.io/crates/tnt-core-bindings/0.17.1).

## What v0.17.1 lands

| Surface | Change |
|---|---|
| M-2 escrow rescue | New: `withdrawRemainingEscrowTo(serviceId, to)` — owner-chosen refund recipient escape hatch when the escrow token blocklists the service owner. |
| H-1 oracle snapshot | Per-(serviceId, op, asset) USD price snapshot captured at activation/join. Post-activation oracle drift cannot inflate one operator's bill share. |
| F-001 pull-payment | Distributor pulls ERC20 via `safeTransferFrom` instead of expecting a pre-push; reverting distributor no longer strands tokens. |
| Governance-tunable operator cap | New: `setMaxOperatorsPerService(uint32)` admin setter + `maxOperatorsPerService()` view, default 256 (was hardcoded 64). |
| New events | `PushTransferFailed`, `PriceOracleFallback`, `MaxOperatorsPerServiceUpdated`. |

## Test plan

- [x] `cargo check --workspace` clean — no ABI break sites.
- [ ] CI lint + test.

Switches off the git-branch pin onto the canonical crates.io release. Follows tnt-core PRs #144 + #147 (M-2 + H-1 + F-001 polish landed on tnt-core main; bindings published to crates.io; tag `bindings-v0.17.1`).