### PR TITLE
chore(qos): bump to 0.2.0-alpha.9 to release OTLP trace export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3710,7 +3710,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-qos"
-version = "0.2.0-alpha.8"
+version = "0.2.0-alpha.9"
 dependencies = [
  "alloy-network 1.8.3",
  "alloy-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -196,7 +196,7 @@ blueprint-macros = { version = "0.2.0-alpha.4", path = "./crates/macros", defaul
 blueprint-context-derive = { version = "0.2.0-alpha.4", path = "./crates/macros/context-derive", default-features = false }
 
 # Quality of Service
-blueprint-qos = { version = "0.2.0-alpha.8", path = "./crates/qos", default-features = false }
+blueprint-qos = { version = "0.2.0-alpha.9", path = "./crates/qos", default-features = false }
 
 # Stores
 blueprint-stores = { version = "0.2.0-alpha.5", path = "./crates/stores", default-features = false }

--- a/crates/qos/Cargo.toml
+++ b/crates/qos/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-qos"
-version = "0.2.0-alpha.8"
+version = "0.2.0-alpha.9"
 description = "Quality of Service (QoS) module for Blueprint SDK"
 authors.workspace = true
 edition.workspace = true


### PR DESCRIPTION
## Summary

Bumps `blueprint-qos` (and its workspace dependency entry) from `0.2.0-alpha.8` to `0.2.0-alpha.9` so the OTLP/HTTP-JSON trace exporter added in #1443 can be released to crates.io. #1443 merged under alpha.8, but alpha.8 was already published (pre-OTLP), so the new code needs a fresh version. release-plz cascades the dependent crates (sdk/runner/manager) on merge.

## Change Class

- Selected class: Class B
- Why this class: Local blast radius. Version-only bump of one crate + its workspace dependency entry; no code or API changes. Builds verified locally.

## Behavior Contract

- Current behavior: the OTLP exporter code is on `main` but unreleasable — its crate version (alpha.8) is already on crates.io without the exporter.
- Intended behavior: qos at alpha.9 carrying the exporter is publishable; consumers can pull the OTLP trace export.
- Invariants that must hold: workspace builds with qos at alpha.9 (path dep); dependents using `{ workspace = true }` resolve to alpha.9.
- Failure mode: not applicable — version metadata change only; no runtime path affected.

## Risk and Scope

- Security impact: none — version bump only.
- Compatibility impact: additive — a new crates.io version; existing published alpha.8 consumers are unaffected.
- Migration notes: none.
- Rollback plan: revert the bump commit; nothing is published until the separate publish-crates workflow runs.

## Verification

- Reproducer: `cargo check -p blueprint-qos` resolves and builds with the bumped version.
- Negative-path coverage: not applicable for a version-only change.
- Key assertions that prove the fix: qos package version and the workspace dependency entry both read 0.2.0-alpha.9; the workspace compiles.

## Harness Evidence

```
cargo check -p blueprint-qos
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Checklist

- [x] qos package version + workspace dependency entry bumped to alpha.9
- [x] `cargo check -p blueprint-qos` passes
- [x] No code/API changes (version metadata only)
