### PR TITLE
fix(release): add missing description to incredible-squaring-blueprint-lib

### DIFF
--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
 version = "0.2.0-alpha.8"
+description = "Example Tangle blueprint demonstrating job processing across local/FaaS execution and single/multi-operator aggregation."
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary

Fixes the Release Plz failure on PR #1435's merge.

The release-plz run in #1435 was 2-for-3:

```
✓ blueprint-manager      0.4.0-alpha.8  — live
✓ cargo-tangle           0.5.0-alpha.8  — live
✗ incredible-squaring-blueprint-lib  0.2.0-alpha.8
    crates.io 400 Bad Request:
    "missing or empty metadata fields: description"
```

`incredible-squaring-blueprint-lib` was the only published example crate without a package-level `description`. Workspace inheritance (`[workspace.package]`) intentionally omits `description` so each crate owns its own, matching the convention used by `incredible-squaring-eigenlayer`, `hello-tangle`, `apikey-blueprint-lib`, and `oauth-blueprint-lib`.

## After merge

The `0.2.0-alpha.8` version is still reservable — crates.io rejected at the metadata-validation stage before accepting the upload, so the version number isn't burned. Re-trigger Release Plz with:

```
gh workflow run "Release Plz" --ref main
```

…and the publish should land on the first try.

## Test plan

- [x] TOML parses (`description` resolves at the package level, `license` still inherits from workspace)
- [ ] After merge, re-run Release Plz and confirm `incredible-squaring-blueprint-lib v0.2.0-alpha.8` lands on crates.io