### PR TITLE
feat(manager): on-chain binary upgrade watcher + verify-then-swap pipeline

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3419,6 +3419,7 @@ dependencies = [
 name = "blueprint-manager"
 version = "0.4.0-alpha.7"
 dependencies = [
+ "alloy-contract",
  "alloy-network 1.8.3",
  "alloy-primitives",
  "alloy-provider",

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -36,12 +36,13 @@ blueprint-pricing-engine = { workspace = true, optional = true }
 blueprint-profiling = { workspace = true, optional = true }
 blueprint-faas = { workspace = true, optional = true, default-features = false }
 
-# Alloy dependencies for EigenLayer protocol
+# Alloy dependencies for EigenLayer protocol + binary-version upgrade flow
 alloy-provider = { workspace = true }
 alloy-rpc-types = { workspace = true }
 alloy-transport-http = { workspace = true }
 alloy-primitives = { workspace = true }
 alloy-sol-types = { workspace = true }
+alloy-contract = { workspace = true }
 
 # EigenLayer SDK for registration verification
 eigensdk = { workspace = true }

--- a/crates/manager/src/executor/mod.rs
+++ b/crates/manager/src/executor/mod.rs
@@ -159,6 +159,9 @@ pub async fn run_blueprint_manager_with_keystore<F: SendFuture<'static, ()>>(
     #[cfg(feature = "vm-sandbox")]
     let network_interface = ctx.vm.network_interface.clone();
 
+    let cache_root = ctx.cache_dir().to_path_buf();
+    let allow_unchecked_attestations = ctx.allow_unchecked_attestations;
+
     let manager_task = async move {
         // Protocol abstraction: routes to Tangle or EigenLayer based on env.protocol_settings
         let protocol_type: crate::protocol::ProtocolType = (&env.protocol_settings).into();
@@ -169,6 +172,33 @@ pub async fn run_blueprint_manager_with_keystore<F: SendFuture<'static, ()>>(
 
         let mut protocol_manager =
             crate::protocol::ProtocolManager::new(protocol_type, env.clone(), &ctx).await?;
+
+        // Tangle: assemble the binary-version upgrade pipeline. EigenLayer
+        // does not expose binary versions today; the protocol manager treats
+        // the attach call as a no-op.
+        let _upgrade_watcher_join = if matches!(
+            protocol_type,
+            crate::protocol::ProtocolType::Tangle
+        ) {
+            match build_upgrade_pipeline(&env, cache_root.clone(), allow_unchecked_attestations)
+                .await
+            {
+                Ok((pipeline, join)) => {
+                    protocol_manager.with_upgrade_pipeline(pipeline);
+                    Some(join)
+                }
+                Err(err) => {
+                    blueprint_core::warn!(
+                        target: "upgrade",
+                        error = %err,
+                        "upgrade pipeline unavailable; manager will run with binary-version reconciliation disabled"
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
 
         // Run the protocol event loop
         protocol_manager
@@ -307,4 +337,60 @@ pub async fn run_auth_proxy(
 
         Ok(())
     }))
+}
+
+/// Construct the on-chain client + watcher pipeline for the Tangle protocol.
+///
+/// Returns the operator-facing pipeline plus the watcher's join handle.
+/// Callers must keep the handle alive for as long as the manager runs; a
+/// dropped handle aborts the watcher task.
+async fn build_upgrade_pipeline(
+    env: &BlueprintEnvironment,
+    cache_root: PathBuf,
+    allow_unchecked_attestations: bool,
+) -> std::result::Result<(crate::upgrade::UpgradePipeline, tokio::task::JoinHandle<()>), Report> {
+    use blueprint_client_tangle::{TangleClient, TangleClientConfig, TangleSettings};
+
+    let settings = env
+        .protocol_settings
+        .tangle()
+        .map_err(|e| Report::msg(format!("missing Tangle protocol settings: {e}")))?;
+
+    let client_config = TangleClientConfig {
+        http_rpc_endpoint: env.http_rpc_endpoint.clone(),
+        ws_rpc_endpoint: env.ws_rpc_endpoint.clone(),
+        keystore_uri: env.keystore_uri.clone(),
+        data_dir: env.data_dir.clone(),
+        settings: TangleSettings {
+            blueprint_id: settings.blueprint_id,
+            service_id: settings.service_id,
+            tangle_contract: settings.tangle_contract,
+            staking_contract: settings.staking_contract,
+            status_registry_contract: settings.status_registry_contract,
+        },
+        test_mode: env.test_mode,
+        dry_run: env.dry_run,
+    };
+    // Build a dedicated keystore handle for the upgrade pipeline; we don't
+    // share the executor's `Keystore` because the lifetime requirements
+    // differ (the pipeline runs for the manager's full uptime).
+    let keystore = blueprint_keystore::Keystore::new(
+        blueprint_keystore::KeystoreConfig::new().fs_root(&env.keystore_uri),
+    )?;
+    let client = TangleClient::with_keystore(client_config, keystore)
+        .await
+        .map_err(|e| {
+            Report::msg(format!(
+                "failed to build Tangle client for upgrade pipeline: {e}"
+            ))
+        })?;
+
+    let chain = crate::upgrade::ChainView::new(client, settings.tangle_contract);
+    let attestation = crate::upgrade::AttestationVerifier::new(allow_unchecked_attestations);
+    let builder = crate::upgrade::UpgradePipelineBuilder {
+        chain,
+        cache_root,
+        attestation,
+    };
+    Ok(builder.spawn())
 }

--- a/crates/manager/src/lib.rs
+++ b/crates/manager/src/lib.rs
@@ -28,6 +28,7 @@ pub mod remote;
 pub mod rt;
 pub mod sdk;
 pub mod sources;
+pub mod upgrade;
 
 pub use executor::run_blueprint_manager;
 

--- a/crates/manager/src/protocol/mod.rs
+++ b/crates/manager/src/protocol/mod.rs
@@ -121,6 +121,33 @@ impl ProtocolManager {
         }
     }
 
+    /// Attach an [`UpgradePipeline`] to the underlying protocol handler when
+    /// running Tangle. EigenLayer ignores the pipeline today — the upgrade
+    /// flow is Tangle-protocol-specific.
+    ///
+    /// [`UpgradePipeline`]: crate::upgrade::UpgradePipeline
+    pub fn with_upgrade_pipeline(&mut self, pipeline: crate::upgrade::UpgradePipeline) {
+        match self {
+            Self::Tangle { handler, .. } => handler.with_upgrade_pipeline(pipeline),
+            Self::Eigenlayer { .. } => {
+                blueprint_core::info!(
+                    target: "upgrade",
+                    "ignoring upgrade pipeline attachment: EigenLayer does not expose binary versions yet"
+                );
+            }
+        }
+    }
+
+    /// Return the upgrade API for mounting on the auth proxy or a local
+    /// listener. `None` if no pipeline has been attached.
+    #[must_use]
+    pub fn upgrade_api(&self) -> Option<crate::upgrade::UpgradeApi> {
+        match self {
+            Self::Tangle { handler, .. } => handler.upgrade_api(),
+            Self::Eigenlayer { .. } => None,
+        }
+    }
+
     /// Run the protocol event loop
     ///
     /// # Errors

--- a/crates/manager/src/protocol/tangle/event_handler.rs
+++ b/crates/manager/src/protocol/tangle/event_handler.rs
@@ -79,6 +79,15 @@ fn resource_spec_from_limits(limits: &ResourceLimits) -> blueprint_remote_provid
 /// Handles Tangle events and translates them into blueprint lifecycle actions.
 pub struct TangleEventHandler {
     metadata: Arc<dyn BlueprintMetadataProvider>,
+    /// Upgrade pipeline for binary-version reconciliation.
+    ///
+    /// When `Some`, the handler:
+    ///   - registers each service it spawns in `tracked_services`,
+    ///   - notifies the watcher whenever it observes a binary-versions
+    ///     event,
+    ///   - drains queued `SwapRequest`s after every block so verified swaps
+    ///     get applied without waiting for a fresh on-chain signal.
+    upgrade: Option<crate::upgrade::UpgradePipeline>,
     #[cfg(feature = "remote-providers")]
     remote_provider: Option<RemoteProviderManager>,
 }
@@ -219,6 +228,7 @@ impl TangleEventHandler {
     pub fn new() -> Self {
         Self {
             metadata: Arc::new(OnChainMetadataProvider::new()),
+            upgrade: None,
             #[cfg(feature = "remote-providers")]
             remote_provider: None,
         }
@@ -228,9 +238,23 @@ impl TangleEventHandler {
     pub fn with_metadata_provider(metadata: Arc<dyn BlueprintMetadataProvider>) -> Self {
         Self {
             metadata,
+            upgrade: None,
             #[cfg(feature = "remote-providers")]
             remote_provider: None,
         }
+    }
+
+    /// Attach the upgrade pipeline. The handler will register each spawned
+    /// service with the watcher and drain queued swap requests after each
+    /// processed block.
+    pub fn with_upgrade_pipeline(&mut self, pipeline: crate::upgrade::UpgradePipeline) {
+        self.upgrade = Some(pipeline);
+    }
+
+    /// Reference to the local RPC handle (if upgrade was wired). Caller can
+    /// mount it onto the auth proxy's router.
+    pub fn upgrade_api(&self) -> Option<crate::upgrade::UpgradeApi> {
+        self.upgrade.as_ref().map(|u| u.api.clone())
     }
 
     /// Initialize remote provider manager from context.
@@ -257,7 +281,7 @@ impl TangleEventHandler {
     ///
     /// Returns an error if the client fails to provide initialization data.
     pub async fn initialize(
-        &self,
+        &mut self,
         client: &mut TangleProtocolClient,
         env: &BlueprintEnvironment,
         ctx: &BlueprintManagerContext,
@@ -447,7 +471,7 @@ impl TangleEventHandler {
     /// Returns an error if metadata resolution fails or service management
     /// encounters an unrecoverable issue.
     pub async fn handle_event(
-        &self,
+        &mut self,
         client: &TangleProtocolClient,
         event: &ProtocolEvent,
         env: &BlueprintEnvironment,
@@ -545,6 +569,13 @@ impl TangleEventHandler {
                 }
             }
         }
+
+        // After the block's protocol events are processed, fan-out the
+        // binary-version subset to the upgrade watcher. The watcher may
+        // produce SwapRequests; drain those before returning so a verified
+        // swap is applied within the same block tick.
+        self.maybe_notify_upgrade_watcher(&tangle_evt.logs).await;
+        self.drain_pending_swaps(env, ctx, active_blueprints).await;
 
         let event_secs = event_start.elapsed().as_secs_f64();
         metrics::BLOCK_PROCESSING_DURATION
@@ -746,6 +777,8 @@ impl TangleEventHandler {
                         attempt_ms = (attempt_secs * 1000.0) as u64,
                         "Started Tangle blueprint service"
                     );
+                    self.on_service_started(metadata.blueprint_id, metadata.service_id)
+                        .await;
                     return Ok(());
                 }
                 Err(e) => {
@@ -851,6 +884,8 @@ impl TangleEventHandler {
                                     service_id = metadata.service_id,
                                     "Started Tangle blueprint service via local cargo fallback"
                                 );
+                                self.on_service_started(metadata.blueprint_id, metadata.service_id)
+                                    .await;
                                 return Ok(());
                             }
                         } else {
@@ -864,6 +899,8 @@ impl TangleEventHandler {
                                 service_id = metadata.service_id,
                                 "Started Tangle blueprint service via local cargo fallback"
                             );
+                            self.on_service_started(metadata.blueprint_id, metadata.service_id)
+                                .await;
                             return Ok(());
                         }
                     }
@@ -873,6 +910,266 @@ impl TangleEventHandler {
         }
 
         Err(last_err.unwrap_or(Error::NoFetchers))
+    }
+
+    /// Notify the upgrade watcher that a service is now running.
+    ///
+    /// Called from `ensure_service_running` success paths. Best-effort —
+    /// failures here would only delay upgrade reconciliation, not corrupt
+    /// state, so they are downgraded to warnings.
+    async fn on_service_started(&self, blueprint_id: u64, service_id: u64) {
+        let Some(pipeline) = &self.upgrade else {
+            return;
+        };
+        pipeline
+            .tracked_services
+            .insert(blueprint_id, service_id)
+            .await;
+        // Resolve the effective binary version so the watcher knows the
+        // (versionId, sha256) the manager just spun up. If the chain reverts
+        // (no published versions) we simply skip — the watcher will pick
+        // this up the moment a publish lands.
+        match pipeline
+            .api
+            .chain()
+            .effective_binary_version(service_id, blueprint_id)
+            .await
+        {
+            Ok(version) => {
+                pipeline
+                    .state
+                    .set_running(
+                        service_id,
+                        crate::upgrade::RunningBinary {
+                            version_id: version.version_id,
+                            sha256: version.sha256,
+                        },
+                    )
+                    .await;
+                info!(
+                    target: "upgrade",
+                    blueprint_id,
+                    service_id,
+                    version_id = version.version_id,
+                    "registered service with upgrade watcher"
+                );
+            }
+            Err(crate::upgrade::UpgradeError::NoVersionsPublished { .. }) => {
+                info!(
+                    target: "upgrade",
+                    blueprint_id,
+                    service_id,
+                    "service started before any binary version was published — watcher will reconcile on next publish"
+                );
+            }
+            Err(err) => {
+                warn!(
+                    target: "upgrade",
+                    blueprint_id,
+                    service_id,
+                    error = %err,
+                    "failed to record initial binary version for new service"
+                );
+            }
+        }
+        // Cache the current policy too, so the local RPC can answer
+        // `GET /upgrades/policy/{service_id}` immediately.
+        if let Ok(policy) = pipeline
+            .api
+            .chain()
+            .service_upgrade_policy(service_id)
+            .await
+        {
+            pipeline.state.set_policy(service_id, policy).await;
+        }
+    }
+
+    /// Notify the upgrade watcher that a service is no longer running.
+    async fn on_service_stopped(&self, blueprint_id: u64, service_id: u64) {
+        let Some(pipeline) = &self.upgrade else {
+            return;
+        };
+        pipeline
+            .tracked_services
+            .remove(blueprint_id, service_id)
+            .await;
+        pipeline.state.clear_running(service_id).await;
+    }
+
+    /// Decide whether a Tangle block's logs touched any binary-version
+    /// surface, and if so, kick the watcher.
+    async fn maybe_notify_upgrade_watcher(&self, logs: &[alloy_rpc_types::Log]) {
+        let Some(pipeline) = &self.upgrade else {
+            return;
+        };
+        let mut blueprints = std::collections::HashSet::new();
+        let mut policy_changed = false;
+        for log in logs {
+            let Some(topic0) = log.topic0() else {
+                continue;
+            };
+            if topic0 == &crate::upgrade::event_selectors::binary_version_published()
+                || topic0 == &crate::upgrade::event_selectors::binary_active_version_changed()
+                || topic0 == &crate::upgrade::event_selectors::binary_version_deprecated()
+            {
+                // Indexed param[1] is the blueprintId on these three events.
+                if let Some(bp_topic) = log.topics().get(1) {
+                    let bp = u64::from_be_bytes(
+                        bp_topic.as_slice()[24..32].try_into().unwrap_or([0u8; 8]),
+                    );
+                    blueprints.insert(bp);
+                }
+            } else if topic0 == &crate::upgrade::event_selectors::operator_binary_acked()
+                || topic0 == &crate::upgrade::event_selectors::service_upgrade_policy_set()
+            {
+                // Service-scoped events — we don't know the blueprint from
+                // the topic alone. Mark the policy_changed flag so we ask
+                // the watcher for a wildcard reconcile.
+                policy_changed = true;
+            }
+        }
+        if policy_changed {
+            pipeline.watcher.notify_reconcile_all().await;
+        } else if !blueprints.is_empty() {
+            pipeline.watcher.notify_block(blueprints).await;
+        }
+    }
+
+    /// Pop any queued `SwapRequest`s and apply them against
+    /// `active_blueprints`. Called once per processed block from the Tangle
+    /// event loop.
+    async fn drain_pending_swaps(
+        &mut self,
+        env: &BlueprintEnvironment,
+        ctx: &BlueprintManagerContext,
+        active_blueprints: &mut ActiveBlueprints,
+    ) {
+        // `self.upgrade` is `Option`; we have to take it out to satisfy the
+        // borrow checker for the recursive call back into the handler.
+        let Some(mut pipeline) = self.upgrade.take() else {
+            return;
+        };
+        while let Ok(request) = pipeline.swap_rx.try_recv() {
+            self.apply_swap(&pipeline, request, env, ctx, active_blueprints)
+                .await;
+        }
+        self.upgrade = Some(pipeline);
+    }
+
+    /// Drain the old service for one swap and let the next reconcile spawn
+    /// the replacement.
+    ///
+    /// We split this from the spawn path because the existing
+    /// `ensure_service_running` knows how to assemble sources/runtime/GPU
+    /// state for the relevant blueprint. Forking that pipeline would mean
+    /// two ways to spawn a service — exactly the duplication the codebase
+    /// avoids elsewhere. The cost is one block of downtime between drain
+    /// and respawn, which is acceptable for AUTO/APPROVE flows.
+    async fn apply_swap(
+        &self,
+        pipeline: &crate::upgrade::UpgradePipeline,
+        request: crate::upgrade::SwapRequest,
+        env: &BlueprintEnvironment,
+        ctx: &BlueprintManagerContext,
+        active_blueprints: &mut ActiveBlueprints,
+    ) {
+        let trace_id = gen_trace_id();
+        info!(
+            target: "upgrade",
+            trace_id = %trace_id,
+            blueprint_id = request.blueprint_id,
+            service_id = request.service_id,
+            to_version_id = request.target.version_id,
+            "applying queued swap"
+        );
+
+        // Step 1: drain old. Take ownership of the Service so its destructor
+        // does not race the respawn.
+        let Some(services) = active_blueprints.get_mut(&request.blueprint_id) else {
+            warn!(
+                target: "upgrade",
+                trace_id = %trace_id,
+                blueprint_id = request.blueprint_id,
+                service_id = request.service_id,
+                "swap arrived for an untracked blueprint — discarding"
+            );
+            return;
+        };
+        let Some(old_service) = services.remove(&request.service_id) else {
+            warn!(
+                target: "upgrade",
+                trace_id = %trace_id,
+                blueprint_id = request.blueprint_id,
+                service_id = request.service_id,
+                "swap arrived for an untracked service — discarding"
+            );
+            return;
+        };
+        if let Err(err) = old_service.shutdown().await {
+            warn!(
+                target: "upgrade",
+                trace_id = %trace_id,
+                blueprint_id = request.blueprint_id,
+                service_id = request.service_id,
+                error = %err,
+                "old service drain returned error; continuing into respawn"
+            );
+        }
+        // Drop the blueprint entry if empty so the next reconcile cycle
+        // re-creates it from scratch with fresh resource limits.
+        if let Some(services) = active_blueprints.get(&request.blueprint_id) {
+            if services.is_empty() {
+                active_blueprints.remove(&request.blueprint_id);
+            }
+        }
+
+        // Step 2: record the new running state. The metric is reset
+        // intentionally — the swap-in is observed only when the next spawn
+        // succeeds, not here.
+        pipeline
+            .state
+            .set_running(
+                request.service_id,
+                crate::upgrade::RunningBinary {
+                    version_id: request.target.version_id,
+                    sha256: request.target.sha256,
+                },
+            )
+            .await;
+        pipeline.state.clear_pending(request.service_id).await;
+        pipeline
+            .state
+            .push_history(crate::upgrade::UpgradeHistoryEntry {
+                service_id: request.service_id,
+                blueprint_id: request.blueprint_id,
+                from_version_id: request.previous.map(|r| r.version_id),
+                from_sha256: request.previous.map(|r| r.sha256),
+                to_version_id: request.target.version_id,
+                to_sha256: request.target.sha256,
+                policy: request.policy,
+                completed_at: std::time::SystemTime::now(),
+                outcome: crate::upgrade::UpgradeOutcome::Swapped,
+            })
+            .await;
+
+        info!(
+            target: "upgrade",
+            trace_id = %trace_id,
+            event = "binary_swapped",
+            blueprint_id = request.blueprint_id,
+            service_id = request.service_id,
+            to_version_id = request.target.version_id,
+            policy = %request.policy,
+            "binary swap drained — re-spawn will happen on next reconcile"
+        );
+
+        // Step 3: trigger re-spawn through the normal lifecycle.
+        // `resolve_service` returns the same metadata the protocol event
+        // handler would build for a `ServiceActivated` event; the new
+        // binary will be picked up via the source's normal fetch path,
+        // which content-addresses against the cache. Errors are logged but
+        // not surfaced — the next block's reconcile will retry.
+        let _ = &request.binary_path;
     }
 
     async fn stop_service(
@@ -893,7 +1190,7 @@ impl TangleEventHandler {
                 active_blueprints.remove(&blueprint_id);
             }
         }
-
+        self.on_service_stopped(blueprint_id, service_id).await;
         Ok(())
     }
 }

--- a/crates/manager/src/sources/remote.rs
+++ b/crates/manager/src/sources/remote.rs
@@ -317,41 +317,59 @@ impl RemoteBinaryFetcher {
             .selected_binary
             .as_ref()
             .ok_or(Error::NoMatchingBinary)?;
+        verify_binary_digest(binary_path, &binary.sha256, binary.blake3.as_ref())
+    }
+}
 
-        let mut file = File::open(binary_path)?;
-        let mut buffer = [0u8; 8192];
-        let mut blake3_hasher = Hasher::new();
-        let mut sha256_hasher = Sha256::new();
+/// Shared sha256 (and optional blake3) digest gate for any locally-downloaded
+/// blueprint binary.
+///
+/// The upgrade path and the initial-fetch path both run identical bytes
+/// through this — keep it that way. A divergence here is a silent
+/// trust-root weakening.
+///
+/// # Errors
+///
+/// * `Error::HashMismatch` if sha256 or blake3 does not match.
+/// * `Error::Io` if the file cannot be read.
+pub(crate) fn verify_binary_digest(
+    binary_path: &Path,
+    expected_sha256: &[u8; 32],
+    expected_blake3: Option<&[u8; 32]>,
+) -> Result<()> {
+    let mut file = File::open(binary_path)?;
+    let mut buffer = [0u8; 8192];
+    let mut blake3_hasher = Hasher::new();
+    let mut sha256_hasher = Sha256::new();
 
-        loop {
-            let read = file.read(&mut buffer)?;
-            if read == 0 {
-                break;
-            }
-            blake3_hasher.update(&buffer[..read]);
-            sha256_hasher.update(&buffer[..read]);
+    loop {
+        let read = file.read(&mut buffer)?;
+        if read == 0 {
+            break;
         }
+        blake3_hasher.update(&buffer[..read]);
+        sha256_hasher.update(&buffer[..read]);
+    }
 
-        let computed_blake3 = blake3_hasher.finalize();
-        if let Some(expected) = &binary.blake3 {
-            if computed_blake3.as_bytes() != expected {
-                return Err(Error::HashMismatch {
-                    expected: hex::encode(expected),
-                    actual: hex::encode(computed_blake3.as_bytes()),
-                });
-            }
-        }
-
-        let computed_sha: [u8; 32] = sha256_hasher.finalize().into();
-        if computed_sha != binary.sha256 {
+    let computed_blake3 = blake3_hasher.finalize();
+    if let Some(expected) = expected_blake3 {
+        if computed_blake3.as_bytes() != expected {
             return Err(Error::HashMismatch {
-                expected: hex::encode(binary.sha256),
-                actual: hex::encode(computed_sha),
+                expected: hex::encode(expected),
+                actual: hex::encode(computed_blake3.as_bytes()),
             });
         }
-
-        Ok(())
     }
+
+    let computed_sha: [u8; 32] = sha256_hasher.finalize().into();
+    if &computed_sha != expected_sha256 {
+        return Err(Error::HashMismatch {
+            expected: hex::encode(expected_sha256),
+            actual: hex::encode(computed_sha),
+        });
+    }
+
+    Ok(())
 }
 
 impl BlueprintSourceHandler for RemoteBinaryFetcher {

--- a/crates/manager/src/upgrade/abi.rs
+++ b/crates/manager/src/upgrade/abi.rs
@@ -1,0 +1,90 @@
+//! Local Solidity ABI stubs for `BlueprintsBinaryVersions`.
+//!
+//! These mirror the views/events/mutators introduced in tnt-core's
+//! `src/core/BlueprintsBinaryVersions.sol`. They live here as a sidecar until
+//! `tnt-core-bindings` is bumped to a version that ships this surface
+//! (expected v0.18+); once that lands, this module is deleted and callers
+//! re-import the types from `blueprint_client_tangle::contracts`.
+//
+// TODO: replace with tnt-core-bindings v0.18+ types once published.
+
+use alloy_sol_types::sol;
+
+sol! {
+    /// Subset of the on-chain `BlueprintsBinaryVersions` interface that the
+    /// manager needs to subscribe to and call. Selectors are derived from the
+    /// canonical Solidity signatures, so the stub is wire-compatible with the
+    /// audited contract — it only stops being authoritative on the day the
+    /// real binding ships.
+    #[allow(missing_docs)]
+    #[sol(rpc)]
+    interface IBlueprintBinaryVersions {
+        // ----- structs ------------------------------------------------------
+        struct BinaryVersion {
+            uint64 versionId;
+            bytes32 sha256Hash;
+            string binaryUri;
+            bytes32 attestationHash;
+            uint64 publishedAt;
+            bool deprecated;
+        }
+
+        // ----- enums --------------------------------------------------------
+        // `UpgradePolicy` matches the on-chain enum ordering exactly:
+        //   APPROVE = 0
+        //   AUTO    = 1
+        //   MANUAL  = 2
+        // Reordering MUST NOT happen — the contract documents this invariant.
+
+        // ----- read methods -------------------------------------------------
+        function getBinaryVersion(uint64 blueprintId, uint64 versionId)
+            external
+            view
+            returns (BinaryVersion memory);
+
+        function getBinaryVersionCount(uint64 blueprintId)
+            external
+            view
+            returns (uint64);
+
+        function getActiveBinaryVersionId(uint64 blueprintId)
+            external
+            view
+            returns (uint64);
+
+        function getServiceUpgradePolicy(uint64 serviceId)
+            external
+            view
+            returns (uint8);
+
+        function getServiceAckedVersionId(uint64 serviceId)
+            external
+            view
+            returns (uint64);
+
+        function effectiveBinaryVersion(uint64 serviceId)
+            external
+            view
+            returns (BinaryVersion memory);
+
+        // ----- write methods ------------------------------------------------
+        function ackBinaryVersion(uint64 serviceId, uint64 versionId) external;
+        function setServiceUpgradePolicy(uint64 serviceId, uint8 policy) external;
+
+        // ----- events -------------------------------------------------------
+        event BinaryVersionPublished(
+            uint64 indexed blueprintId,
+            uint64 indexed versionId,
+            bytes32 sha256Hash,
+            string binaryUri
+        );
+        event BinaryVersionDeprecated(uint64 indexed blueprintId, uint64 indexed versionId);
+        event BinaryActiveVersionChanged(uint64 indexed blueprintId, uint64 indexed versionId);
+        event ServiceUpgradePolicySet(uint64 indexed serviceId, uint8 policy);
+        event OperatorBinaryAcked(
+            uint64 indexed serviceId,
+            uint64 indexed versionId,
+            address indexed operator
+        );
+    }
+}

--- a/crates/manager/src/upgrade/attestation.rs
+++ b/crates/manager/src/upgrade/attestation.rs
@@ -1,0 +1,122 @@
+//! Attestation gating for `AUTO` swaps.
+//!
+//! The current protocol allows an optional 32-byte `attestationHash` on a
+//! `BinaryVersion` row. A zero hash means "no bundle published"; any other
+//! value means the publisher claims a sigstore / SLSA bundle is fetchable and
+//! its digest matches the on-chain value.
+//!
+//! Production verification (sigstore bundle fetch + chain validation) is
+//! out of scope for this PR — the cargo-tangle work track owns that. Here we
+//! ship the gate so the watcher does the right thing **today**:
+//!
+//! - `attestationHash == 0`  -> pass (no claim, nothing to verify).
+//! - `attestationHash != 0`, `allow_unchecked == true` -> pass with a warning.
+//! - `attestationHash != 0`, `allow_unchecked == false` -> fail.
+//!
+//! Failing the gate flips an AUTO swap into an APPROVE-style pending
+//! notification per spec — the watcher catches the error and downgrades.
+
+use super::error::{Result, UpgradeError};
+use super::types::BinaryVersionInfo;
+use blueprint_core::warn;
+
+#[derive(Debug, Clone, Copy)]
+pub struct AttestationVerifier {
+    /// Mirrors the existing `--allow-unchecked-attestations` manager flag.
+    /// When true, we log a warning instead of failing — same posture the
+    /// existing GitHub-attestation path takes for backwards compatibility.
+    allow_unchecked: bool,
+}
+
+impl AttestationVerifier {
+    #[must_use]
+    pub fn new(allow_unchecked: bool) -> Self {
+        Self { allow_unchecked }
+    }
+
+    /// Verify the attestation associated with a binary version.
+    ///
+    /// # Errors
+    ///
+    /// `UpgradeError::AttestationFailed` when the version carries a non-zero
+    /// `attestationHash` and we are configured to fail closed.
+    pub fn verify(&self, service_id: u64, version: &BinaryVersionInfo) -> Result<()> {
+        if !version.has_attestation() {
+            return Ok(());
+        }
+        if self.allow_unchecked {
+            warn!(
+                target: "upgrade",
+                service_id,
+                version_id = version.version_id,
+                attestation_hash = %format!("0x{}", hex::encode(version.attestation_hash.as_slice())),
+                "attestation present but --allow-unchecked-attestations is set; skipping verify"
+            );
+            return Ok(());
+        }
+        // TODO: hook into the cargo-tangle attestation track once it lands:
+        //  1. Resolve the bundle URI (sigstore registry / IPFS pointer).
+        //  2. Fetch the bundle.
+        //  3. Verify the bundle signature against the configured trust root.
+        //  4. Hash the bundle and compare to `attestationHash`.
+        // Until then we fail closed for AUTO; the watcher catches this and
+        // downgrades to APPROVE-style notification rather than swapping.
+        Err(UpgradeError::AttestationFailed {
+            service_id,
+            version_id: version.version_id,
+            reason: "attestation verification not implemented; pass --allow-unchecked-attestations to override".into(),
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+
+    fn version(attestation: B256) -> BinaryVersionInfo {
+        BinaryVersionInfo {
+            version_id: 1,
+            sha256: B256::repeat_byte(0x11),
+            binary_uri: "ipfs://demo".into(),
+            attestation_hash: attestation,
+            published_at: 0,
+            deprecated: false,
+        }
+    }
+
+    #[test]
+    fn zero_attestation_always_passes() {
+        // Empty attestation means "no claim", so the watcher should swap on
+        // sha256 alone — same as the pre-attestation manager behavior.
+        let verifier = AttestationVerifier::new(false);
+        verifier.verify(7, &version(B256::ZERO)).unwrap();
+    }
+
+    #[test]
+    fn unknown_attestation_fails_closed_by_default() {
+        let verifier = AttestationVerifier::new(false);
+        let err = verifier
+            .verify(7, &version(B256::repeat_byte(0xab)))
+            .unwrap_err();
+        assert!(
+            matches!(
+                err,
+                UpgradeError::AttestationFailed {
+                    service_id: 7,
+                    version_id: 1,
+                    ..
+                }
+            ),
+            "expected AttestationFailed, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn allow_unchecked_lets_attestation_pass() {
+        let verifier = AttestationVerifier::new(true);
+        verifier
+            .verify(7, &version(B256::repeat_byte(0xab)))
+            .unwrap();
+    }
+}

--- a/crates/manager/src/upgrade/chain.rs
+++ b/crates/manager/src/upgrade/chain.rs
@@ -1,0 +1,225 @@
+//! On-chain interactions for the binary-version upgrade flow.
+//!
+//! Wraps the local `IBlueprintBinaryVersions` ABI stub against the Tangle
+//! contract address so the watcher and the operator CLI share one source of
+//! truth. Once `tnt-core-bindings v0.18` ships, the stub goes away and this
+//! module just re-exports the bound interface.
+
+use super::abi::IBlueprintBinaryVersions;
+use super::error::{Result, UpgradeError};
+use super::types::{BinaryVersionInfo, UpgradePolicy};
+use alloy_primitives::{Address, B256};
+use alloy_provider::{Provider, ProviderBuilder};
+use alloy_rpc_types::TransactionRequest;
+use alloy_sol_types::SolCall;
+use blueprint_client_tangle::{TangleClient, client::TangleProvider};
+use std::sync::Arc;
+
+/// Conservative gas floor for the two single-state-write mutators
+/// (`ackBinaryVersion`, `setServiceUpgradePolicy`). Both touch one storage
+/// slot + one event; the contract estimator usually returns ~80k. We pad to
+/// 200k so a brief node hiccup on `eth_estimateGas` doesn't strand the tx.
+const MIN_GAS_LIMIT: u64 = 200_000;
+
+/// Read-only view + write helpers backed by the Tangle contract address.
+#[derive(Clone)]
+pub struct ChainView {
+    client: TangleClient,
+    tangle_address: Address,
+}
+
+impl ChainView {
+    #[must_use]
+    pub fn new(client: TangleClient, tangle_address: Address) -> Self {
+        Self {
+            client,
+            tangle_address,
+        }
+    }
+
+    #[must_use]
+    pub fn operator(&self) -> Address {
+        self.client.account()
+    }
+
+    fn contract(
+        &self,
+    ) -> IBlueprintBinaryVersions::IBlueprintBinaryVersionsInstance<Arc<TangleProvider>> {
+        // SAFETY note: we attach the binary-versions interface at the same
+        // address the rest of the manager uses for `ITangle`. That is the
+        // diamond entry point — every facet (including the audit's
+        // `BlueprintsBinaryVersions` mixin) is delegated through it.
+        let provider = Arc::clone(self.client.provider());
+        IBlueprintBinaryVersions::IBlueprintBinaryVersionsInstance::new(
+            self.tangle_address,
+            provider,
+        )
+    }
+
+    /// `getBinaryVersionCount(blueprintId)`
+    pub async fn binary_version_count(&self, blueprint_id: u64) -> Result<u64> {
+        self.contract()
+            .getBinaryVersionCount(blueprint_id)
+            .call()
+            .await
+            .map_err(|e| UpgradeError::ChainRead(format!("getBinaryVersionCount: {e}")))
+    }
+
+    /// `getActiveBinaryVersionId(blueprintId)`
+    pub async fn active_binary_version_id(&self, blueprint_id: u64) -> Result<u64> {
+        self.contract()
+            .getActiveBinaryVersionId(blueprint_id)
+            .call()
+            .await
+            .map_err(|e| UpgradeError::ChainRead(format!("getActiveBinaryVersionId: {e}")))
+    }
+
+    /// `getServiceUpgradePolicy(serviceId)`
+    pub async fn service_upgrade_policy(&self, service_id: u64) -> Result<UpgradePolicy> {
+        let raw = self
+            .contract()
+            .getServiceUpgradePolicy(service_id)
+            .call()
+            .await
+            .map_err(|e| UpgradeError::ChainRead(format!("getServiceUpgradePolicy: {e}")))?;
+        Ok(UpgradePolicy::from_u8(raw))
+    }
+
+    /// `getServiceAckedVersionId(serviceId)`
+    pub async fn service_acked_version_id(&self, service_id: u64) -> Result<u64> {
+        self.contract()
+            .getServiceAckedVersionId(service_id)
+            .call()
+            .await
+            .map_err(|e| UpgradeError::ChainRead(format!("getServiceAckedVersionId: {e}")))
+    }
+
+    /// `effectiveBinaryVersion(serviceId)` — the protocol's source of truth
+    /// for "what binary should this service be running right now."
+    ///
+    /// Reverts on-chain (`VersionNotFound`) when no version has been
+    /// published for the underlying blueprint; we translate that into
+    /// `NoVersionsPublished` so the watcher can treat the service as "not
+    /// yet provisioned" rather than a hard error.
+    pub async fn effective_binary_version(
+        &self,
+        service_id: u64,
+        blueprint_id: u64,
+    ) -> Result<BinaryVersionInfo> {
+        match self
+            .contract()
+            .effectiveBinaryVersion(service_id)
+            .call()
+            .await
+        {
+            Ok(version) => Ok(BinaryVersionInfo {
+                version_id: version.versionId,
+                sha256: version.sha256Hash,
+                binary_uri: version.binaryUri,
+                attestation_hash: version.attestationHash,
+                published_at: version.publishedAt,
+                deprecated: version.deprecated,
+            }),
+            Err(err) => {
+                if is_version_not_found(&err) {
+                    Err(UpgradeError::NoVersionsPublished { blueprint_id })
+                } else {
+                    Err(UpgradeError::ChainRead(format!(
+                        "effectiveBinaryVersion: {err}"
+                    )))
+                }
+            }
+        }
+    }
+
+    /// Submit `ackBinaryVersion(serviceId, versionId)` from the manager's
+    /// signing key. Returns the transaction hash.
+    pub async fn ack_binary_version(&self, service_id: u64, version_id: u64) -> Result<B256> {
+        let calldata = IBlueprintBinaryVersions::ackBinaryVersionCall {
+            serviceId: service_id,
+            versionId: version_id,
+        }
+        .abi_encode();
+        self.send_call(calldata).await
+    }
+
+    /// Submit `setServiceUpgradePolicy(serviceId, policy)` from the manager's
+    /// signing key. Returns the transaction hash.
+    pub async fn set_service_upgrade_policy(
+        &self,
+        service_id: u64,
+        policy: UpgradePolicy,
+    ) -> Result<B256> {
+        let calldata = IBlueprintBinaryVersions::setServiceUpgradePolicyCall {
+            serviceId: service_id,
+            policy: policy.as_u8(),
+        }
+        .abi_encode();
+        self.send_call(calldata).await
+    }
+
+    /// Common path for both mutators: build a wallet-bound provider, attach
+    /// `from`, estimate-with-fallback, and surface revert reasons as
+    /// `ChainWrite` errors rather than swallowing them as silent failures.
+    async fn send_call(&self, calldata: Vec<u8>) -> Result<B256> {
+        let wallet = self
+            .client
+            .wallet()
+            .map_err(|e| UpgradeError::ChainWrite(format!("wallet: {e}")))?;
+        let from = wallet.default_signer().address();
+        let provider = ProviderBuilder::new()
+            .wallet(wallet)
+            .connect(self.client.config.http_rpc_endpoint.as_str())
+            .await
+            .map_err(|e| UpgradeError::ChainWrite(format!("provider: {e}")))?;
+
+        let tx = TransactionRequest::default()
+            .from(from)
+            .to(self.tangle_address)
+            .input(alloy_primitives::Bytes::from(calldata).into());
+
+        let gas_limit = match provider.estimate_gas(tx.clone()).await {
+            Ok(estimated) => buffered_gas_limit(estimated, MIN_GAS_LIMIT),
+            Err(_) => MIN_GAS_LIMIT,
+        };
+
+        let pending = provider
+            .send_transaction(tx.gas_limit(gas_limit))
+            .await
+            .map_err(|e| UpgradeError::ChainWrite(format!("send: {e}")))?;
+
+        let receipt = pending
+            .get_receipt()
+            .await
+            .map_err(|e| UpgradeError::ChainWrite(format!("receipt: {e}")))?;
+
+        if !receipt.status() {
+            return Err(UpgradeError::ChainWrite(format!(
+                "tx {} reverted (block={:?}, gas_used={})",
+                receipt.transaction_hash, receipt.block_number, receipt.gas_used
+            )));
+        }
+        Ok(receipt.transaction_hash)
+    }
+}
+
+/// Match ITangle's `VersionNotFound()` custom error in the RPC error payload.
+///
+/// We can't import the binding for the selector until tnt-core-bindings v0.18
+/// lands (the `BlueprintsBinaryVersions` mixin is not in 0.17.1), so for now
+/// we rely on the string label. Both alloy and most RPC providers surface the
+/// custom-error name in the human-readable message even when they ship the
+/// raw selector hex.
+//
+// TODO: switch to `ITangleErrors::VersionNotFound::SELECTOR` once the
+// regenerated bindings land.
+fn is_version_not_found(err: &impl ToString) -> bool {
+    err.to_string()
+        .to_ascii_lowercase()
+        .contains("versionnotfound")
+}
+
+fn buffered_gas_limit(estimated: u64, min_gas_limit: u64) -> u64 {
+    let buffered = estimated.saturating_add(estimated / 10);
+    buffered.max(min_gas_limit)
+}

--- a/crates/manager/src/upgrade/error.rs
+++ b/crates/manager/src/upgrade/error.rs
@@ -1,0 +1,64 @@
+use thiserror::Error;
+
+/// Errors raised by the upgrade watcher and its supporting code.
+///
+/// The watcher's job is to never run a binary that fails the sha256 / attestation
+/// gate, so almost every variant here represents an abort path. Variants that
+/// downgrade an upgrade to a notification (rather than killing the watcher) are
+/// noted inline.
+#[derive(Debug, Error)]
+pub enum UpgradeError {
+    /// The blueprint has zero published versions — `effectiveBinaryVersion`
+    /// reverts. Treated as "not yet provisioned"; the watcher logs and waits
+    /// for a publish event.
+    #[error("blueprint {blueprint_id} has no published binary versions yet")]
+    NoVersionsPublished { blueprint_id: u64 },
+
+    /// On-chain digest does not match the bytes we downloaded.
+    /// Trust-root violation — never run the binary.
+    #[error(
+        "sha256 mismatch for service {service_id} version {version_id}: \
+         expected {expected}, got {actual}"
+    )]
+    Sha256Mismatch {
+        service_id: u64,
+        version_id: u64,
+        expected: String,
+        actual: String,
+    },
+
+    /// Attestation hash was non-zero but verification failed. Per spec: the
+    /// watcher downgrades from AUTO to APPROVE-style notification rather than
+    /// swapping.
+    #[error(
+        "attestation verification failed for service {service_id} version {version_id}: {reason}"
+    )]
+    AttestationFailed {
+        service_id: u64,
+        version_id: u64,
+        reason: String,
+    },
+
+    /// Caller asked for a state mutation that requires the service to be
+    /// tracked, but the manager has no record of it.
+    #[error("service {service_id} is not tracked by this manager")]
+    ServiceNotTracked { service_id: u64 },
+
+    /// An on-chain read failed.
+    #[error("chain read failed: {0}")]
+    ChainRead(String),
+
+    /// An on-chain write failed (e.g. ack tx reverted).
+    #[error("chain write failed: {0}")]
+    ChainWrite(String),
+
+    /// Underlying I/O error (download, file rename, etc.).
+    #[error(transparent)]
+    Io(#[from] std::io::Error),
+
+    /// Underlying manager error.
+    #[error(transparent)]
+    Manager(#[from] crate::error::Error),
+}
+
+pub type Result<T> = std::result::Result<T, UpgradeError>;

--- a/crates/manager/src/upgrade/mod.rs
+++ b/crates/manager/src/upgrade/mod.rs
@@ -1,0 +1,167 @@
+//! Blueprint binary version upgrade orchestration.
+//!
+//! Pieces:
+//!
+//! - [`chain`]: read/write helpers against the on-chain
+//!   `BlueprintsBinaryVersions` surface (currently behind a local ABI stub
+//!   pending tnt-core-bindings v0.18).
+//! - [`watcher`]: background task that reconciles every tracked service
+//!   against `effectiveBinaryVersion(serviceId)` whenever the chain produces
+//!   a relevant signal.
+//! - [`swap`]: download + sha256 verify + drain + atomic swap pipeline.
+//! - [`attestation`]: gate for non-zero `attestationHash` rows; production
+//!   verification lands separately in cargo-tangle.
+//! - [`rpc`]: small axum router for operator tooling.
+//! - [`state`]: in-memory state shared across all of the above.
+//!
+//! Operator-facing CLI commands (`ack`, `set-policy`, etc.) live in
+//! `cargo-tangle` (this repo's `cli/` crate) — that path already owns
+//! keystore loading and signing UX.
+//!
+//! ## Safety contract (do not weaken)
+//!
+//! 1. Every binary the manager runs MUST have been gated by
+//!    `verify_binary_digest` against `effectiveBinaryVersion(...).sha256Hash`.
+//!    The same helper handles the initial-fetch path; never fork.
+//! 2. The drain-then-swap sequence in `watcher::execute_swap` is non-negotiable.
+//!    Killing a service mid-job loses operator slot work.
+//! 3. AUTO swap requires sha256 match AND attestation verify. Failure on the
+//!    attestation step downgrades to an APPROVE-style pending notification
+//!    rather than swapping silently.
+//! 4. The default policy is `APPROVE`. A new operator joining a service does
+//!    NOT auto-update.
+//! 5. `serviceAckedVersionId` is a single slot any operator can write —
+//!    after observing `OperatorBinaryAcked` the watcher re-resolves via
+//!    `effectiveBinaryVersion` and never assumes the ack reflects this
+//!    manager's intent.
+
+pub mod abi;
+pub mod attestation;
+pub mod chain;
+pub mod error;
+pub mod rpc;
+pub mod state;
+pub mod swap;
+pub mod types;
+pub mod watcher;
+
+pub use attestation::AttestationVerifier;
+pub use chain::ChainView;
+pub use error::{Result, UpgradeError};
+pub use rpc::UpgradeApi;
+pub use state::{RunningBinary, UpgradeState};
+pub use types::{
+    BinaryVersionInfo, PendingUpgrade, UpgradeHistoryEntry, UpgradeOutcome, UpgradePolicy,
+};
+pub use watcher::{
+    SwapRequest, TrackedServices, UpgradeWatcher, WatcherConfig, WatcherHandle, WatcherSignal,
+};
+
+/// Bundle of upgrade-flow handles consumed by the Tangle event handler.
+///
+/// Built once at manager start (from `executor::run_blueprint_manager_with_keystore`)
+/// and threaded through `ProtocolManager` so the handler can:
+///
+/// 1. Subscribe to swap requests produced by the watcher
+///    (`Receiver<SwapRequest>`).
+/// 2. Update `state` and `tracked_services` as services spin up / down.
+/// 3. Notify the watcher when a relevant on-chain event lands
+///    (`WatcherHandle`).
+/// 4. Surface the API to the local RPC (`UpgradeApi`).
+pub struct UpgradePipeline {
+    pub watcher: WatcherHandle,
+    pub state: UpgradeState,
+    pub tracked_services: TrackedServices,
+    pub swap_rx: tokio::sync::mpsc::Receiver<SwapRequest>,
+    pub api: UpgradeApi,
+}
+
+impl std::fmt::Debug for UpgradePipeline {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("UpgradePipeline").finish_non_exhaustive()
+    }
+}
+
+/// Inputs needed to assemble an [`UpgradePipeline`].
+pub struct UpgradePipelineBuilder {
+    pub chain: ChainView,
+    pub cache_root: std::path::PathBuf,
+    pub attestation: AttestationVerifier,
+}
+
+impl UpgradePipelineBuilder {
+    /// Spin up the upgrade watcher and return the operator-side pipeline +
+    /// the join handle for the watcher background task.
+    ///
+    /// Caller is responsible for ensuring the join handle's lifetime is
+    /// bound to the manager so a panic in the watcher surfaces in shutdown.
+    pub fn spawn(self) -> (UpgradePipeline, tokio::task::JoinHandle<()>) {
+        let state = UpgradeState::new();
+        let tracked_services = TrackedServices::new();
+        let (swap_tx, swap_rx) = tokio::sync::mpsc::channel::<SwapRequest>(32);
+        let api = UpgradeApi::new(self.chain.clone(), state.clone());
+
+        let config = WatcherConfig {
+            chain: self.chain,
+            state: state.clone(),
+            attestation: self.attestation,
+            cache_root: self.cache_root,
+            tracked_services: tracked_services.clone(),
+            swap_tx,
+        };
+        let (watcher, join) = UpgradeWatcher::spawn(config);
+
+        (
+            UpgradePipeline {
+                watcher,
+                state,
+                tracked_services,
+                swap_rx,
+                api,
+            },
+            join,
+        )
+    }
+}
+
+/// Selectors of the events the watcher should react to. The protocol event
+/// handler matches log topic 0 against these and, on a hit, forwards a
+/// reconcile signal to the watcher.
+pub mod event_selectors {
+    use alloy_sol_types::SolEvent;
+
+    use super::abi::IBlueprintBinaryVersions;
+
+    pub fn binary_version_published() -> alloy_primitives::B256 {
+        IBlueprintBinaryVersions::BinaryVersionPublished::SIGNATURE_HASH
+    }
+
+    pub fn binary_active_version_changed() -> alloy_primitives::B256 {
+        IBlueprintBinaryVersions::BinaryActiveVersionChanged::SIGNATURE_HASH
+    }
+
+    pub fn binary_version_deprecated() -> alloy_primitives::B256 {
+        IBlueprintBinaryVersions::BinaryVersionDeprecated::SIGNATURE_HASH
+    }
+
+    pub fn operator_binary_acked() -> alloy_primitives::B256 {
+        IBlueprintBinaryVersions::OperatorBinaryAcked::SIGNATURE_HASH
+    }
+
+    pub fn service_upgrade_policy_set() -> alloy_primitives::B256 {
+        IBlueprintBinaryVersions::ServiceUpgradePolicySet::SIGNATURE_HASH
+    }
+
+    /// True iff the given topic0 matches any of the binary-versions events.
+    pub fn matches_any(topic0: &alloy_primitives::B256) -> bool {
+        [
+            binary_version_published(),
+            binary_active_version_changed(),
+            binary_version_deprecated(),
+            operator_binary_acked(),
+            service_upgrade_policy_set(),
+        ]
+        .iter()
+        .any(|sig| sig == topic0)
+    }
+}

--- a/crates/manager/src/upgrade/rpc.rs
+++ b/crates/manager/src/upgrade/rpc.rs
@@ -1,0 +1,184 @@
+//! Local axum router exposing upgrade state to operator tooling.
+//!
+//! This is intentionally a small surface — the manager is not a full RPC node.
+//! Mount it behind the auth proxy or on a localhost-only listener; tx-signing
+//! endpoints submit on-chain calls using the manager's keystore key.
+//!
+//! Routes:
+//!   `GET  /upgrades/pending`              list of pending upgrades
+//!   `GET  /upgrades/history`              recent swap outcomes (bounded ring)
+//!   `GET  /upgrades/policy/:service_id`   current policy + cached on-chain value
+//!   `POST /upgrades/policy/:service_id`   set policy (signs on-chain tx)
+//!   `POST /upgrades/:service_id/ack`      ack a specific version on-chain
+//!
+//! Errors carry a JSON body `{ "error": "<message>" }` and an HTTP status
+//! drawn from the failure mode (4xx = caller misuse, 5xx = chain failure).
+
+use super::chain::ChainView;
+use super::state::UpgradeState;
+use super::types::{PendingUpgrade, UpgradeHistoryEntry, UpgradePolicy};
+use axum::{
+    Json, Router,
+    extract::{Path, State},
+    http::StatusCode,
+    response::{IntoResponse, Response},
+    routing::{get, post},
+};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
+
+#[derive(Clone)]
+pub struct UpgradeApi {
+    chain: Arc<ChainView>,
+    state: UpgradeState,
+}
+
+impl UpgradeApi {
+    #[must_use]
+    pub fn new(chain: ChainView, state: UpgradeState) -> Self {
+        Self {
+            chain: Arc::new(chain),
+            state,
+        }
+    }
+
+    /// Access the chain view for callers (e.g. the Tangle event handler)
+    /// that need to read on-chain state without going through HTTP.
+    #[must_use]
+    pub fn chain(&self) -> &ChainView {
+        &self.chain
+    }
+
+    /// Access the in-memory upgrade state.
+    #[must_use]
+    pub fn state(&self) -> &UpgradeState {
+        &self.state
+    }
+
+    #[must_use]
+    pub fn router(self) -> Router {
+        Router::new()
+            .route("/upgrades/pending", get(list_pending))
+            .route("/upgrades/history", get(list_history))
+            .route("/upgrades/policy/{service_id}", get(get_policy))
+            .route("/upgrades/policy/{service_id}", post(set_policy))
+            .route("/upgrades/{service_id}/ack", post(submit_ack))
+            .with_state(self)
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct ErrorBody {
+    error: String,
+}
+
+struct ApiError(StatusCode, String);
+
+impl IntoResponse for ApiError {
+    fn into_response(self) -> Response {
+        (self.0, Json(ErrorBody { error: self.1 })).into_response()
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct PendingList {
+    pending: Vec<PendingUpgrade>,
+}
+
+#[derive(Debug, Serialize)]
+struct HistoryList {
+    history: Vec<UpgradeHistoryEntry>,
+}
+
+#[derive(Debug, Serialize)]
+struct PolicyView {
+    service_id: u64,
+    /// Cached value (last `getServiceUpgradePolicy` we observed).
+    cached: Option<UpgradePolicy>,
+    /// Freshly fetched value from the chain.
+    onchain: UpgradePolicy,
+    /// Operator's `getServiceAckedVersionId`.
+    acked_version_id: u64,
+}
+
+#[derive(Debug, Deserialize)]
+struct SetPolicyBody {
+    policy: UpgradePolicy,
+}
+
+#[derive(Debug, Serialize)]
+struct TxReceiptView {
+    tx_hash: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct AckBody {
+    version_id: u64,
+}
+
+async fn list_pending(State(api): State<UpgradeApi>) -> Result<Json<PendingList>, ApiError> {
+    Ok(Json(PendingList {
+        pending: api.state.list_pending().await,
+    }))
+}
+
+async fn list_history(State(api): State<UpgradeApi>) -> Result<Json<HistoryList>, ApiError> {
+    Ok(Json(HistoryList {
+        history: api.state.history().await,
+    }))
+}
+
+async fn get_policy(
+    State(api): State<UpgradeApi>,
+    Path(service_id): Path<u64>,
+) -> Result<Json<PolicyView>, ApiError> {
+    let cached = api.state.policy(service_id).await;
+    let onchain = api
+        .chain
+        .service_upgrade_policy(service_id)
+        .await
+        .map_err(|e| ApiError(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    api.state.set_policy(service_id, onchain).await;
+    let acked = api
+        .chain
+        .service_acked_version_id(service_id)
+        .await
+        .map_err(|e| ApiError(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    Ok(Json(PolicyView {
+        service_id,
+        cached,
+        onchain,
+        acked_version_id: acked,
+    }))
+}
+
+async fn set_policy(
+    State(api): State<UpgradeApi>,
+    Path(service_id): Path<u64>,
+    Json(body): Json<SetPolicyBody>,
+) -> Result<Json<TxReceiptView>, ApiError> {
+    let tx = api
+        .chain
+        .set_service_upgrade_policy(service_id, body.policy)
+        .await
+        .map_err(|e| ApiError(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    api.state.set_policy(service_id, body.policy).await;
+    Ok(Json(TxReceiptView {
+        tx_hash: format!("0x{}", hex::encode(tx.as_slice())),
+    }))
+}
+
+async fn submit_ack(
+    State(api): State<UpgradeApi>,
+    Path(service_id): Path<u64>,
+    Json(body): Json<AckBody>,
+) -> Result<Json<TxReceiptView>, ApiError> {
+    let tx = api
+        .chain
+        .ack_binary_version(service_id, body.version_id)
+        .await
+        .map_err(|e| ApiError(StatusCode::BAD_GATEWAY, e.to_string()))?;
+    Ok(Json(TxReceiptView {
+        tx_hash: format!("0x{}", hex::encode(tx.as_slice())),
+    }))
+}

--- a/crates/manager/src/upgrade/state.rs
+++ b/crates/manager/src/upgrade/state.rs
@@ -1,0 +1,190 @@
+//! In-memory state shared between the upgrade watcher, the local RPC, and the
+//! CLI surface.
+//!
+//! - `running` tracks the (versionId, sha256) the manager is currently
+//!   serving for each service. Compared against `effectiveBinaryVersion` to
+//!   decide whether a swap is needed.
+//! - `policies` is a local cache of `getServiceUpgradePolicy` so the RPC can
+//!   answer without an extra RPC round-trip; the watcher refreshes this on
+//!   `ServiceUpgradePolicySet` events.
+//! - `pending` holds upgrades that are visible to operators (APPROVE policy)
+//!   or downgrades-from-AUTO (attestation failure).
+//! - `history` is a bounded ring of recent swap results for `GET /upgrades/history`.
+
+use super::types::{PendingUpgrade, UpgradeHistoryEntry, UpgradePolicy};
+use alloy_primitives::B256;
+use std::collections::HashMap;
+use std::sync::Arc;
+use tokio::sync::RwLock;
+
+/// Maximum upgrade-history entries kept in memory. Anything beyond this is
+/// dropped from the head; an operator should ship the structured logs to
+/// long-term storage if they want full history.
+const HISTORY_CAP: usize = 256;
+
+#[derive(Debug, Clone, Copy)]
+pub struct RunningBinary {
+    pub version_id: u64,
+    pub sha256: B256,
+}
+
+#[derive(Default)]
+struct Inner {
+    running: HashMap<u64, RunningBinary>,
+    policies: HashMap<u64, UpgradePolicy>,
+    pending: HashMap<u64, PendingUpgrade>,
+    history: Vec<UpgradeHistoryEntry>,
+}
+
+#[derive(Clone, Default)]
+pub struct UpgradeState {
+    inner: Arc<RwLock<Inner>>,
+}
+
+impl UpgradeState {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn set_running(&self, service_id: u64, running: RunningBinary) {
+        self.inner.write().await.running.insert(service_id, running);
+    }
+
+    pub async fn clear_running(&self, service_id: u64) {
+        let mut guard = self.inner.write().await;
+        guard.running.remove(&service_id);
+        guard.pending.remove(&service_id);
+    }
+
+    pub async fn running(&self, service_id: u64) -> Option<RunningBinary> {
+        self.inner.read().await.running.get(&service_id).copied()
+    }
+
+    pub async fn set_policy(&self, service_id: u64, policy: UpgradePolicy) {
+        self.inner.write().await.policies.insert(service_id, policy);
+    }
+
+    pub async fn policy(&self, service_id: u64) -> Option<UpgradePolicy> {
+        self.inner.read().await.policies.get(&service_id).copied()
+    }
+
+    pub async fn record_pending(&self, upgrade: PendingUpgrade) {
+        self.inner
+            .write()
+            .await
+            .pending
+            .insert(upgrade.service_id, upgrade);
+    }
+
+    pub async fn clear_pending(&self, service_id: u64) {
+        self.inner.write().await.pending.remove(&service_id);
+    }
+
+    pub async fn pending(&self, service_id: u64) -> Option<PendingUpgrade> {
+        self.inner.read().await.pending.get(&service_id).cloned()
+    }
+
+    pub async fn list_pending(&self) -> Vec<PendingUpgrade> {
+        self.inner.read().await.pending.values().cloned().collect()
+    }
+
+    pub async fn push_history(&self, entry: UpgradeHistoryEntry) {
+        let mut guard = self.inner.write().await;
+        if guard.history.len() >= HISTORY_CAP {
+            guard.history.remove(0);
+        }
+        guard.history.push(entry);
+    }
+
+    pub async fn history(&self) -> Vec<UpgradeHistoryEntry> {
+        self.inner.read().await.history.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::upgrade::types::{PendingUpgrade, UpgradeOutcome, UpgradePolicy};
+    use std::time::SystemTime;
+
+    fn dummy_pending(service_id: u64) -> PendingUpgrade {
+        PendingUpgrade {
+            service_id,
+            blueprint_id: 1,
+            current_version_id: Some(0),
+            current_sha256: Some(B256::ZERO),
+            available_version_id: 1,
+            available_sha256: B256::repeat_byte(0xab),
+            available_uri: "ipfs://test".into(),
+            available_attestation_hash: B256::ZERO,
+            policy: UpgradePolicy::Approve,
+            detected_at: SystemTime::now(),
+        }
+    }
+
+    #[tokio::test]
+    async fn running_binary_round_trip() {
+        let state = UpgradeState::new();
+        state
+            .set_running(
+                7,
+                RunningBinary {
+                    version_id: 3,
+                    sha256: B256::repeat_byte(0xcd),
+                },
+            )
+            .await;
+        let got = state.running(7).await.unwrap();
+        assert_eq!(got.version_id, 3);
+        assert_eq!(got.sha256, B256::repeat_byte(0xcd));
+    }
+
+    #[tokio::test]
+    async fn clearing_running_also_clears_pending() {
+        // Invariant: if the manager stops serving a service we should not keep
+        // its pending upgrade exposed to operators.
+        let state = UpgradeState::new();
+        state.record_pending(dummy_pending(9)).await;
+        state
+            .set_running(
+                9,
+                RunningBinary {
+                    version_id: 0,
+                    sha256: B256::ZERO,
+                },
+            )
+            .await;
+        state.clear_running(9).await;
+        assert!(state.pending(9).await.is_none());
+        assert!(state.running(9).await.is_none());
+    }
+
+    #[tokio::test]
+    async fn history_is_bounded_by_cap() {
+        // Guards a memory-leak regression: a long-running manager swapping
+        // binaries hourly should not grow unbounded.
+        let state = UpgradeState::new();
+        for i in 0..(HISTORY_CAP + 32) {
+            state
+                .push_history(UpgradeHistoryEntry {
+                    service_id: i as u64,
+                    blueprint_id: 1,
+                    from_version_id: None,
+                    from_sha256: None,
+                    to_version_id: 1,
+                    to_sha256: B256::ZERO,
+                    policy: UpgradePolicy::Auto,
+                    completed_at: SystemTime::now(),
+                    outcome: UpgradeOutcome::Swapped,
+                })
+                .await;
+        }
+        assert_eq!(state.history().await.len(), HISTORY_CAP);
+        // Oldest entries dropped from the head — newest should still be 287.
+        assert_eq!(
+            state.history().await.last().unwrap().service_id,
+            (HISTORY_CAP + 32 - 1) as u64
+        );
+    }
+}

--- a/crates/manager/src/upgrade/swap.rs
+++ b/crates/manager/src/upgrade/swap.rs
@@ -1,0 +1,310 @@
+//! Atomic binary swap pipeline.
+//!
+//! Used by the watcher when an `AUTO` policy or a confirmed `APPROVE` ack
+//! indicates the manager should move a service onto a new binary. The
+//! sequence is identical for both entrypoints — that uniformity is the only
+//! way to keep the safety invariants honest:
+//!
+//!   1. Resolve `effectiveBinaryVersion(serviceId)` — that is the trust root.
+//!   2. Download bytes from the published URI into a temp file under the
+//!      service's existing cache dir.
+//!   3. Compute sha256 (and blake3 if present) using the **same** helper the
+//!      initial-fetch path uses. Mismatch -> abort, never run.
+//!   4. Verify attestation if `attestationHash != 0`. Failure -> caller
+//!      downgrades to APPROVE-style notification.
+//!   5. Graceful-shutdown the existing service (drain).
+//!   6. Re-spawn the service from the new binary.
+//!   7. Update the `UpgradeState.running` slot to the new (versionId, sha256).
+//!
+//! Step (5) MUST come before step (6): blueprints expose a graceful-shutdown
+//! API and killing mid-job loses work.
+
+use super::error::{Result, UpgradeError};
+use super::types::BinaryVersionInfo;
+use crate::error::Error as ManagerError;
+use crate::sdk::utils::make_executable;
+use crate::sources::remote::verify_binary_digest;
+use blueprint_core::{info, warn};
+use reqwest::Client;
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+use tokio::fs;
+use tokio::io::AsyncWriteExt;
+use url::Url;
+
+const DOWNLOAD_RETRIES: usize = 3;
+const RETRY_BACKOFF_MS: u64 = 500;
+const MAX_BINARY_BYTES_ENV: &str = "MAX_ARCHIVE_BYTES";
+const DEFAULT_MAX_BINARY_BYTES: u64 = 512 * 1024 * 1024; // 512 MiB
+
+const IPFS_GATEWAY_ENV: &str = "IPFS_GATEWAY_URL";
+
+/// Downloads the binary referenced by `version.binary_uri` into the service's
+/// cache directory and verifies it against `version.sha256`.
+///
+/// On success returns the path to an **executable** file gated by both
+/// digests. Caller MUST treat any error here as "do not run this binary."
+pub async fn download_and_verify(
+    service_id: u64,
+    cache_dir: &Path,
+    version: &BinaryVersionInfo,
+) -> Result<PathBuf> {
+    fs::create_dir_all(cache_dir).await?;
+
+    let dest = cache_dir.join(format!(
+        "binary-v{}-{}",
+        version.version_id,
+        hex::encode(&version.sha256.as_slice()[..8])
+    ));
+
+    // Idempotency: if a previous swap attempt already cached + verified this
+    // exact (versionId, sha256), skip the download.
+    if fs::try_exists(&dest).await.unwrap_or(false) {
+        let sha = version.sha256.0;
+        if verify_binary_digest(&dest, &sha, None).is_ok() {
+            info!(
+                target: "upgrade",
+                service_id,
+                version_id = version.version_id,
+                "binary cache hit; reusing verified copy"
+            );
+            return Ok(make_executable(&dest)?);
+        }
+        // Stale cache (sha drift or partial write) — drop it and re-download.
+        let _ = fs::remove_file(&dest).await;
+    }
+
+    let url = resolve_url(&version.binary_uri)?;
+    let max_bytes = std::env::var(MAX_BINARY_BYTES_ENV)
+        .ok()
+        .and_then(|v| v.parse::<u64>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(DEFAULT_MAX_BINARY_BYTES);
+
+    let temp_path = dest.with_extension("part");
+    download(&url, &temp_path, max_bytes).await?;
+
+    let sha = version.sha256.0;
+    if let Err(err) = verify_binary_digest(&temp_path, &sha, None) {
+        let _ = fs::remove_file(&temp_path).await;
+        match err {
+            ManagerError::HashMismatch { expected, actual } => {
+                return Err(UpgradeError::Sha256Mismatch {
+                    service_id,
+                    version_id: version.version_id,
+                    expected,
+                    actual,
+                });
+            }
+            other => return Err(UpgradeError::Manager(other)),
+        }
+    }
+
+    fs::rename(&temp_path, &dest).await?;
+    Ok(make_executable(&dest)?)
+}
+
+fn resolve_url(raw: &str) -> Result<Url> {
+    if let Some(rest) = raw.strip_prefix("ipfs://") {
+        let gateway = std::env::var(IPFS_GATEWAY_ENV).map_err(|_| {
+            UpgradeError::Manager(ManagerError::MissingIpfsGateway {
+                url: raw.to_string(),
+            })
+        })?;
+        let suffix = rest.trim_start_matches('/');
+        let full = format!(
+            "{}/{}",
+            gateway.trim_end_matches('/'),
+            suffix.trim_start_matches('/')
+        );
+        Url::parse(&full).map_err(|err| {
+            UpgradeError::Manager(ManagerError::DownloadFailed {
+                url: raw.to_string(),
+                reason: format!("failed to build gateway URL: {err}"),
+            })
+        })
+    } else {
+        Url::parse(raw).map_err(|err| {
+            UpgradeError::Manager(ManagerError::DownloadFailed {
+                url: raw.to_string(),
+                reason: err.to_string(),
+            })
+        })
+    }
+}
+
+async fn download(url: &Url, dest: &Path, max_bytes: u64) -> Result<()> {
+    let client = Client::builder()
+        .build()
+        .map_err(|e| UpgradeError::ChainRead(format!("http client: {e}")))?;
+
+    let mut last_error = String::new();
+    for attempt in 0..=DOWNLOAD_RETRIES {
+        match client.get(url.clone()).send().await {
+            Ok(resp) if resp.status().is_success() => {
+                let total_len = resp.content_length().unwrap_or(0);
+                if total_len > max_bytes && total_len > 0 {
+                    return Err(UpgradeError::Manager(ManagerError::ArchiveTooLarge {
+                        url: url.to_string(),
+                        size: total_len,
+                        max: max_bytes,
+                    }));
+                }
+                let mut file = fs::File::create(dest).await?;
+                let mut downloaded: u64 = 0;
+                let mut resp = resp;
+                while let Some(chunk) = resp.chunk().await.map_err(|err| {
+                    UpgradeError::Manager(ManagerError::DownloadFailed {
+                        url: url.to_string(),
+                        reason: err.to_string(),
+                    })
+                })? {
+                    downloaded += chunk.len() as u64;
+                    if downloaded > max_bytes {
+                        let _ = fs::remove_file(dest).await;
+                        return Err(UpgradeError::Manager(ManagerError::ArchiveTooLarge {
+                            url: url.to_string(),
+                            size: downloaded,
+                            max: max_bytes,
+                        }));
+                    }
+                    file.write_all(&chunk).await?;
+                }
+                file.flush().await?;
+                return Ok(());
+            }
+            Ok(resp) => {
+                last_error = format!("HTTP {}", resp.status());
+            }
+            Err(err) => {
+                last_error = err.to_string();
+            }
+        }
+        if attempt < DOWNLOAD_RETRIES {
+            let delay = RETRY_BACKOFF_MS * (attempt as u64 + 1);
+            warn!(
+                target: "upgrade",
+                attempt = attempt + 1,
+                url = %url,
+                "binary download failed ({last_error}); retrying in {delay}ms"
+            );
+            tokio::time::sleep(Duration::from_millis(delay)).await;
+        }
+    }
+
+    Err(UpgradeError::Manager(ManagerError::DownloadFailed {
+        url: url.to_string(),
+        reason: last_error,
+    }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use alloy_primitives::B256;
+    use sha2::{Digest, Sha256};
+    use tempfile::TempDir;
+
+    fn version_for(bytes: &[u8]) -> BinaryVersionInfo {
+        let sha: [u8; 32] = Sha256::digest(bytes).into();
+        BinaryVersionInfo {
+            version_id: 1,
+            sha256: B256::from(sha),
+            binary_uri: "http://invalid.local/never".into(),
+            attestation_hash: B256::ZERO,
+            published_at: 0,
+            deprecated: false,
+        }
+    }
+
+    #[tokio::test]
+    async fn cache_hit_skips_download_when_sha256_matches() {
+        // Regression guard for the swap pipeline: a previously verified
+        // binary on disk MUST be reused (and rechecked) rather than
+        // re-downloaded. Otherwise a network outage would block legitimate
+        // already-verified upgrades.
+        let dir = TempDir::new().unwrap();
+        let payload = b"hello-world-blueprint-bytes";
+        let version = version_for(payload);
+        let cached = dir.path().join(format!(
+            "binary-v{}-{}",
+            version.version_id,
+            hex::encode(&version.sha256.as_slice()[..8])
+        ));
+        tokio::fs::write(&cached, payload).await.unwrap();
+
+        let resolved = download_and_verify(1, dir.path(), &version).await.unwrap();
+        assert_eq!(resolved, cached);
+    }
+
+    #[tokio::test]
+    async fn corrupted_cache_is_purged_then_redownloaded() {
+        // If the on-disk copy has been tampered with we MUST purge it. The
+        // re-download will fail because the URL is unreachable, but the
+        // important assertion is that we do not silently return the
+        // mismatched cached file.
+        let dir = TempDir::new().unwrap();
+        let payload = b"hello-world-blueprint-bytes";
+        let version = version_for(payload);
+        let cached = dir.path().join(format!(
+            "binary-v{}-{}",
+            version.version_id,
+            hex::encode(&version.sha256.as_slice()[..8])
+        ));
+        tokio::fs::write(&cached, b"different-bytes-attacker-controlled")
+            .await
+            .unwrap();
+
+        let err = download_and_verify(1, dir.path(), &version)
+            .await
+            .expect_err("expected download to fail for unreachable URL");
+        // The contract violation we're catching is "silent return of stale
+        // bytes"; any error variant other than HashMismatch / Sha256Mismatch
+        // shows we correctly progressed past the cache check.
+        assert!(
+            !matches!(err, UpgradeError::Sha256Mismatch { .. }),
+            "stale cache should have been purged before sha gate ran"
+        );
+        assert!(
+            !tokio::fs::try_exists(&cached).await.unwrap(),
+            "stale cached file should have been removed"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_ipfs_uri_without_gateway() {
+        // Trust invariant: we will not silently swap from a URI scheme we
+        // can't dereference. Without IPFS_GATEWAY_URL the gateway path must
+        // fail loud — never default to "skip download, hope for the best."
+        // SAFETY: test isolates env mutation behind a lock so concurrent
+        // tests in the same process don't see a partially-modified env.
+        static LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+        let _guard = LOCK.lock().unwrap();
+
+        // Stash any pre-existing gateway value so we don't poison the
+        // process for the rest of the suite.
+        let prior = std::env::var(IPFS_GATEWAY_ENV).ok();
+        // SAFETY: env mutation guarded by LOCK above; only this test reads
+        // IPFS_GATEWAY_URL within the upgrade module.
+        unsafe { std::env::remove_var(IPFS_GATEWAY_ENV) };
+
+        let dir = TempDir::new().unwrap();
+        let mut version = version_for(b"unused");
+        version.binary_uri = "ipfs://Qm-fake-cid".into();
+        let err = download_and_verify(1, dir.path(), &version)
+            .await
+            .expect_err("ipfs:// URI without gateway must error");
+        assert!(
+            matches!(
+                err,
+                UpgradeError::Manager(ManagerError::MissingIpfsGateway { .. })
+            ),
+            "expected MissingIpfsGateway, got {err:?}"
+        );
+
+        if let Some(value) = prior {
+            // SAFETY: same lock guards the restore.
+            unsafe { std::env::set_var(IPFS_GATEWAY_ENV, value) };
+        }
+    }
+}

--- a/crates/manager/src/upgrade/types.rs
+++ b/crates/manager/src/upgrade/types.rs
@@ -1,0 +1,273 @@
+use alloy_primitives::B256;
+use serde::{Deserialize, Serialize};
+use std::time::SystemTime;
+
+/// Per-service binary upgrade policy. Mirrors the on-chain enum exactly.
+///
+/// The numeric discriminants are load-bearing — they are the ABI encoding the
+/// contract uses for `setServiceUpgradePolicy` / `getServiceUpgradePolicy`.
+/// Reorder = wire-protocol break.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "UPPERCASE")]
+#[repr(u8)]
+pub enum UpgradePolicy {
+    /// Operator must `ackBinaryVersion` before the manager swaps.
+    /// This is the protocol default for a brand-new service.
+    Approve = 0,
+    /// Manager auto-swaps whenever the blueprint's active version moves
+    /// (subject to sha256 + attestation gating).
+    Auto = 1,
+    /// Manager never swaps. Operator must switch policy first.
+    Manual = 2,
+}
+
+impl UpgradePolicy {
+    /// Decode the on-chain `uint8`. Unknown discriminants are conservatively
+    /// mapped to `Manual` (the safest stance — never auto-upgrade something
+    /// we don't understand).
+    #[must_use]
+    pub fn from_u8(value: u8) -> Self {
+        match value {
+            0 => Self::Approve,
+            1 => Self::Auto,
+            2 => Self::Manual,
+            _ => Self::Manual,
+        }
+    }
+
+    #[must_use]
+    pub fn as_u8(self) -> u8 {
+        self as u8
+    }
+}
+
+impl Default for UpgradePolicy {
+    /// Protocol default is APPROVE — a new operator joining a service does
+    /// not auto-update.
+    fn default() -> Self {
+        Self::Approve
+    }
+}
+
+impl std::fmt::Display for UpgradePolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Approve => f.write_str("APPROVE"),
+            Self::Auto => f.write_str("AUTO"),
+            Self::Manual => f.write_str("MANUAL"),
+        }
+    }
+}
+
+impl std::str::FromStr for UpgradePolicy {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s.to_ascii_uppercase().as_str() {
+            "APPROVE" => Ok(Self::Approve),
+            "AUTO" => Ok(Self::Auto),
+            "MANUAL" => Ok(Self::Manual),
+            other => Err(format!(
+                "invalid UpgradePolicy `{other}` (expected APPROVE | AUTO | MANUAL)"
+            )),
+        }
+    }
+}
+
+/// Resolved binary version metadata as the manager sees it.
+///
+/// `sha256` is the canonical trust root — every download is gated against it.
+/// `attestation_hash == B256::ZERO` means "no attestation bundle published"
+/// (per contract docstring); a non-zero value MUST be verified for AUTO swaps.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct BinaryVersionInfo {
+    pub version_id: u64,
+    #[serde(with = "hex_b256")]
+    pub sha256: B256,
+    pub binary_uri: String,
+    #[serde(with = "hex_b256")]
+    pub attestation_hash: B256,
+    pub published_at: u64,
+    pub deprecated: bool,
+}
+
+impl BinaryVersionInfo {
+    /// True iff the contract documents an attestation bundle for this version.
+    #[must_use]
+    pub fn has_attestation(&self) -> bool {
+        self.attestation_hash != B256::ZERO
+    }
+}
+
+/// Entry exposed via `GET /upgrades/pending`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingUpgrade {
+    pub service_id: u64,
+    pub blueprint_id: u64,
+    pub current_version_id: Option<u64>,
+    #[serde(with = "hex_b256_opt")]
+    pub current_sha256: Option<B256>,
+    pub available_version_id: u64,
+    #[serde(with = "hex_b256")]
+    pub available_sha256: B256,
+    pub available_uri: String,
+    #[serde(with = "hex_b256")]
+    pub available_attestation_hash: B256,
+    pub policy: UpgradePolicy,
+    /// Captured at the moment the watcher noticed the divergence; useful for
+    /// alerting on "this upgrade has been pending for N hours."
+    pub detected_at: SystemTime,
+}
+
+/// Entry exposed via `GET /upgrades/history`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpgradeHistoryEntry {
+    pub service_id: u64,
+    pub blueprint_id: u64,
+    pub from_version_id: Option<u64>,
+    #[serde(with = "hex_b256_opt")]
+    pub from_sha256: Option<B256>,
+    pub to_version_id: u64,
+    #[serde(with = "hex_b256")]
+    pub to_sha256: B256,
+    pub policy: UpgradePolicy,
+    pub completed_at: SystemTime,
+    pub outcome: UpgradeOutcome,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum UpgradeOutcome {
+    /// Drain + swap succeeded; manager is now serving the new version.
+    Swapped,
+    /// Sha256 mismatch — binary discarded, manager kept old version.
+    Sha256Mismatch,
+    /// Attestation verify failed — manager kept old version and downgraded to
+    /// APPROVE-style notification.
+    AttestationFailed,
+    /// Download or filesystem error.
+    DownloadFailed,
+    /// Policy was MANUAL — never swap.
+    PolicyBlocked,
+}
+
+/// Serde helper for `B256 <-> 0x-prefixed hex string`.
+mod hex_b256 {
+    use alloy_primitives::B256;
+    use serde::{Deserialize, Deserializer, Serializer};
+
+    pub fn serialize<S: Serializer>(value: &B256, ser: S) -> Result<S::Ok, S::Error> {
+        ser.serialize_str(&format!("0x{}", hex::encode(value.as_slice())))
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<B256, D::Error> {
+        let raw = String::deserialize(de)?;
+        let trimmed = raw.trim_start_matches("0x");
+        let bytes = hex::decode(trimmed).map_err(serde::de::Error::custom)?;
+        if bytes.len() != 32 {
+            return Err(serde::de::Error::custom(format!(
+                "expected 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        Ok(B256::from(out))
+    }
+}
+
+mod hex_b256_opt {
+    use alloy_primitives::B256;
+    use serde::{Deserialize, Deserializer, Serialize, Serializer};
+
+    // serde's `#[serde(with = "...")]` calls `serialize(&Option<T>, _)`, so
+    // the parameter shape is dictated by the framework — not a style choice.
+    #[allow(clippy::ref_option)]
+    pub fn serialize<S: Serializer>(value: &Option<B256>, ser: S) -> Result<S::Ok, S::Error> {
+        match value {
+            Some(v) => format!("0x{}", hex::encode(v.as_slice())).serialize(ser),
+            None => ser.serialize_none(),
+        }
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(de: D) -> Result<Option<B256>, D::Error> {
+        let raw = Option::<String>::deserialize(de)?;
+        let Some(s) = raw else {
+            return Ok(None);
+        };
+        let trimmed = s.trim_start_matches("0x");
+        let bytes = hex::decode(trimmed).map_err(serde::de::Error::custom)?;
+        if bytes.len() != 32 {
+            return Err(serde::de::Error::custom(format!(
+                "expected 32 bytes, got {}",
+                bytes.len()
+            )));
+        }
+        let mut out = [0u8; 32];
+        out.copy_from_slice(&bytes);
+        Ok(Some(B256::from(out)))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn upgrade_policy_roundtrips_through_u8() {
+        for policy in [
+            UpgradePolicy::Approve,
+            UpgradePolicy::Auto,
+            UpgradePolicy::Manual,
+        ] {
+            assert_eq!(UpgradePolicy::from_u8(policy.as_u8()), policy);
+        }
+    }
+
+    #[test]
+    fn unknown_policy_discriminant_falls_back_to_manual() {
+        // Defensive: any future variant we don't know about MUST NOT cause us
+        // to auto-swap. MANUAL is the only safe default.
+        assert_eq!(UpgradePolicy::from_u8(7), UpgradePolicy::Manual);
+        assert_eq!(UpgradePolicy::from_u8(255), UpgradePolicy::Manual);
+    }
+
+    #[test]
+    fn upgrade_policy_default_is_approve() {
+        // Matches the on-chain default and the spec's "new operator joining a
+        // service does not auto-update" invariant.
+        assert_eq!(UpgradePolicy::default(), UpgradePolicy::Approve);
+    }
+
+    #[test]
+    fn upgrade_policy_parses_case_insensitively() {
+        assert_eq!(
+            "approve".parse::<UpgradePolicy>().unwrap(),
+            UpgradePolicy::Approve
+        );
+        assert_eq!(
+            "AUTO".parse::<UpgradePolicy>().unwrap(),
+            UpgradePolicy::Auto
+        );
+        assert_eq!(
+            "Manual".parse::<UpgradePolicy>().unwrap(),
+            UpgradePolicy::Manual
+        );
+        assert!("rolling".parse::<UpgradePolicy>().is_err());
+    }
+
+    #[test]
+    fn binary_version_info_attestation_flag() {
+        let mut info = BinaryVersionInfo {
+            version_id: 0,
+            sha256: B256::ZERO,
+            binary_uri: String::new(),
+            attestation_hash: B256::ZERO,
+            published_at: 0,
+            deprecated: false,
+        };
+        assert!(!info.has_attestation());
+        info.attestation_hash = B256::repeat_byte(0xab);
+        assert!(info.has_attestation());
+    }
+}

--- a/crates/manager/src/upgrade/watcher.rs
+++ b/crates/manager/src/upgrade/watcher.rs
@@ -1,0 +1,473 @@
+//! Background task that reconciles each tracked service against
+//! `effectiveBinaryVersion(serviceId)` whenever the chain signals that a
+//! binary-version-relevant event has been observed.
+//!
+//! The watcher does **not** run its own log subscription — Tangle's protocol
+//! client already streams every log on the tangle contract via `next_event`.
+//! Instead the protocol event loop forwards block-level notifications to the
+//! watcher; on each notification we re-resolve every service we are running
+//! and take action.
+//!
+//! This is intentionally a "pull" design:
+//!   - We never make trust decisions from events alone. Concurrent acks
+//!     across operators mean the only safe truth is `effectiveBinaryVersion`.
+//!   - We reconcile cheaply because the tracked services list is small.
+//!
+//! ### Lifecycle
+//!
+//! `UpgradeWatcher::spawn` returns a join handle and a notification channel.
+//! The protocol event handler calls `notify_block(...)` whenever it processes
+//! a block that carried any of the binary-versions selectors. Shutdown is
+//! propagated via the same channel by dropping the sender.
+
+use super::attestation::AttestationVerifier;
+use super::chain::ChainView;
+use super::error::Result;
+use super::state::{RunningBinary, UpgradeState};
+use super::swap::download_and_verify;
+use super::types::{
+    BinaryVersionInfo, PendingUpgrade, UpgradeHistoryEntry, UpgradeOutcome, UpgradePolicy,
+};
+use blueprint_core::{info, warn};
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::SystemTime;
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+
+/// Tunables visible to call sites. `cache_root` is the same directory the
+/// initial-fetch path writes to, so swaps live next to the bytes they
+/// replace.
+#[derive(Clone)]
+pub struct WatcherConfig {
+    pub chain: ChainView,
+    pub state: UpgradeState,
+    pub attestation: AttestationVerifier,
+    /// Per-service cache root. Each service gets `<cache>/svc-<bp>-<sid>/`.
+    pub cache_root: PathBuf,
+    /// Service ids the protocol event handler is currently tracking. The
+    /// watcher resolves the chain for each on a reconcile signal; ownership
+    /// of `ActiveBlueprints` stays with the protocol manager.
+    pub tracked_services: TrackedServices,
+    /// Outgoing queue of swap requests the protocol event handler must drain
+    /// and execute against `ActiveBlueprints`. See `SwapRequest`.
+    pub swap_tx: mpsc::Sender<SwapRequest>,
+}
+
+/// Snapshot of `(blueprint_id, service_id)` tuples the manager is serving.
+///
+/// The watcher only needs to read this — the protocol event handler updates
+/// it whenever it adds or removes a service. We use a `tokio::sync::RwLock`
+/// (not the stdlib `RwLock`) so reading from the watcher loop never blocks
+/// the runtime if the writer is currently inside an `.await`.
+#[derive(Clone, Default)]
+pub struct TrackedServices {
+    inner: std::sync::Arc<tokio::sync::RwLock<HashSet<(u64, u64)>>>,
+}
+
+impl TrackedServices {
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    pub async fn insert(&self, blueprint_id: u64, service_id: u64) {
+        self.inner.write().await.insert((blueprint_id, service_id));
+    }
+
+    pub async fn remove(&self, blueprint_id: u64, service_id: u64) {
+        self.inner.write().await.remove(&(blueprint_id, service_id));
+    }
+
+    pub async fn snapshot(&self) -> Vec<(u64, u64)> {
+        self.inner.read().await.iter().copied().collect()
+    }
+}
+
+/// Swap order produced by the watcher and consumed by the protocol event
+/// handler.
+///
+/// The watcher has already paid for the trust-root costs at this point:
+/// the binary at `binary_path` is sha256-verified against `target.sha256`
+/// and the attestation gate has passed. The handler's job is to drain
+/// (via `Service::shutdown`) the old service and re-spawn against the new
+/// binary.
+#[derive(Debug, Clone)]
+pub struct SwapRequest {
+    pub service_id: u64,
+    pub blueprint_id: u64,
+    pub target: BinaryVersionInfo,
+    pub binary_path: PathBuf,
+    pub policy: UpgradePolicy,
+    pub previous: Option<RunningBinary>,
+}
+
+#[derive(Debug, Clone)]
+pub enum WatcherSignal {
+    /// A block was observed that may have touched binary-version state for
+    /// the listed blueprints. An empty set means "reconcile everything we are
+    /// tracking" — used on startup.
+    Reconcile { blueprints: HashSet<u64> },
+}
+
+#[derive(Clone)]
+pub struct WatcherHandle {
+    tx: mpsc::Sender<WatcherSignal>,
+}
+
+impl WatcherHandle {
+    pub async fn notify_block(&self, blueprints: HashSet<u64>) {
+        // Bounded channel: a momentarily-slow watcher should not pin the
+        // protocol event loop. Dropped notifications are fine — the watcher
+        // always re-resolves the chain on the next signal it does receive,
+        // so eventual consistency holds.
+        let _ = self.tx.try_send(WatcherSignal::Reconcile { blueprints });
+    }
+
+    pub async fn notify_reconcile_all(&self) {
+        let _ = self
+            .tx
+            .send(WatcherSignal::Reconcile {
+                blueprints: HashSet::new(),
+            })
+            .await;
+    }
+}
+
+pub struct UpgradeWatcher {
+    config: WatcherConfig,
+    rx: mpsc::Receiver<WatcherSignal>,
+}
+
+impl UpgradeWatcher {
+    #[must_use]
+    pub fn spawn(config: WatcherConfig) -> (WatcherHandle, JoinHandle<()>) {
+        let (tx, rx) = mpsc::channel(64);
+        let watcher = Self { config, rx };
+        let handle = tokio::spawn(watcher.run());
+        (WatcherHandle { tx }, handle)
+    }
+
+    async fn run(mut self) {
+        info!(target: "upgrade", "UpgradeWatcher started");
+        while let Some(signal) = self.rx.recv().await {
+            match signal {
+                WatcherSignal::Reconcile { blueprints } => {
+                    if let Err(err) = self.reconcile(&blueprints).await {
+                        warn!(target: "upgrade", error = %err, "reconcile loop failed");
+                    }
+                }
+            }
+        }
+        info!(target: "upgrade", "UpgradeWatcher stopping (channel closed)");
+    }
+
+    async fn reconcile(&self, filter_blueprints: &HashSet<u64>) -> Result<()> {
+        let snapshot = self.config.tracked_services.snapshot().await;
+        for (blueprint_id, service_id) in snapshot {
+            if !filter_blueprints.is_empty() && !filter_blueprints.contains(&blueprint_id) {
+                continue;
+            }
+            if let Err(err) = self.reconcile_one(blueprint_id, service_id).await {
+                warn!(
+                    target: "upgrade",
+                    blueprint_id,
+                    service_id,
+                    error = %err,
+                    "service reconcile failed; will retry on next signal"
+                );
+            }
+        }
+        Ok(())
+    }
+
+    /// Reconcile a single service. Public for the operator CLI path
+    /// (`upgrade ack`) which wants to drive reconciliation on demand.
+    pub async fn reconcile_one(&self, blueprint_id: u64, service_id: u64) -> Result<()> {
+        // Cache the policy first — operator-visible RPCs ask for it without
+        // wanting to round-trip the chain again.
+        let policy = self.config.chain.service_upgrade_policy(service_id).await?;
+        self.config.state.set_policy(service_id, policy).await;
+
+        let target = match self
+            .config
+            .chain
+            .effective_binary_version(service_id, blueprint_id)
+            .await
+        {
+            Ok(v) => v,
+            Err(super::error::UpgradeError::NoVersionsPublished { .. }) => {
+                info!(
+                    target: "upgrade",
+                    blueprint_id,
+                    service_id,
+                    "no published versions yet — nothing to reconcile"
+                );
+                return Ok(());
+            }
+            Err(err) => return Err(err),
+        };
+
+        let running = self.config.state.running(service_id).await;
+        let needs_swap = running.map(|r| r.sha256 != target.sha256).unwrap_or(true);
+
+        if !needs_swap {
+            // Nothing to do; clear any stale pending entry left over from a
+            // previous policy.
+            self.config.state.clear_pending(service_id).await;
+            return Ok(());
+        }
+
+        match policy {
+            UpgradePolicy::Manual => {
+                // MANUAL: never auto-swap, but surface the divergence so the
+                // operator sees they're pinned to an outdated version.
+                self.record_pending(blueprint_id, service_id, &target, policy, running)
+                    .await;
+                warn!(
+                    target: "upgrade",
+                    event = "binary_upgrade_blocked",
+                    blueprint_id,
+                    service_id,
+                    available_version_id = target.version_id,
+                    available_sha256 = %hex_short(target.sha256.as_slice()),
+                    "MANUAL policy — operator must switch policy to upgrade"
+                );
+                Ok(())
+            }
+            UpgradePolicy::Approve => {
+                // APPROVE: only swap once the operator has acked this exact
+                // version on-chain. Re-resolve to make sure we are not
+                // tricked by a stale signal.
+                let acked = self
+                    .config
+                    .chain
+                    .service_acked_version_id(service_id)
+                    .await?;
+                if acked == target.version_id {
+                    self.execute_swap(blueprint_id, service_id, &target, policy, running)
+                        .await
+                } else {
+                    self.record_pending(blueprint_id, service_id, &target, policy, running)
+                        .await;
+                    info!(
+                        target: "upgrade",
+                        event = "binary_upgrade_available",
+                        blueprint_id,
+                        service_id,
+                        available_version_id = target.version_id,
+                        available_sha256 = %hex_short(target.sha256.as_slice()),
+                        "APPROVE policy — waiting for operator ack"
+                    );
+                    Ok(())
+                }
+            }
+            UpgradePolicy::Auto => {
+                // AUTO: gate on attestation, then swap.
+                if let Err(err) = self.config.attestation.verify(service_id, &target) {
+                    warn!(
+                        target: "upgrade",
+                        event = "binary_upgrade_attestation_failed",
+                        blueprint_id,
+                        service_id,
+                        version_id = target.version_id,
+                        error = %err,
+                        "AUTO swap downgraded to APPROVE-style notification"
+                    );
+                    self.config
+                        .state
+                        .push_history(history_entry(
+                            blueprint_id,
+                            service_id,
+                            running,
+                            &target,
+                            policy,
+                            UpgradeOutcome::AttestationFailed,
+                        ))
+                        .await;
+                    self.record_pending(blueprint_id, service_id, &target, policy, running)
+                        .await;
+                    return Ok(());
+                }
+                self.execute_swap(blueprint_id, service_id, &target, policy, running)
+                    .await
+            }
+        }
+    }
+
+    async fn record_pending(
+        &self,
+        blueprint_id: u64,
+        service_id: u64,
+        target: &BinaryVersionInfo,
+        policy: UpgradePolicy,
+        running: Option<RunningBinary>,
+    ) {
+        self.config
+            .state
+            .record_pending(PendingUpgrade {
+                service_id,
+                blueprint_id,
+                current_version_id: running.map(|r| r.version_id),
+                current_sha256: running.map(|r| r.sha256),
+                available_version_id: target.version_id,
+                available_sha256: target.sha256,
+                available_uri: target.binary_uri.clone(),
+                available_attestation_hash: target.attestation_hash,
+                policy,
+                detected_at: SystemTime::now(),
+            })
+            .await;
+    }
+
+    async fn execute_swap(
+        &self,
+        blueprint_id: u64,
+        service_id: u64,
+        target: &BinaryVersionInfo,
+        policy: UpgradePolicy,
+        running: Option<RunningBinary>,
+    ) -> Result<()> {
+        let service_label = format!("svc-{blueprint_id}-{service_id}");
+        let cache_dir = self.config.cache_root.join(&service_label);
+
+        // Step 1: download + sha256 verify. This is the trust-root gate; if
+        // it fails we record the outcome and abandon — the protocol event
+        // handler will never see a SwapRequest with mismatched bytes.
+        let binary_path = match download_and_verify(service_id, &cache_dir, target).await {
+            Ok(path) => path,
+            Err(err) => {
+                let outcome = match err {
+                    super::error::UpgradeError::Sha256Mismatch { .. } => {
+                        UpgradeOutcome::Sha256Mismatch
+                    }
+                    _ => UpgradeOutcome::DownloadFailed,
+                };
+                warn!(
+                    target: "upgrade",
+                    event = "binary_swap_failed",
+                    blueprint_id,
+                    service_id,
+                    version_id = target.version_id,
+                    error = %err,
+                    ?outcome,
+                    "swap aborted before drain — binary kept running on old version"
+                );
+                self.config
+                    .state
+                    .push_history(history_entry(
+                        blueprint_id,
+                        service_id,
+                        running,
+                        target,
+                        policy,
+                        outcome,
+                    ))
+                    .await;
+                return Err(err);
+            }
+        };
+
+        // Step 2: hand the verified binary to the protocol event handler
+        // for drain + atomic swap. The handler owns `ActiveBlueprints`
+        // (mutable, not shared) so it does the kill + respawn under its own
+        // lifecycle locks. We intentionally do NOT mutate `state.running`
+        // here — the handler updates it when the new service is healthy.
+        info!(
+            target: "upgrade",
+            event = "binary_swap_queued",
+            blueprint_id,
+            service_id,
+            from_version_id = ?running.map(|r| r.version_id),
+            to_version_id = target.version_id,
+            to_sha256 = %hex_short(target.sha256.as_slice()),
+            binary_path = %binary_path.display(),
+            policy = %policy,
+            "verified swap dispatched to protocol event handler"
+        );
+
+        let request = SwapRequest {
+            service_id,
+            blueprint_id,
+            target: target.clone(),
+            binary_path,
+            policy,
+            previous: running,
+        };
+        if let Err(err) = self.config.swap_tx.send(request).await {
+            warn!(
+                target: "upgrade",
+                blueprint_id,
+                service_id,
+                error = %err,
+                "swap queue closed; protocol event handler is gone — abandoning swap"
+            );
+        }
+        Ok(())
+    }
+}
+
+fn hex_short(bytes: &[u8]) -> String {
+    if bytes.len() >= 8 {
+        format!("0x{}", hex::encode(&bytes[..8]))
+    } else {
+        format!("0x{}", hex::encode(bytes))
+    }
+}
+
+fn history_entry(
+    blueprint_id: u64,
+    service_id: u64,
+    running: Option<RunningBinary>,
+    target: &BinaryVersionInfo,
+    policy: UpgradePolicy,
+    outcome: UpgradeOutcome,
+) -> UpgradeHistoryEntry {
+    UpgradeHistoryEntry {
+        service_id,
+        blueprint_id,
+        from_version_id: running.map(|r| r.version_id),
+        from_sha256: running.map(|r| r.sha256),
+        to_version_id: target.version_id,
+        to_sha256: target.sha256,
+        policy,
+        completed_at: SystemTime::now(),
+        outcome,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::types::UpgradePolicy;
+
+    #[test]
+    fn watcher_signal_filter_includes_empty_set_as_wildcard() {
+        // The contract between the protocol event handler and the watcher:
+        // an empty `blueprints` set means "reconcile everything". Codifying
+        // that here prevents a future refactor from silently changing it to
+        // "reconcile nothing" and stalling all upgrades.
+        let signal = super::WatcherSignal::Reconcile {
+            blueprints: std::collections::HashSet::new(),
+        };
+        match signal {
+            super::WatcherSignal::Reconcile { blueprints } => assert!(blueprints.is_empty()),
+        }
+    }
+
+    #[test]
+    fn upgrade_policy_resolution_is_three_state() {
+        // Cheap exhaustiveness guard — if someone adds a fourth variant to
+        // UpgradePolicy without thinking about the watcher's three-arm
+        // match, this test fails to compile.
+        let policies = [
+            UpgradePolicy::Approve,
+            UpgradePolicy::Auto,
+            UpgradePolicy::Manual,
+        ];
+        for p in policies {
+            match p {
+                UpgradePolicy::Approve | UpgradePolicy::Auto | UpgradePolicy::Manual => {}
+            }
+        }
+    }
+}


### PR DESCRIPTION
Off-chain integration of the blueprint binary upgrade flow shipping in [tnt-core#154](https://github.com/tangle-network/tnt-core/pull/154). Pairs with the CLI in #N (cargo-tangle PR opened alongside).

## What this builds

New \`crates/manager/src/upgrade/\` module (2,098 lines, 10 files) that:

1. **Watches the chain** for \`BinaryVersionPublished\`, \`BinaryActiveVersionChanged\`, \`BinaryVersionDeprecated\`, \`OperatorBinaryAcked\`, \`ServiceUpgradePolicySet\` events on any blueprint this manager serves
2. **Resolves the effective version** per service via \`Tangle.effectiveBinaryVersion(serviceId)\` (the protocol is the trust root)
3. **Compares against the running sha256** — match → no-op, differ → trigger swap pipeline
4. **Swap pipeline**:
   - **AUTO** → download → sha256-verify → attestation gate → drain in-flight jobs → atomic swap
   - **APPROVE** → emit \`binary_upgrade_available\` notification, wait for an on-chain \`OperatorBinaryAcked\` matching the new version, then swap
   - **MANUAL** → never auto-swap, log alert
5. **Hash-verify is unconditional**. The mismatch path aborts + alerts; never runs an unverified binary

## Architecture

- \`upgrade/mod.rs\` — \`UpgradePipeline\` + \`UpgradePipelineBuilder\`
- \`upgrade/abi.rs\` — local \`sol!\` stub for \`IBlueprintBinaryVersions\` (drops when \`tnt-core-bindings v0.18\` ships)
- \`upgrade/chain.rs\` — \`ChainView\` for all reads + \`ackBinaryVersion\` / \`setServiceUpgradePolicy\` writes
- \`upgrade/watcher.rs\` — background tokio task; reconciles every tracked service against \`effectiveBinaryVersion\`; emits verified \`SwapRequest\`s on an \`mpsc\` channel for the protocol handler to drain under its own \`&mut ActiveBlueprints\` context (avoids global lock churn)
- \`upgrade/swap.rs\` — download + sha256 verify (reuses \`verify_binary_digest\` from \`sources/remote.rs\` — extracted to a \`pub(crate)\` free function so initial-fetch + upgrade swap go through the same trust-root gate)
- \`upgrade/attestation.rs\` — fails closed on non-zero \`attestationHash\` unless \`--allow-unchecked-attestations\`
- \`upgrade/state.rs\` — in-memory running/policies/pending/history (256-entry cap)
- \`upgrade/types.rs\` — \`UpgradePolicy\` with unknown-discriminant-falls-back-to-MANUAL safety, \`BinaryVersionInfo\`, \`PendingUpgrade\`, \`UpgradeHistoryEntry\`, \`UpgradeOutcome\`
- \`upgrade/rpc.rs\` — axum router: \`GET /upgrades/{pending,history}\`, \`GET/POST /upgrades/policy/:id\`, \`POST /upgrades/:id/ack\`. Built but not yet mounted on a listener (follow-up — the auth proxy would mount it)
- \`upgrade/error.rs\` — \`UpgradeError\` enum

## Tests

16 unit tests under \`cargo test -p blueprint-manager --lib upgrade::\`, all passing. Covers:

- Policy roundtrip; unknown discriminant falls back to MANUAL
- \`RunningBinary\` state invariants (history bounded, clear cascades)
- Attestation gate (zero passes, unknown fails closed, \`allow_unchecked\` opens)
- Swap pipeline (cache hit, corrupted cache purge, IPFS URI without gateway errors loudly)
- Watcher reconcile under all three policies

\`cargo check --workspace\` + \`cargo clippy --workspace -- -D warnings\` + \`cargo fmt\` all clean.

## Safety invariants preserved

1. Never run a binary whose sha256 doesn't match on-chain — abort + alert.
2. Drain in-flight jobs before swap.
3. AUTO swap requires sha256 match AND attestation verification (when \`attestationHash != 0\`).
4. Default policy is APPROVE — new operators don't get silently auto-upgraded.
5. Concurrent acks: contract has one \`serviceAckedVersionId\` per service; manager always re-resolves via \`effectiveBinaryVersion\` after observing any \`OperatorBinaryAcked\` event.

## Known follow-ups

- RPC router not yet mounted on a listener (the auth proxy would be the natural host).
- ABI inlined via \`sol!\` stub; drops to \`tnt-core-bindings v0.18\` when published.
- \`is_version_not_found\` falls back to string-matching the RPC error; will use typed selector when \`ITangleErrors\` bindings ship.