### PR TITLE
fix(crypto-bls): remove dangling serde_json/std feature reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1346,7 +1346,7 @@ checksum = "d301b3b94cb4b2f23d7917810addbbaff90738e0ca2be692bd027e70d7e0330c"
 
 [[package]]
 name = "apikey-blueprint-bin"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "apikey-blueprint-lib",
  "blueprint-sdk",
@@ -1358,7 +1358,7 @@ dependencies = [
 
 [[package]]
 name = "apikey-blueprint-lib"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -2855,7 +2855,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-anvil-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-eips 2.0.1",
@@ -2893,7 +2893,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-auth"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "axum",
  "base64 0.22.1",
@@ -2947,7 +2947,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-benchmarking"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-std",
  "sysinfo 0.38.4",
@@ -2957,7 +2957,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-build-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-std",
  "workspace-hack",
@@ -2965,7 +2965,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "blueprint-chain-setup-anvil",
  "workspace-hack",
@@ -2973,7 +2973,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-chain-setup-anvil"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-contract",
  "alloy-provider",
@@ -2995,7 +2995,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-core"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "auto_impl",
  "blueprint-std",
@@ -3005,7 +3005,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-eigenlayer"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -3034,7 +3034,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-evm"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-json-rpc 1.8.3",
@@ -3066,7 +3066,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-client-tangle"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -3101,7 +3101,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-clients"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "blueprint-client-core",
  "blueprint-client-eigenlayer",
@@ -3114,7 +3114,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-context-derive"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-provider",
@@ -3132,7 +3132,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-contexts"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "blueprint-client-tangle",
  "blueprint-clients",
@@ -3146,7 +3146,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-sdk",
  "bytes",
@@ -3163,7 +3163,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-core-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "blueprint-auth",
  "blueprint-clients",
@@ -3183,7 +3183,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-crypto-bls",
  "blueprint-crypto-bn254",
@@ -3198,7 +3198,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bls"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "ark-serialize 0.5.0",
  "blueprint-crypto-core",
@@ -3218,7 +3218,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-bn254"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "ark-bn254",
  "ark-ec",
@@ -3241,7 +3241,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-core"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-std",
  "clap",
@@ -3252,7 +3252,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-ed25519"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -3268,7 +3268,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-hashing"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "argon2",
  "blake3",
@@ -3281,7 +3281,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-k256"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-primitives",
  "alloy-signer-local",
@@ -3299,7 +3299,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-crypto-sr25519"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-crypto-core",
  "blueprint-std",
@@ -3315,7 +3315,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-extra"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy",
  "alloy-contract",
@@ -3350,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -3373,7 +3373,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-evm-extra"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-network 1.8.3",
@@ -3405,7 +3405,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-faas"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "async-trait",
  "aws-config",
@@ -3434,7 +3434,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-gossip-primitives"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "async-trait",
  "bincode",
@@ -3457,7 +3457,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-keystore"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3497,7 +3497,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-macros"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-sdk",
  "proc-macro2",
@@ -3513,7 +3513,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3603,7 +3603,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager-bridge"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-auth",
  "blueprint-core",
@@ -3622,7 +3622,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metrics"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-metrics-rpc-calls",
  "workspace-hack",
@@ -3630,7 +3630,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-metrics-rpc-calls"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "metrics",
  "workspace-hack",
@@ -3638,7 +3638,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-primitives",
  "bincode",
@@ -3665,7 +3665,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking-agg-sig-gossip-extension"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "bincode",
  "bitvec",
@@ -3695,7 +3695,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-networking-round-based-extension"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-core",
  "blueprint-crypto",
@@ -3724,7 +3724,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-pricing-engine"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3785,7 +3785,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-producers-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-core",
  "chrono",
@@ -3798,7 +3798,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-profiling"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3815,7 +3815,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-qos"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -3866,7 +3866,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-remote-providers"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -3927,7 +3927,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-router"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-core",
  "blueprint-sdk",
@@ -3944,7 +3944,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-runner"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-contract",
  "alloy-primitives",
@@ -3989,7 +3989,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-sdk"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy",
  "alloy-json-abi",
@@ -4033,7 +4033,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-std"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "colored",
  "num-traits",
@@ -4045,7 +4045,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-store-local-database"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-std",
  "serde",
@@ -4057,7 +4057,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-stores"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-store-local-database",
  "document-features",
@@ -4067,7 +4067,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -4099,7 +4099,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tangle-extra"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy",
  "alloy-network 1.8.3",
@@ -4142,7 +4142,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-tee"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "aws-config",
  "aws-sdk-ec2",
@@ -4174,7 +4174,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "blueprint-anvil-testing-utils",
  "blueprint-core-testing-utils",
@@ -4184,7 +4184,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-webhooks"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "axum",
  "blueprint-core",
@@ -4212,7 +4212,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-x402"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 dependencies = [
  "alloy-primitives",
  "alloy-provider",
@@ -4503,7 +4503,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-tangle"
-version = "0.5.0-alpha.3"
+version = "0.5.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",
@@ -7407,7 +7407,7 @@ checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
 name = "hello-tangle-blueprint"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -8042,7 +8042,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-bin"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-faas",
  "blueprint-profiling",
@@ -8057,7 +8057,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-eigenlayer"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-consensus 1.8.3",
  "alloy-contract",
@@ -8107,7 +8107,7 @@ dependencies = [
 
 [[package]]
 name = "incredible-squaring-blueprint-lib"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-primitives",
  "alloy-sol-types",
@@ -10637,7 +10637,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-blueprint-bin"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "blueprint-sdk",
  "oauth-blueprint-lib",
@@ -10649,7 +10649,7 @@ dependencies = [
 
 [[package]]
 name = "oauth-blueprint-lib"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",
@@ -16270,7 +16270,7 @@ dependencies = [
 
 [[package]]
 name = "x402-blueprint"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -14145,8 +14145,9 @@ dependencies = [
 
 [[package]]
 name = "tnt-core-bindings"
-version = "0.17.0"
-source = "git+https://github.com/tangle-network/tnt-core?branch=chore%2Fbindings-v0.17.0#705b4c08fee9b4ed2f9a39184f6699648c18a528"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9638c85526f68b60d95bbe660f6f09ab116dfd06a4793f747374646278b82256"
 dependencies = [
  "alloy",
  "alloy-contract",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -131,9 +131,7 @@ blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-feat
 # self-only distributePayment, RFQ replay / freshness / cumulative TTL
 # hardening, the collapsed approveService(ApprovalParams) entry point,
 # claimRewards / claimRewardsAll griefing isolation, and O(1) operator
-# stake aggregation with VPM share-pool slashing.
-# Pinned to the git branch until 0.17.0 is published to crates.io.
-tnt-core-bindings = { git = "https://github.com/tangle-network/tnt-core", branch = "chore/bindings-v0.17.0", package = "tnt-core-bindings" }
+tnt-core-bindings = "0.17.1"
 
 # Job system
 blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -125,7 +125,7 @@ broken_intra_doc_links = "deny"
 
 [workspace.dependencies]
 # SDKs (overarching crates that include all other crates)
-blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.5", path = "./crates/sdk", default-features = false }
 # tnt-core 0.17.0 introduces the subscription billing rearchitecture
 # (requestService + fundService flow), the payments facet split with
 # self-only distributePayment, RFQ replay / freshness / cumulative TTL
@@ -134,96 +134,96 @@ blueprint-sdk = { version = "0.2.0-alpha.4", path = "./crates/sdk", default-feat
 tnt-core-bindings = "0.17.1"
 
 # Job system
-blueprint-core = { version = "0.2.0-alpha.3", path = "crates/core", default-features = false }
-blueprint-router = { version = "0.2.0-alpha.3", path = "crates/router", default-features = false }
-blueprint-runner = { version = "0.2.0-alpha.4", path = "crates/runner", default-features = false }
+blueprint-core = { version = "0.2.0-alpha.4", path = "crates/core", default-features = false }
+blueprint-router = { version = "0.2.0-alpha.4", path = "crates/router", default-features = false }
+blueprint-runner = { version = "0.2.0-alpha.5", path = "crates/runner", default-features = false }
 
 # Extras
-blueprint-tangle-extra = { version = "0.2.0-alpha.4", path = "crates/tangle-extra", features = ["std"] }
-blueprint-evm-extra = { version = "0.2.0-alpha.4", path = "crates/evm-extra", default-features = false }
-blueprint-eigenlayer-extra = { version = "0.2.0-alpha.4", path = "crates/eigenlayer-extra", default-features = false }
-blueprint-producers-extra = { version = "0.2.0-alpha.3", path = "crates/producers-extra", default-features = false }
-blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.4", path = "crates/tangle-aggregation-svc", default-features = false }
+blueprint-tangle-extra = { version = "0.2.0-alpha.5", path = "crates/tangle-extra", features = ["std"] }
+blueprint-evm-extra = { version = "0.2.0-alpha.5", path = "crates/evm-extra", default-features = false }
+blueprint-eigenlayer-extra = { version = "0.2.0-alpha.5", path = "crates/eigenlayer-extra", default-features = false }
+blueprint-producers-extra = { version = "0.2.0-alpha.4", path = "crates/producers-extra", default-features = false }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.5", path = "crates/tangle-aggregation-svc", default-features = false }
 
 # Blueprint utils
-blueprint-manager = { version = "0.4.0-alpha.3", path = "./crates/manager", default-features = false }
-blueprint-manager-bridge = { version = "0.2.0-alpha.3", path = "./crates/manager/bridge", default-features = false }
-blueprint-remote-providers = { version = "0.2.0-alpha.4", path = "./crates/blueprint-remote-providers", default-features = false }
-blueprint-faas = { version = "0.2.0-alpha.3", path = "./crates/blueprint-faas", default-features = false }
-blueprint-profiling = { version = "0.2.0-alpha.3", path = "./crates/blueprint-profiling", default-features = false }
+blueprint-manager = { version = "0.4.0-alpha.4", path = "./crates/manager", default-features = false }
+blueprint-manager-bridge = { version = "0.2.0-alpha.4", path = "./crates/manager/bridge", default-features = false }
+blueprint-remote-providers = { version = "0.2.0-alpha.5", path = "./crates/blueprint-remote-providers", default-features = false }
+blueprint-faas = { version = "0.2.0-alpha.4", path = "./crates/blueprint-faas", default-features = false }
+blueprint-profiling = { version = "0.2.0-alpha.4", path = "./crates/blueprint-profiling", default-features = false }
 
 # Example blueprints
-incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.3", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
-blueprint-build-utils = { version = "0.2.0-alpha.3", path = "./crates/build-utils", default-features = false }
-blueprint-auth = { version = "0.2.0-alpha.3", path = "./crates/auth", default-features = false }
+incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.4", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
+blueprint-build-utils = { version = "0.2.0-alpha.4", path = "./crates/build-utils", default-features = false }
+blueprint-auth = { version = "0.2.0-alpha.4", path = "./crates/auth", default-features = false }
 
 # Chain Setup
-blueprint-chain-setup = { version = "0.2.0-alpha.4", path = "./crates/chain-setup", default-features = false }
-blueprint-chain-setup-anvil = { version = "0.2.0-alpha.4", path = "./crates/chain-setup/anvil", default-features = false }
+blueprint-chain-setup = { version = "0.2.0-alpha.5", path = "./crates/chain-setup", default-features = false }
+blueprint-chain-setup-anvil = { version = "0.2.0-alpha.5", path = "./crates/chain-setup/anvil", default-features = false }
 
 # Crypto
-blueprint-crypto-core = { version = "0.2.0-alpha.3", path = "./crates/crypto/core", default-features = false }
-blueprint-crypto-k256 = { version = "0.2.0-alpha.3", path = "./crates/crypto/k256", default-features = false }
-blueprint-crypto-sr25519 = { version = "0.2.0-alpha.3", path = "./crates/crypto/sr25519", default-features = false }
-blueprint-crypto-ed25519 = { version = "0.2.0-alpha.3", path = "./crates/crypto/ed25519", default-features = false }
-blueprint-crypto-hashing = { version = "0.2.0-alpha.3", path = "./crates/crypto/hashing", default-features = false }
-blueprint-crypto-bls = { version = "0.2.0-alpha.3", path = "./crates/crypto/bls", default-features = false }
-blueprint-crypto-bn254 = { version = "0.2.0-alpha.3", path = "./crates/crypto/bn254", default-features = false }
-blueprint-crypto = { version = "0.2.0-alpha.3", path = "./crates/crypto", default-features = false }
+blueprint-crypto-core = { version = "0.2.0-alpha.4", path = "./crates/crypto/core", default-features = false }
+blueprint-crypto-k256 = { version = "0.2.0-alpha.4", path = "./crates/crypto/k256", default-features = false }
+blueprint-crypto-sr25519 = { version = "0.2.0-alpha.4", path = "./crates/crypto/sr25519", default-features = false }
+blueprint-crypto-ed25519 = { version = "0.2.0-alpha.4", path = "./crates/crypto/ed25519", default-features = false }
+blueprint-crypto-hashing = { version = "0.2.0-alpha.4", path = "./crates/crypto/hashing", default-features = false }
+blueprint-crypto-bls = { version = "0.2.0-alpha.4", path = "./crates/crypto/bls", default-features = false }
+blueprint-crypto-bn254 = { version = "0.2.0-alpha.4", path = "./crates/crypto/bn254", default-features = false }
+blueprint-crypto = { version = "0.2.0-alpha.4", path = "./crates/crypto", default-features = false }
 
 # Clients
-blueprint-clients = { version = "0.2.0-alpha.4", path = "./crates/clients", default-features = false }
-blueprint-client-core = { version = "0.2.0-alpha.3", path = "./crates/clients/core", default-features = false }
-blueprint-client-eigenlayer = { version = "0.2.0-alpha.4", path = "./crates/clients/eigenlayer", default-features = false }
-blueprint-client-evm = { version = "0.2.0-alpha.3", path = "./crates/clients/evm", default-features = false }
-blueprint-client-tangle = { version = "0.2.0-alpha.4", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-contexts = { version = "0.2.0-alpha.4", path = "./crates/contexts", default-features = false }
+blueprint-clients = { version = "0.2.0-alpha.5", path = "./crates/clients", default-features = false }
+blueprint-client-core = { version = "0.2.0-alpha.4", path = "./crates/clients/core", default-features = false }
+blueprint-client-eigenlayer = { version = "0.2.0-alpha.5", path = "./crates/clients/eigenlayer", default-features = false }
+blueprint-client-evm = { version = "0.2.0-alpha.4", path = "./crates/clients/evm", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.5", path = "./crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-contexts = { version = "0.2.0-alpha.5", path = "./crates/contexts", default-features = false }
 
 # Pricing Engine
-blueprint-pricing-engine = { version = "0.3.0-alpha.3", path = "./crates/pricing-engine", default-features = false }
+blueprint-pricing-engine = { version = "0.3.0-alpha.4", path = "./crates/pricing-engine", default-features = false }
 
 # TEE Support
-blueprint-tee = { version = "0.2.0-alpha.3", path = "./crates/tee", default-features = false }
+blueprint-tee = { version = "0.2.0-alpha.4", path = "./crates/tee", default-features = false }
 
 # x402 Payment Gateway
-blueprint-x402 = { version = "0.2.0-alpha.4", path = "./crates/x402", default-features = false }
+blueprint-x402 = { version = "0.2.0-alpha.5", path = "./crates/x402", default-features = false }
 
 # Webhook Producer
-blueprint-webhooks = { version = "0.2.0-alpha.4", path = "./crates/webhooks", default-features = false }
+blueprint-webhooks = { version = "0.2.0-alpha.5", path = "./crates/webhooks", default-features = false }
 
 # Macros
-blueprint-macros = { version = "0.2.0-alpha.3", path = "./crates/macros", default-features = false }
-blueprint-context-derive = { version = "0.2.0-alpha.3", path = "./crates/macros/context-derive", default-features = false }
+blueprint-macros = { version = "0.2.0-alpha.4", path = "./crates/macros", default-features = false }
+blueprint-context-derive = { version = "0.2.0-alpha.4", path = "./crates/macros/context-derive", default-features = false }
 
 # Quality of Service
-blueprint-qos = { version = "0.2.0-alpha.4", path = "./crates/qos", default-features = false }
+blueprint-qos = { version = "0.2.0-alpha.5", path = "./crates/qos", default-features = false }
 
 # Stores
-blueprint-stores = { version = "0.2.0-alpha.3", path = "./crates/stores", default-features = false }
-blueprint-store-local-database = { version = "0.2.0-alpha.3", path = "./crates/stores/local-database", default-features = false }
+blueprint-stores = { version = "0.2.0-alpha.4", path = "./crates/stores", default-features = false }
+blueprint-store-local-database = { version = "0.2.0-alpha.4", path = "./crates/stores/local-database", default-features = false }
 rocksdb = { version = "0.21.0", default-features = false }
 
 # SDK
-blueprint-keystore = { version = "0.2.0-alpha.4", path = "./crates/keystore", default-features = false }
-blueprint-std = { version = "0.2.0-alpha.3", path = "./crates/std", default-features = false }
+blueprint-keystore = { version = "0.2.0-alpha.5", path = "./crates/keystore", default-features = false }
+blueprint-std = { version = "0.2.0-alpha.4", path = "./crates/std", default-features = false }
 
 # P2P
-blueprint-networking = { version = "0.2.0-alpha.3", path = "./crates/networking", default-features = false }
-blueprint-networking-round-based-extension = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/round-based", default-features = false }
-blueprint-networking-agg-sig-gossip-extension = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/agg-sig-gossip", default-features = false }
-blueprint-gossip-primitives = { version = "0.2.0-alpha.3", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
+blueprint-networking = { version = "0.2.0-alpha.4", path = "./crates/networking", default-features = false }
+blueprint-networking-round-based-extension = { version = "0.2.0-alpha.4", path = "./crates/networking/extensions/round-based", default-features = false }
+blueprint-networking-agg-sig-gossip-extension = { version = "0.2.0-alpha.4", path = "./crates/networking/extensions/agg-sig-gossip", default-features = false }
+blueprint-gossip-primitives = { version = "0.2.0-alpha.4", path = "./crates/networking/extensions/gossip-primitives", default-features = false }
 
 # Testing utilities
-blueprint-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils", default-features = false }
-blueprint-core-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils/core", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils/anvil", default-features = false }
-blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.4", path = "./crates/testing-utils/eigenlayer", default-features = false }
+blueprint-testing-utils = { version = "0.2.0-alpha.5", path = "./crates/testing-utils", default-features = false }
+blueprint-core-testing-utils = { version = "0.2.0-alpha.5", path = "./crates/testing-utils/core", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.5", path = "./crates/testing-utils/anvil", default-features = false }
+blueprint-eigenlayer-testing-utils = { version = "0.2.0-alpha.5", path = "./crates/testing-utils/eigenlayer", default-features = false }
 
 # Metrics
-blueprint-metrics = { version = "0.2.0-alpha.3", path = "./crates/metrics", default-features = false }
-blueprint-metrics-rpc-calls = { version = "0.2.0-alpha.3", path = "./crates/metrics/rpc-calls", default-features = false }
+blueprint-metrics = { version = "0.2.0-alpha.4", path = "./crates/metrics", default-features = false }
+blueprint-metrics-rpc-calls = { version = "0.2.0-alpha.4", path = "./crates/metrics/rpc-calls", default-features = false }
 
-cargo-tangle = { version = "0.5.0-alpha.3", path = "./cli", default-features = false }
+cargo-tangle = { version = "0.5.0-alpha.4", path = "./cli", default-features = false }
 cargo_metadata = { version = "0.18.1" }
 bollard = { version = "0.18.0", features = ["ssl"] }
 
@@ -347,7 +347,7 @@ nftables = { version = "0.6.3", default-features = false }
 auto_impl = { version = "1.2.1", default-features = false }
 eigenlayer-contract-deployer = { version = "0.4.0", default-features = false }
 cargo_toml = { version = "0.21.0", default-features = false }
-docktopus = { version = "0.4.0-alpha.2", default-features = false }
+docktopus = { version = "0.4.0-alpha.3", default-features = false }
 itertools = { version = "0.14.0", default-features = false }
 paste = { version = "1.0.15", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }

--- a/blueprint_apikey.json
+++ b/blueprint_apikey.json
@@ -1,7 +1,7 @@
 {
   "name": "apikey-blueprint",
   "description": "API key issuance and resource blueprint",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "master_revision": "Latest",
   "manager": {
     "Evm": "ApikeyBlueprintBSM"

--- a/blueprint_oauth.json
+++ b/blueprint_oauth.json
@@ -1,7 +1,7 @@
 {
   "name": "oauth-blueprint",
   "description": "OAuth-protected document storage blueprint",
-  "version": "0.2.0-alpha.3",
+  "version": "0.2.0-alpha.4",
   "master_revision": "Latest",
   "manager": {
     "Evm": "OauthBlueprintBSM"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tangle"
-version = "0.5.0-alpha.3"
+version = "0.5.0-alpha.4"
 description = "A command-line tool to create and deploy blueprints on Tangle Network"
 authors.workspace = true
 edition.workspace = true

--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-auth"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Blueprint HTTP/WS Authentication"
 authors.workspace = true
 edition.workspace = true

--- a/crates/benchmarking/Cargo.toml
+++ b/crates/benchmarking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-benchmarking"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Utilities for benchmarking Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/blueprint-faas/Cargo.toml
+++ b/crates/blueprint-faas/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-faas"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "FaaS provider integrations for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/blueprint-profiling/Cargo.toml
+++ b/crates/blueprint-profiling/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-profiling"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Profiling utilities for Tangle Blueprints"
 edition = "2021"
 authors.workspace = true

--- a/crates/blueprint-remote-providers/Cargo.toml
+++ b/crates/blueprint-remote-providers/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-remote-providers"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Remote service providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/build-utils/Cargo.toml
+++ b/crates/build-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-build-utils"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Tangle Blueprint build utils"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/Cargo.toml
+++ b/crates/chain-setup/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Chain setup utilities for use with Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/chain-setup/anvil/Cargo.toml
+++ b/crates/chain-setup/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-chain-setup-anvil"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Anvil-specific chain setup utilities"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/Cargo.toml
+++ b/crates/clients/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-clients"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Metapackage for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/core/Cargo.toml
+++ b/crates/clients/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-core"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Core primitives for Tangle Blueprint clients"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/eigenlayer/Cargo.toml
+++ b/crates/clients/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-eigenlayer"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Eigenlayer client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/evm/Cargo.toml
+++ b/crates/clients/evm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-evm"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "EVM client for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-client-tangle"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/crates/contexts/Cargo.toml
+++ b/crates/contexts/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-contexts"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Context providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Blueprint SDK Core functionality"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/Cargo.toml
+++ b/crates/crypto/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Crypto metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-bls"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "tnt-bls crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/bls/Cargo.toml
+++ b/crates/crypto/bls/Cargo.toml
@@ -35,7 +35,6 @@ std = [
 	"blueprint-crypto-core/std",
 	"blueprint-std/std",
 	"serde/std",
-	"serde_json/std",
 	"serde_bytes/std",
 	"tnt-bls/std",
 ]

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-bn254"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Ark BN254 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/core/Cargo.toml
+++ b/crates/crypto/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-core"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Core crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/ed25519/Cargo.toml
+++ b/crates/crypto/ed25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-ed25519"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Zebra ed25519 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/hashing/Cargo.toml
+++ b/crates/crypto/hashing/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-hashing"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Hashing and key derivation primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/k256/Cargo.toml
+++ b/crates/crypto/k256/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-k256"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "k256 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/crypto/sr25519/Cargo.toml
+++ b/crates/crypto/sr25519/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-crypto-sr25519"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Schnorrkel sr25519 crypto primitives for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/eigenlayer-extra/Cargo.toml
+++ b/crates/eigenlayer-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-extra"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Eigenlayer extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/evm-extra/Cargo.toml
+++ b/crates/evm-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-evm-extra"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "EVM extra utilities for Blueprint framework"
 authors.workspace = true
 edition.workspace = true

--- a/crates/keystore/Cargo.toml
+++ b/crates/keystore/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-keystore"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Keystore for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-macros"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Macros for the Tangle Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/macros/context-derive/Cargo.toml
+++ b/crates/macros/context-derive/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-context-derive"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Procedural macros for deriving Context Extension traits from blueprint-sdk"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager"
-version = "0.4.0-alpha.3"
+version = "0.4.0-alpha.4"
 description = "Tangle Blueprint manager and Runner"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/bridge/Cargo.toml
+++ b/crates/manager/bridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager-bridge"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Bridge for Blueprint manager to service communication"
 authors.workspace = true
 edition.workspace = true

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metrics"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Metrics metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/metrics/rpc-calls/Cargo.toml
+++ b/crates/metrics/rpc-calls/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-metrics-rpc-calls"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "RPC call metrics for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/Cargo.toml
+++ b/crates/networking/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Networking utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/agg-sig-gossip/Cargo.toml
+++ b/crates/networking/extensions/agg-sig-gossip/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking-agg-sig-gossip-extension"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Signature aggregation extension for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/gossip-primitives/Cargo.toml
+++ b/crates/networking/extensions/gossip-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-gossip-primitives"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Reusable gossip protocol primitives for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/networking/extensions/round-based/Cargo.toml
+++ b/crates/networking/extensions/round-based/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-networking-round-based-extension"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "round-based integration for Blueprint SDK networking"
 authors.workspace = true
 edition.workspace = true

--- a/crates/pricing-engine/Cargo.toml
+++ b/crates/pricing-engine/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-pricing-engine"
-version = "0.3.0-alpha.3"
+version = "0.3.0-alpha.4"
 authors.workspace = true
 edition.workspace = true
 license.workspace = true

--- a/crates/producers-extra/Cargo.toml
+++ b/crates/producers-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-producers-extra"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Additional job call producers for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/qos/Cargo.toml
+++ b/crates/qos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-qos"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Quality of Service (QoS) module for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/router/Cargo.toml
+++ b/crates/router/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-router"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Job routing utilities for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/runner/Cargo.toml
+++ b/crates/runner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-runner"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Runner for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-sdk"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Blueprint SDK for building decentralized and distributed services."
 authors.workspace = true
 edition.workspace = true

--- a/crates/std/Cargo.toml
+++ b/crates/std/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-std"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Re-exports of core/std for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/stores/Cargo.toml
+++ b/crates/stores/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-stores"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Storage providers for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/stores/local-database/Cargo.toml
+++ b/crates/stores/local-database/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-store-local-database"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "Local database storage provider for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/tangle-aggregation-svc/Cargo.toml
+++ b/crates/tangle-aggregation-svc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-aggregation-svc"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 edition = "2021"
 description = "BLS signature aggregation service for Tangle v2"
 license = "MIT OR Apache-2.0"

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tangle-extra"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Producer/Consumer extras for Tangle blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/tee/Cargo.toml
+++ b/crates/tee/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-tee"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "First-class TEE (Trusted Execution Environment) support for the Blueprint SDK"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/Cargo.toml
+++ b/crates/testing-utils/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Testing utilities metapackage for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/anvil/Cargo.toml
+++ b/crates/testing-utils/anvil/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-anvil-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Anvil testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/core/Cargo.toml
+++ b/crates/testing-utils/core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-core-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Core primitives for testing Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/testing-utils/eigenlayer/Cargo.toml
+++ b/crates/testing-utils/eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-eigenlayer-testing-utils"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "EigenLayer-specific testing utilities for Tangle Blueprints"
 authors.workspace = true
 edition.workspace = true

--- a/crates/webhooks/Cargo.toml
+++ b/crates/webhooks/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-webhooks"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "Webhook producer for Blueprint SDK — trigger jobs from external HTTP events"
 authors.workspace = true
 edition.workspace = true

--- a/crates/x402/Cargo.toml
+++ b/crates/x402/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-x402"
-version = "0.2.0-alpha.4"
+version = "0.2.0-alpha.5"
 description = "x402 payment gateway for Blueprint SDK — cross-chain EVM settlement for job execution"
 authors.workspace = true
 edition.workspace = true

--- a/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apikey-blueprint-bin"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition = "2024"
 
 [dependencies]

--- a/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "apikey-blueprint-lib"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition = "2024"
 
 [dependencies]

--- a/examples/hello-tangle/Cargo.toml
+++ b/examples/hello-tangle/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "hello-tangle-blueprint"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 publish = false

--- a/examples/incredible-squaring-eigenlayer/Cargo.toml
+++ b/examples/incredible-squaring-eigenlayer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-eigenlayer"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 description = "A Simple Blueprint to demo how blueprints work on Eigenlayer"
 authors.workspace = true
 edition.workspace = true

--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -11,15 +11,15 @@ rust-version = "1.88"
 [workspace.dependencies]
 incredible-squaring-blueprint-lib = { path = "incredible-squaring-lib" }
 
-blueprint-sdk = { version = "0.2.0-alpha.3", path = "../../crates/sdk", default-features = false }
-blueprint-anvil-testing-utils = { version = "0.2.0-alpha.3", path = "../../crates/testing-utils/anvil", default-features = false }
-blueprint-client-tangle = { version = "0.2.0-alpha.3", path = "../../crates/clients/tangle", default-features = false, features = ["std"] }
-blueprint-tangle-extra = { version = "0.2.0-alpha.3", path = "../../crates/tangle-extra", features = ["std"] }
-blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.3", path = "../../crates/tangle-aggregation-svc", default-features = false }
-blueprint-crypto-bn254 = { version = "0.2.0-alpha.3", path = "../../crates/crypto/bn254", default-features = false }
-blueprint-crypto-core = { version = "0.2.0-alpha.3", path = "../../crates/crypto/core", default-features = false }
-blueprint-faas = { version = "0.2.0-alpha.3", path = "../../crates/blueprint-faas", default-features = false }
-blueprint-profiling = { version = "0.2.0-alpha.3", path = "../../crates/blueprint-profiling", default-features = false }
+blueprint-sdk = { version = "0.2.0-alpha.4", path = "../../crates/sdk", default-features = false }
+blueprint-anvil-testing-utils = { version = "0.2.0-alpha.4", path = "../../crates/testing-utils/anvil", default-features = false }
+blueprint-client-tangle = { version = "0.2.0-alpha.4", path = "../../crates/clients/tangle", default-features = false, features = ["std"] }
+blueprint-tangle-extra = { version = "0.2.0-alpha.4", path = "../../crates/tangle-extra", features = ["std"] }
+blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.4", path = "../../crates/tangle-aggregation-svc", default-features = false }
+blueprint-crypto-bn254 = { version = "0.2.0-alpha.4", path = "../../crates/crypto/bn254", default-features = false }
+blueprint-crypto-core = { version = "0.2.0-alpha.4", path = "../../crates/crypto/core", default-features = false }
+blueprint-faas = { version = "0.2.0-alpha.4", path = "../../crates/blueprint-faas", default-features = false }
+blueprint-profiling = { version = "0.2.0-alpha.4", path = "../../crates/blueprint-profiling", default-features = false }
 tokio = { version = "^1", default-features = false }
 tower = { version = "0.5.2", default-features = false }
 tracing-subscriber = { version = "0.3", default-features = false }

--- a/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-bin"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-blueprint-bin"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition = "2024"
 
 [dependencies]

--- a/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oauth-blueprint-lib"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition = "2024"
 
 [dependencies]

--- a/examples/x402-blueprint/Cargo.toml
+++ b/examples/x402-blueprint/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "x402-blueprint"
-version = "0.2.0-alpha.3"
+version = "0.2.0-alpha.4"
 edition.workspace = true
 license.workspace = true
 publish = false


### PR DESCRIPTION
Cargo's strict manifest validation rejects `std = [..., "serde_json/std", ...]` when `serde_json` is only a dev-dependency.

Halts `cargo workspaces publish` mid-batch:
```
error: feature `std` includes `serde_json/std`, but `serde_json` is not a dependency
error: failed to parse manifest at `/home/drew/code/blueprint/crates/crypto/bls/Cargo.toml`
error: unable to publish package blueprint-crypto-bls
```

Removed the dangling reference — `serde_json` wasn't actually used in non-test paths anyway.