### PR TITLE
chore(release): bump incredible-squaring-blueprint-lib to 0.2.0-alpha.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -153,7 +153,7 @@ blueprint-faas = { version = "0.2.0-alpha.5", path = "./crates/blueprint-faas", 
 blueprint-profiling = { version = "0.2.0-alpha.4", path = "./crates/blueprint-profiling", default-features = false }
 
 # Example blueprints
-incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.8", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
+incredible-squaring-blueprint-lib = { version = "0.2.0-alpha.9", path = "./examples/incredible-squaring/incredible-squaring-lib", default-features = false }
 blueprint-build-utils = { version = "0.2.0-alpha.5", path = "./crates/build-utils", default-features = false }
 blueprint-auth = { version = "0.2.0-alpha.7", path = "./crates/auth", default-features = false }
 

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,6 +1,7 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
 version = "0.2.0-alpha.8"
+description = "Example Tangle blueprint demonstrating job processing across local/FaaS execution and single/multi-operator aggregation."
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true

--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "incredible-squaring-blueprint-lib"
-version = "0.2.0-alpha.8"
+version = "0.2.0-alpha.9"
 description = "Example Tangle blueprint demonstrating job processing across local/FaaS execution and single/multi-operator aggregation."
 edition.workspace = true
 license.workspace = true


### PR DESCRIPTION
## Why a manual bump

release-plz tagged `incredible-squaring-blueprint-lib-v0.2.0-alpha.5/6/7/8` but cargo publish failed silently for **four consecutive releases** on a missing `description` metadata field. crates.io still has `0.2.0-alpha.4` as the latest live version.

PR #1436 fixed the description. But on the post-merge Release Plz run, release-plz saw the existing `v0.2.0-alpha.8` tag and skipped:

```
INFO incredible-squaring-blueprint-lib 0.2.0-alpha.8:
     Already published - Tag incredible-squaring-blueprint-lib-v0.2.0-alpha.8 already exists
```

…so the stuck version is permanently skipped.

## Fix

Bump to `0.2.0-alpha.9` (plus the workspace-dep pin for internal honesty). On merge:

1. Release Plz sees a tag-less version
2. Creates `incredible-squaring-blueprint-lib-v0.2.0-alpha.9`
3. `cargo publish` lands (description now present)
4. crates.io catches up

## Test plan

- [x] No external consumers (the only reverse dep is `incredible-squaring-blueprint-bin` which has `publish = false`)
- [ ] After merge, watch Release Plz → confirm crates.io shows `0.2.0-alpha.9`