### PR TITLE
chore(deps): batch safe patch bumps (metrics, libc)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8667,9 +8667,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.185"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ff2c0fe9bc6cb6b14a0592c2ff4fa9ceb83eea9db979b0487cd054946a2b8f"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
@@ -9606,12 +9606,12 @@ dependencies = [
 
 [[package]]
 name = "metrics"
-version = "0.24.3"
+version = "0.24.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d5312e9ba3771cfa961b585728215e3d972c950a3eed9252aa093d6301277e8"
+checksum = "89550ee9f79e88fef3119de263694973a8adb26c21d75322164fb8c493039fe2"
 dependencies = [
- "ahash 0.8.12",
  "portable-atomic",
+ "rapidhash",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -367,7 +367,7 @@ chrono = { version = "0.4", default-features = false }
 # System & OS
 sysinfo = { version = "0.38.0", default-features = false }
 num_cpus = { version = "1.17", default-features = false }
-libc = { version = "0.2.175", default-features = false }
+libc = { version = "0.2.186", default-features = false }
 
 # gRPC & Protocol Buffers
 tonic = { version = "0.13.1", default-features = false, features = ["tls-webpki-roots"] }
@@ -449,7 +449,7 @@ rust-bls-bn254 = { version = "0.2.1", default-features = false }
 testcontainers = { version = "0.23.1", default-features = false }
 
 # Metrics
-metrics = { version = "0.24.2", default-features = false }
+metrics = { version = "0.24.6", default-features = false }
 
 # x402 protocol
 x402-types = { version = "1", default-features = false }


### PR DESCRIPTION
## Summary

Batches the two safe dependabot patch bumps into one PR: `metrics` 0.24.2→0.24.6 (#1438) and `libc` 0.2.175→0.2.186 (#1439). Excludes three dependabot PRs that are not safe standalone bumps (see below).

## Change Class

- Selected class: Class B
- Why this class: Local blast radius. Two patch-level dependency bumps of API-stable crates; no code changes.

## Behavior Contract

- Current behavior: workspace pins `metrics` 0.24.2 and `libc` 0.2.175.
- Intended behavior: pins move to 0.24.6 / 0.2.186 (patch updates, no API change).
- Invariants that must hold: workspace resolves and compiles with the bumped versions.
- Failure mode: not applicable — patch dependency bumps only.

## Risk and Scope

- Security impact: positive — patch updates include upstream fixes.
- Compatibility impact: none — patch-level semver, API-stable.
- Migration notes: none.
- Rollback plan: revert this commit.

Excluded dependabot PRs (closed with rationale, not merged here):
- #1442 alloy-rpc-types-eth 1.8→2.0: major bump; bumping one alloy crate mixes alloy 1.x/2.x types. Needs a coordinated alloy-2.0 migration, tracked separately.
- #1440 opentelemetry_sdk 0.29→0.31 and #1441 opentelemetry-semantic-conventions 0.29→0.32: break the 0.29 metrics path (opentelemetry-prometheus 0.29 requires sdk 0.29). The trace path already runs 0.31 via renamed deps (opentelemetry-031) from #1443.

## Verification

- Reproducer: `cargo update -p metrics -p libc` resolves cleanly; `cargo check -p blueprint-qos` (a metrics consumer) compiles.
- Negative-path coverage: not applicable for patch bumps.
- Key assertions that prove the fix: Cargo.lock shows libc 0.2.186 and metrics 0.24.6; blueprint-qos builds.

## Harness Evidence

```
cargo check -p blueprint-qos
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## Checklist

- [x] metrics and libc bumped in Cargo.toml + Cargo.lock
- [x] blueprint-qos compiles with the bumps
- [x] Incompatible dependabot PRs identified for closure (not merged)
