### PR TITLE
chore(examples): incredible-squaring metadata for crates.io publish

### DIFF
--- a/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-bin/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "apikey-blueprint-bin"
 version = "0.2.0-alpha.4"
+publish = false
 edition = "2024"
 
 [dependencies]

--- a/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
+++ b/examples/apikey-blueprint/apikey-blueprint-lib/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "apikey-blueprint-lib"
 version = "0.2.0-alpha.4"
+publish = false
 edition = "2024"
 
 [dependencies]

--- a/examples/incredible-squaring/Cargo.toml
+++ b/examples/incredible-squaring/Cargo.toml
@@ -4,6 +4,7 @@ members = ["incredible-squaring-lib", "incredible-squaring-bin"]
 
 [workspace.package]
 version = "0.1.1"
+publish = false
 description = "An experimental blueprint"
 edition = "2024"
 rust-version = "1.88"

--- a/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-bin/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "incredible-squaring-blueprint-bin"
 version = "0.2.0-alpha.4"
+publish = false
 edition.workspace = true
 rust-version.workspace = true
 

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,7 +1,12 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
 version = "0.2.0-alpha.4"
+description = "Reference example: an incredible-squaring blueprint built on the Tangle SDK"
+authors.workspace = true
 edition.workspace = true
+license.workspace = true
+homepage.workspace = true
+repository.workspace = true
 rust-version.workspace = true
 
 [dependencies]

--- a/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-bin/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "oauth-blueprint-bin"
 version = "0.2.0-alpha.4"
+publish = false
 edition = "2024"
 
 [dependencies]

--- a/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
+++ b/examples/oauth-blueprint/oauth-blueprint-lib/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "oauth-blueprint-lib"
 version = "0.2.0-alpha.4"
+publish = false
 edition = "2024"
 
 [dependencies]


### PR DESCRIPTION
Adds description + workspace-inheritance for license/repository/homepage. crates.io rejects publish without them.