### PR TITLE
fix(manager): make upgrade-swap arch-aware via binary manifest

### DIFF
--- a/crates/manager/src/blueprint/native.rs
+++ b/crates/manager/src/blueprint/native.rs
@@ -30,7 +30,14 @@ pub fn get_blueprint_binary(blueprint_binaries: &[BlueprintBinary]) -> Option<&B
     None
 }
 
-fn normalize_arch(value: &str) -> String {
+/// Canonicalize an architecture identifier so values published by tooling
+/// (`amd64`, `arm64`, …) compare equal to Rust's `std::env::consts::ARCH`
+/// (`x86_64`, `aarch64`, …).
+///
+/// Shared by the initial-fetch path and the upgrade-swap manifest resolver so
+/// the two never drift — a divergence would let one path match a binary the
+/// other rejects.
+pub(crate) fn normalize_arch(value: &str) -> String {
     match value.to_lowercase().as_str() {
         "amd" => "x86".to_string(),
         "amd64" => "x86_64".to_string(),
@@ -39,7 +46,10 @@ fn normalize_arch(value: &str) -> String {
     }
 }
 
-fn normalize_os(value: &str) -> String {
+/// Canonicalize an OS identifier (`darwin`/`osx` → `macos`, target-triple
+/// fragments like `unknown-linux-gnu` → `linux`, …). See [`normalize_arch`]
+/// for why this is shared.
+pub(crate) fn normalize_os(value: &str) -> String {
     let lower = value.to_lowercase();
     if lower.contains("darwin") || lower.contains("macos") || lower == "mac" || lower == "osx" {
         "macos".to_string()

--- a/crates/manager/src/sources/manifest.rs
+++ b/crates/manager/src/sources/manifest.rs
@@ -1,0 +1,326 @@
+//! Architecture-aware binary manifest.
+//!
+//! An on-chain `BinaryVersion` carries a single `binaryUri` + single `sha256`.
+//! That is fine for a single-arch raw tarball, but an operator fleet spans
+//! `x86_64` and `aarch64` — a literal fetch hands an aarch64 box an x86_64
+//! binary. To stay backward compatible while fixing that, the manager treats
+//! `binaryUri` as one of two things:
+//!
+//!   * a **manifest** (this module): a small JSON document, itself pinned by
+//!     the on-chain `sha256`, that lists one download per `(os, arch)`. The
+//!     manager verifies the manifest bytes against the on-chain hash, selects
+//!     the entry for the current platform, then verifies the downloaded asset
+//!     against that entry's own `sha256` (+ optional `blake3`).
+//!   * a **raw binary/tarball** (legacy): fetched literally and verified
+//!     against the on-chain `sha256`, exactly as before.
+//!
+//! Platform matching reuses [`normalize_os`]/[`normalize_arch`] from the
+//! initial-fetch path so the two resolvers can never select different
+//! binaries for the same host.
+
+use crate::blueprint::native::{normalize_arch, normalize_os};
+use crate::error::Error;
+use crate::sdk::utils::get_formatted_os_string;
+use serde::Deserialize;
+
+/// Schema discriminator embedded in every manifest. Bumping the version is a
+/// wire-protocol change: old managers must reject documents they don't
+/// understand rather than guess.
+pub const MANIFEST_SCHEMA_V1: &str = "tangle-binary-manifest/v1";
+
+/// Architecture-aware binary manifest, version 1.
+///
+/// Deserialized from the bytes referenced by an on-chain `binaryUri`. The
+/// `schema` field is validated on parse; unknown values are rejected.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct BinaryManifest {
+    /// Must equal [`MANIFEST_SCHEMA_V1`].
+    pub schema: String,
+    /// One entry per supported `(os, arch)`. Order is not significant.
+    pub binaries: Vec<ManifestBinary>,
+}
+
+/// A single per-platform download within a [`BinaryManifest`].
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+pub struct ManifestBinary {
+    /// OS identifier (e.g. `linux`, `macos`). Compared via [`normalize_os`].
+    pub os: String,
+    /// Architecture identifier (e.g. `x86_64`, `aarch64`). Compared via
+    /// [`normalize_arch`].
+    pub arch: String,
+    /// Fully-qualified download URL for this platform's artifact. May use the
+    /// `ipfs://` scheme; the caller resolves it through the configured gateway.
+    pub url: String,
+    /// Hex-encoded (no `0x`) sha256 of the artifact at `url`. Required — the
+    /// per-asset digest is the trust root once the manifest itself is pinned.
+    pub sha256: String,
+    /// Optional hex-encoded blake3 of the artifact, verified in addition to
+    /// sha256 when present.
+    #[serde(default)]
+    pub blake3: Option<String>,
+}
+
+impl ManifestBinary {
+    /// Decode `sha256` into a 32-byte array.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Other` if the field is not 32 bytes of hex.
+    pub fn sha256_bytes(&self) -> Result<[u8; 32], Error> {
+        decode_hex32(&self.sha256, "sha256")
+    }
+
+    /// Decode the optional `blake3` field into a 32-byte array.
+    ///
+    /// # Errors
+    ///
+    /// `Error::Other` if the field is present but not 32 bytes of hex.
+    pub fn blake3_bytes(&self) -> Result<Option<[u8; 32]>, Error> {
+        match &self.blake3 {
+            Some(hex) => Ok(Some(decode_hex32(hex, "blake3")?)),
+            None => Ok(None),
+        }
+    }
+}
+
+/// Heuristic used to decide whether to treat a `binaryUri` as a manifest based
+/// on its path alone (before any bytes are fetched). A `.json` suffix is the
+/// publish convention; bytes that parse as a manifest are the authoritative
+/// signal handled separately by [`parse_manifest`].
+#[must_use]
+pub fn uri_looks_like_manifest(uri: &str) -> bool {
+    // Strip any query/fragment before checking the extension so
+    // `…/manifest.json?token=…` still resolves as a manifest.
+    let path = uri.split(['?', '#']).next().unwrap_or(uri);
+    path.trim_end_matches('/')
+        .rsplit('/')
+        .next()
+        .is_some_and(|name| name.to_ascii_lowercase().ends_with(".json"))
+}
+
+/// Parse and validate manifest bytes.
+///
+/// # Errors
+///
+/// * `Error::Serialization` if the bytes are not valid JSON of the expected
+///   shape.
+/// * `Error::Other` if the `schema` field is not [`MANIFEST_SCHEMA_V1`], or if
+///   the manifest lists zero binaries.
+pub fn parse_manifest(bytes: &[u8]) -> Result<BinaryManifest, Error> {
+    let manifest: BinaryManifest = serde_json::from_slice(bytes)?;
+    if manifest.schema != MANIFEST_SCHEMA_V1 {
+        return Err(Error::Other(format!(
+            "unsupported binary manifest schema `{}` (expected `{MANIFEST_SCHEMA_V1}`)",
+            manifest.schema
+        )));
+    }
+    if manifest.binaries.is_empty() {
+        return Err(Error::Other(
+            "binary manifest lists no binaries".to_string(),
+        ));
+    }
+    Ok(manifest)
+}
+
+/// Best-effort detection: do these bytes parse as a valid v1 manifest?
+///
+/// Used to disambiguate the case where a `binaryUri` does not end in `.json`
+/// but nonetheless points at a manifest (e.g. an IPFS CID). A raw tarball is
+/// not valid UTF-8 JSON, so this is false for the legacy path.
+#[must_use]
+pub fn bytes_are_manifest(bytes: &[u8]) -> bool {
+    parse_manifest(bytes).is_ok()
+}
+
+/// Select the manifest entry matching the host the manager is running on.
+///
+/// Returns `None` when no entry matches — the caller MUST abort (never run a
+/// foreign-arch binary) rather than fall back to an arbitrary entry.
+#[must_use]
+pub fn select_for_current_platform(manifest: &BinaryManifest) -> Option<&ManifestBinary> {
+    let host_os = normalize_os(&get_formatted_os_string());
+    let host_arch = normalize_arch(std::env::consts::ARCH);
+    manifest.binaries.iter().find(|binary| {
+        normalize_os(&binary.os) == host_os && normalize_arch(&binary.arch) == host_arch
+    })
+}
+
+fn decode_hex32(value: &str, field: &str) -> Result<[u8; 32], Error> {
+    let trimmed = value.strip_prefix("0x").unwrap_or(value);
+    let bytes = hex::decode(trimmed)
+        .map_err(|err| Error::Other(format!("manifest `{field}` is not valid hex: {err}")))?;
+    let array: [u8; 32] = bytes.try_into().map_err(|bytes: Vec<u8>| {
+        Error::Other(format!(
+            "manifest `{field}` must be 32 bytes, got {}",
+            bytes.len()
+        ))
+    })?;
+    Ok(array)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn manifest_json() -> String {
+        format!(
+            r#"{{
+              "schema": "{MANIFEST_SCHEMA_V1}",
+              "binaries": [
+                {{ "os": "linux", "arch": "x86_64",
+                   "url": "https://x/a-x86_64-unknown-linux-gnu.tar.xz",
+                   "sha256": "{}" }},
+                {{ "os": "linux", "arch": "aarch64",
+                   "url": "https://x/a-aarch64-unknown-linux-gnu.tar.xz",
+                   "sha256": "{}", "blake3": "{}" }},
+                {{ "os": "macos", "arch": "aarch64",
+                   "url": "https://x/a-aarch64-apple-darwin.tar.xz",
+                   "sha256": "{}" }}
+              ]
+            }}"#,
+            hex::encode([0x11u8; 32]),
+            hex::encode([0x22u8; 32]),
+            hex::encode([0x33u8; 32]),
+            hex::encode([0x44u8; 32]),
+        )
+    }
+
+    #[test]
+    fn parses_v1_and_decodes_digests() {
+        let manifest = parse_manifest(manifest_json().as_bytes()).unwrap();
+        assert_eq!(manifest.schema, MANIFEST_SCHEMA_V1);
+        assert_eq!(manifest.binaries.len(), 3);
+        assert_eq!(manifest.binaries[0].sha256_bytes().unwrap(), [0x11u8; 32]);
+        assert_eq!(manifest.binaries[0].blake3_bytes().unwrap(), None);
+        assert_eq!(manifest.binaries[1].sha256_bytes().unwrap(), [0x22u8; 32]);
+        assert_eq!(
+            manifest.binaries[1].blake3_bytes().unwrap(),
+            Some([0x33u8; 32])
+        );
+    }
+
+    #[test]
+    fn rejects_unknown_schema() {
+        // A future schema version must hard-fail on an old manager rather than
+        // be silently misinterpreted as v1.
+        let bad = r#"{"schema":"tangle-binary-manifest/v2","binaries":[]}"#;
+        let err = parse_manifest(bad.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::Other(msg) if msg.contains("unsupported")));
+    }
+
+    #[test]
+    fn rejects_empty_binaries() {
+        let bad = format!(r#"{{"schema":"{MANIFEST_SCHEMA_V1}","binaries":[]}}"#);
+        let err = parse_manifest(bad.as_bytes()).unwrap_err();
+        assert!(matches!(err, Error::Other(msg) if msg.contains("no binaries")));
+    }
+
+    #[test]
+    fn raw_tarball_bytes_are_not_a_manifest() {
+        // The legacy detection path: arbitrary binary bytes must never be
+        // mistaken for a manifest.
+        assert!(!bytes_are_manifest(&[0xde, 0xad, 0xbe, 0xef, 0x00, 0x1f]));
+        assert!(!bytes_are_manifest(b"#!/bin/sh\necho hi\n"));
+    }
+
+    #[test]
+    fn uri_suffix_detection() {
+        assert!(uri_looks_like_manifest("https://x/manifest.json"));
+        assert!(uri_looks_like_manifest("https://x/MANIFEST.JSON"));
+        assert!(uri_looks_like_manifest("https://x/m.json?token=abc"));
+        assert!(uri_looks_like_manifest("ipfs://Qm.../binary.json"));
+        assert!(!uri_looks_like_manifest("https://x/binary.tar.xz"));
+        assert!(!uri_looks_like_manifest("ipfs://Qmraw"));
+    }
+
+    #[test]
+    fn invalid_hex_digest_is_rejected() {
+        let bad = format!(
+            r#"{{"schema":"{MANIFEST_SCHEMA_V1}","binaries":[
+                {{"os":"linux","arch":"x86_64","url":"https://x/a","sha256":"zz"}}]}}"#
+        );
+        let manifest = parse_manifest(bad.as_bytes()).unwrap();
+        assert!(manifest.binaries[0].sha256_bytes().is_err());
+    }
+
+    #[test]
+    fn selects_entry_for_current_platform() {
+        // Build a manifest that always contains an entry for whatever host the
+        // test runs on, plus a decoy for a different arch. Selection must pick
+        // the host entry, proving the resolver is arch-aware (the bug fix).
+        let host_arch = std::env::consts::ARCH;
+        let decoy_arch = if host_arch == "x86_64" {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
+        let host_os = normalize_os(&get_formatted_os_string());
+        let manifest = BinaryManifest {
+            schema: MANIFEST_SCHEMA_V1.to_string(),
+            binaries: vec![
+                ManifestBinary {
+                    os: host_os.clone(),
+                    arch: decoy_arch.to_string(),
+                    url: "https://x/decoy".to_string(),
+                    sha256: hex::encode([0x01u8; 32]),
+                    blake3: None,
+                },
+                ManifestBinary {
+                    os: host_os.clone(),
+                    arch: host_arch.to_string(),
+                    url: "https://x/host".to_string(),
+                    sha256: hex::encode([0x02u8; 32]),
+                    blake3: None,
+                },
+            ],
+        };
+        let selected = select_for_current_platform(&manifest).expect("host entry must match");
+        assert_eq!(selected.url, "https://x/host");
+        assert_eq!(normalize_arch(&selected.arch), normalize_arch(host_arch));
+    }
+
+    #[test]
+    fn no_match_when_arch_absent() {
+        // No entry for the host arch → None → caller aborts. This is the
+        // "never run a foreign-arch binary" invariant.
+        let decoy_arch = if std::env::consts::ARCH == "x86_64" {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
+        let manifest = BinaryManifest {
+            schema: MANIFEST_SCHEMA_V1.to_string(),
+            binaries: vec![ManifestBinary {
+                os: normalize_os(&get_formatted_os_string()),
+                arch: decoy_arch.to_string(),
+                url: "https://x/decoy".to_string(),
+                sha256: hex::encode([0x01u8; 32]),
+                blake3: None,
+            }],
+        };
+        assert!(select_for_current_platform(&manifest).is_none());
+    }
+
+    #[test]
+    fn arch_aliases_match() {
+        // amd64 / arm64 aliases must normalize to the Rust arch names so a
+        // manifest published by foreign tooling still resolves.
+        let host_os = normalize_os(&get_formatted_os_string());
+        let (alias, _canonical) = match std::env::consts::ARCH {
+            "x86_64" => ("amd64", "x86_64"),
+            "aarch64" => ("arm64", "aarch64"),
+            other => (other, other),
+        };
+        let manifest = BinaryManifest {
+            schema: MANIFEST_SCHEMA_V1.to_string(),
+            binaries: vec![ManifestBinary {
+                os: host_os,
+                arch: alias.to_string(),
+                url: "https://x/aliased".to_string(),
+                sha256: hex::encode([0x05u8; 32]),
+                blake3: None,
+            }],
+        };
+        assert!(select_for_current_platform(&manifest).is_some());
+    }
+}

--- a/crates/manager/src/sources/mod.rs
+++ b/crates/manager/src/sources/mod.rs
@@ -13,6 +13,7 @@ use url::Url;
 #[cfg(feature = "containers")]
 pub mod container;
 pub mod github;
+pub mod manifest;
 pub mod remote;
 pub mod testing;
 pub mod types;

--- a/crates/manager/src/upgrade/swap.rs
+++ b/crates/manager/src/upgrade/swap.rs
@@ -23,6 +23,9 @@ use super::error::{Result, UpgradeError};
 use super::types::BinaryVersionInfo;
 use crate::error::Error as ManagerError;
 use crate::sdk::utils::make_executable;
+use crate::sources::manifest::{
+    bytes_are_manifest, parse_manifest, select_for_current_platform, uri_looks_like_manifest,
+};
 use crate::sources::remote::verify_binary_digest;
 use blueprint_core::{info, warn};
 use reqwest::Client;
@@ -51,57 +54,167 @@ pub async fn download_and_verify(
 ) -> Result<PathBuf> {
     fs::create_dir_all(cache_dir).await?;
 
+    // Cache key includes the host arch so an `x86_64` artifact and an
+    // `aarch64` artifact published under the same on-chain (versionId, sha256)
+    // never collide on a shared cache dir. Legacy raw-URI swaps inherit the
+    // same suffix harmlessly.
     let dest = cache_dir.join(format!(
-        "binary-v{}-{}",
+        "binary-v{}-{}-{}",
         version.version_id,
+        std::env::consts::ARCH,
         hex::encode(&version.sha256.as_slice()[..8])
     ));
 
-    // Idempotency: if a previous swap attempt already cached + verified this
-    // exact (versionId, sha256), skip the download.
-    if fs::try_exists(&dest).await.unwrap_or(false) {
-        let sha = version.sha256.0;
-        if verify_binary_digest(&dest, &sha, None).is_ok() {
-            info!(
-                target: "upgrade",
-                service_id,
-                version_id = version.version_id,
-                "binary cache hit; reusing verified copy"
-            );
-            return Ok(make_executable(&dest)?);
-        }
-        // Stale cache (sha drift or partial write) — drop it and re-download.
-        let _ = fs::remove_file(&dest).await;
-    }
-
-    let url = resolve_url(&version.binary_uri)?;
     let max_bytes = std::env::var(MAX_BINARY_BYTES_ENV)
         .ok()
         .and_then(|v| v.parse::<u64>().ok())
         .filter(|v| *v > 0)
         .unwrap_or(DEFAULT_MAX_BINARY_BYTES);
 
+    // Idempotency: a previously cached + verified artifact for this platform is
+    // reused after a recheck. Manifest mode caches the per-asset bytes, so the
+    // recheck digest differs by mode: raw mode rechecks against the on-chain
+    // sha256, manifest mode cannot know the asset digest without re-reading the
+    // manifest, so it always re-resolves (cheap) before trusting the cache.
+    if fs::try_exists(&dest).await.unwrap_or(false) {
+        let manifest_mode = uri_looks_like_manifest(&version.binary_uri);
+        if !manifest_mode {
+            let sha = version.sha256.0;
+            if verify_binary_digest(&dest, &sha, None).is_ok() {
+                info!(
+                    target: "upgrade",
+                    service_id,
+                    version_id = version.version_id,
+                    "binary cache hit; reusing verified copy"
+                );
+                return Ok(make_executable(&dest)?);
+            }
+        }
+        // Stale cache (sha drift, partial write, or manifest-mode re-resolve) —
+        // drop it and go through the full download+verify path again.
+        let _ = fs::remove_file(&dest).await;
+    }
+
+    let url = resolve_url(&version.binary_uri)?;
     let temp_path = dest.with_extension("part");
     download(&url, &temp_path, max_bytes).await?;
 
-    let sha = version.sha256.0;
-    if let Err(err) = verify_binary_digest(&temp_path, &sha, None) {
+    // Decide path: the URI suffix is a hint, the parsed bytes are authoritative.
+    let downloaded = fs::read(&temp_path).await?;
+    let is_manifest =
+        uri_looks_like_manifest(&version.binary_uri) || bytes_are_manifest(&downloaded);
+
+    if is_manifest {
+        let result = swap_via_manifest(
+            service_id,
+            cache_dir,
+            version,
+            &temp_path,
+            &downloaded,
+            &dest,
+            max_bytes,
+        )
+        .await;
+        // The manifest itself was downloaded to `temp_path`; the resolved asset
+        // lands at `dest`. Always purge the manifest temp file.
         let _ = fs::remove_file(&temp_path).await;
-        match err {
-            ManagerError::HashMismatch { expected, actual } => {
-                return Err(UpgradeError::Sha256Mismatch {
-                    service_id,
-                    version_id: version.version_id,
-                    expected,
-                    actual,
-                });
-            }
-            other => return Err(UpgradeError::Manager(other)),
-        }
+        return result;
     }
 
+    // Legacy/raw mode: verify the literal download against the on-chain sha256.
+    verify_against_onchain(service_id, version, &temp_path).await?;
     fs::rename(&temp_path, &dest).await?;
     Ok(make_executable(&dest)?)
+}
+
+/// Manifest-mode resolution: pin the manifest against the on-chain sha256,
+/// select this host's entry, download + digest-verify that entry's artifact.
+///
+/// `manifest_path` holds the already-downloaded manifest bytes (also passed as
+/// `manifest_bytes` to avoid a re-read); `dest` is the final cache path for the
+/// resolved per-platform artifact.
+async fn swap_via_manifest(
+    service_id: u64,
+    cache_dir: &Path,
+    version: &BinaryVersionInfo,
+    manifest_path: &Path,
+    manifest_bytes: &[u8],
+    dest: &Path,
+    max_bytes: u64,
+) -> Result<PathBuf> {
+    // (1) Manifest integrity: the manifest bytes MUST hash to the on-chain
+    // sha256. This is the trust root — a tampered manifest could redirect to a
+    // malicious asset, so it is gated exactly like a raw binary.
+    verify_against_onchain(service_id, version, manifest_path).await?;
+
+    // (2) Parse + select this platform's entry. Parse failure or no arch match
+    // aborts; we never run a foreign-arch (or unparseable) artifact.
+    let manifest = parse_manifest(manifest_bytes).map_err(UpgradeError::Manager)?;
+    let entry = select_for_current_platform(&manifest).ok_or_else(|| {
+        UpgradeError::Manager(ManagerError::Other(format!(
+            "binary manifest for service {service_id} version {} has no entry for {}/{}",
+            version.version_id,
+            std::env::consts::OS,
+            std::env::consts::ARCH,
+        )))
+    })?;
+
+    // (3) Download the selected artifact and verify against the manifest
+    // entry's own sha256 (+ blake3 if present).
+    let asset_url = resolve_url(&entry.url)?;
+    let asset_tmp = cache_dir.join(format!(
+        "binary-v{}-{}-asset.part",
+        version.version_id,
+        std::env::consts::ARCH
+    ));
+    download(&asset_url, &asset_tmp, max_bytes).await?;
+
+    let expected_sha = entry.sha256_bytes().map_err(UpgradeError::Manager)?;
+    let expected_blake3 = entry.blake3_bytes().map_err(UpgradeError::Manager)?;
+    if let Err(err) = verify_binary_digest(&asset_tmp, &expected_sha, expected_blake3.as_ref()) {
+        let _ = fs::remove_file(&asset_tmp).await;
+        return Err(map_digest_error(service_id, version.version_id, err));
+    }
+
+    fs::rename(&asset_tmp, dest).await?;
+    info!(
+        target: "upgrade",
+        service_id,
+        version_id = version.version_id,
+        arch = std::env::consts::ARCH,
+        "resolved binary via manifest; per-asset digest verified"
+    );
+    Ok(make_executable(dest)?)
+}
+
+/// Verify a downloaded file against the on-chain `version.sha256`. Used for the
+/// legacy raw binary and for manifest integrity. On mismatch the temp file is
+/// purged and a `Sha256Mismatch` is returned; never leaves an unverified file.
+async fn verify_against_onchain(
+    service_id: u64,
+    version: &BinaryVersionInfo,
+    path: &Path,
+) -> Result<()> {
+    let sha = version.sha256.0;
+    if let Err(err) = verify_binary_digest(path, &sha, None) {
+        let _ = fs::remove_file(path).await;
+        return Err(map_digest_error(service_id, version.version_id, err));
+    }
+    Ok(())
+}
+
+/// Map a digest-layer `HashMismatch` onto the upgrade-specific
+/// `Sha256Mismatch` variant; pass everything else through unchanged.
+fn map_digest_error(service_id: u64, version_id: u64, err: ManagerError) -> UpgradeError {
+    match err {
+        ManagerError::HashMismatch { expected, actual } => UpgradeError::Sha256Mismatch {
+            service_id,
+            version_id,
+            expected,
+            actual,
+        },
+        other => UpgradeError::Manager(other),
+    }
 }
 
 fn resolve_url(raw: &str) -> Result<Url> {
@@ -227,8 +340,9 @@ mod tests {
         let payload = b"hello-world-blueprint-bytes";
         let version = version_for(payload);
         let cached = dir.path().join(format!(
-            "binary-v{}-{}",
+            "binary-v{}-{}-{}",
             version.version_id,
+            std::env::consts::ARCH,
             hex::encode(&version.sha256.as_slice()[..8])
         ));
         tokio::fs::write(&cached, payload).await.unwrap();
@@ -247,8 +361,9 @@ mod tests {
         let payload = b"hello-world-blueprint-bytes";
         let version = version_for(payload);
         let cached = dir.path().join(format!(
-            "binary-v{}-{}",
+            "binary-v{}-{}-{}",
             version.version_id,
+            std::env::consts::ARCH,
             hex::encode(&version.sha256.as_slice()[..8])
         ));
         tokio::fs::write(&cached, b"different-bytes-attacker-controlled")
@@ -312,5 +427,267 @@ mod tests {
             // SAFETY: same lock guards the restore.
             unsafe { std::env::set_var(IPFS_GATEWAY_ENV, value) };
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Manifest-mode swap tests.
+    //
+    // These exercise the arch-aware resolution path end to end against a real
+    // local HTTP server (mirrors the harness in
+    // `tests/blueprint_sources_e2e.rs`). The regression they defend: an
+    // aarch64 operator fetching the on-chain `binaryUri` literally would
+    // receive an x86_64 binary. Manifest mode must instead select THIS host's
+    // entry and verify its own digest.
+    // ---------------------------------------------------------------------
+
+    use crate::sources::manifest::MANIFEST_SCHEMA_V1;
+    use std::net::SocketAddr;
+
+    fn sha256_hex(bytes: &[u8]) -> String {
+        hex::encode::<[u8; 32]>(Sha256::digest(bytes).into())
+    }
+
+    fn version_with_uri(uri: &str, manifest_bytes: &[u8]) -> BinaryVersionInfo {
+        // The on-chain sha256 pins the MANIFEST bytes in manifest mode.
+        let sha: [u8; 32] = Sha256::digest(manifest_bytes).into();
+        BinaryVersionInfo {
+            version_id: 7,
+            sha256: B256::from(sha),
+            binary_uri: uri.to_string(),
+            attestation_hash: B256::ZERO,
+            published_at: 0,
+            deprecated: false,
+        }
+    }
+
+    /// Bind an ephemeral port, hand the caller its address to build routes
+    /// against, then serve those routes. This two-phase shape lets a manifest
+    /// embed the asset URL of the very server that will host it without any
+    /// fragile string rewriting.
+    async fn serve_with<F>(build: F) -> (SocketAddr, tokio::task::JoinHandle<()>)
+    where
+        F: FnOnce(SocketAddr) -> Vec<(String, Vec<u8>)>,
+    {
+        use axum::Router;
+        use axum::routing::get;
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let mut app = Router::new();
+        for (path, data) in build(addr) {
+            app = app.route(
+                &path,
+                get(move || {
+                    let d = data.clone();
+                    async move { d }
+                }),
+            );
+        }
+
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+        (addr, handle)
+    }
+
+    /// Build a v1 manifest whose ONLY linux/macos entry for the host arch
+    /// points at `asset_url`, plus a decoy entry for a different arch that
+    /// points at a bogus URL. If the resolver were arch-blind it would pick
+    /// the wrong (or first) entry.
+    fn host_manifest(asset_url: &str, asset_sha: &str, decoy_url: &str) -> String {
+        let host_os =
+            crate::blueprint::native::normalize_os(&crate::sdk::utils::get_formatted_os_string());
+        let host_arch = std::env::consts::ARCH;
+        let decoy_arch = if host_arch == "x86_64" {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
+        format!(
+            r#"{{
+              "schema": "{MANIFEST_SCHEMA_V1}",
+              "binaries": [
+                {{ "os": "{host_os}", "arch": "{decoy_arch}",
+                   "url": "{decoy_url}", "sha256": "{}" }},
+                {{ "os": "{host_os}", "arch": "{host_arch}",
+                   "url": "{asset_url}", "sha256": "{asset_sha}" }}
+              ]
+            }}"#,
+            hex::encode([0xab_u8; 32]),
+        )
+    }
+
+    #[tokio::test]
+    async fn manifest_mode_selects_host_entry_and_verifies_digest() {
+        // The core fix: with a multi-arch manifest the swap path must pick the
+        // current host's artifact and gate it on that entry's own sha256.
+        let dir = TempDir::new().unwrap();
+        let asset = b"#!/bin/sh\necho host-binary\n".to_vec();
+        let asset_sha = sha256_hex(&asset);
+
+        // Capture the exact manifest bytes the server returns so we can pin the
+        // on-chain sha256 to them.
+        let captured: std::sync::Arc<std::sync::Mutex<Vec<u8>>> = Default::default();
+        let cap = captured.clone();
+        let asset2 = asset.clone();
+        let (addr, server) = serve_with(move |addr| {
+            let asset_url = format!("http://{addr}/host-asset.tar.xz");
+            let decoy_url = format!("http://{addr}/decoy");
+            let manifest = host_manifest(&asset_url, &asset_sha, &decoy_url).into_bytes();
+            *cap.lock().unwrap() = manifest.clone();
+            vec![
+                ("/manifest.json".to_string(), manifest),
+                ("/host-asset.tar.xz".to_string(), asset2),
+            ]
+        })
+        .await;
+
+        let manifest_bytes = captured.lock().unwrap().clone();
+        let version = version_with_uri(&format!("http://{addr}/manifest.json"), &manifest_bytes);
+        let resolved = download_and_verify(7, dir.path(), &version).await;
+        server.abort();
+
+        let path = resolved.expect("manifest-mode swap should resolve host artifact");
+        assert_eq!(
+            std::fs::read(&path).unwrap(),
+            asset,
+            "resolved binary must be the host artifact, not the decoy"
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_integrity_failure_aborts() {
+        // The manifest bytes must hash to the on-chain sha256. A manifest that
+        // doesn't match is a tampered trust root -> Sha256Mismatch, never run.
+        let dir = TempDir::new().unwrap();
+        let (addr, server) = serve_with(|addr| {
+            let manifest = host_manifest(
+                &format!("http://{addr}/asset"),
+                &sha256_hex(b"x"),
+                &format!("http://{addr}/decoy"),
+            )
+            .into_bytes();
+            vec![("/manifest.json".to_string(), manifest)]
+        })
+        .await;
+
+        // Pin the on-chain sha to DIFFERENT bytes so the integrity check fails.
+        let version = version_with_uri(&format!("http://{addr}/manifest.json"), b"different");
+        let err = download_and_verify(7, dir.path(), &version).await;
+        server.abort();
+        let err = err.expect_err("manifest integrity mismatch must abort");
+        assert!(
+            matches!(err, UpgradeError::Sha256Mismatch { .. }),
+            "expected Sha256Mismatch on manifest integrity failure, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_no_arch_match_aborts() {
+        // A manifest with no entry for the host arch must abort — never run a
+        // foreign-arch binary.
+        let dir = TempDir::new().unwrap();
+        let host_os =
+            crate::blueprint::native::normalize_os(&crate::sdk::utils::get_formatted_os_string());
+        let foreign_arch = if std::env::consts::ARCH == "x86_64" {
+            "aarch64"
+        } else {
+            "x86_64"
+        };
+        let manifest_bytes = format!(
+            r#"{{"schema":"{MANIFEST_SCHEMA_V1}","binaries":[
+                {{"os":"{host_os}","arch":"{foreign_arch}",
+                  "url":"http://127.0.0.1:1/foreign","sha256":"{}"}}]}}"#,
+            hex::encode([0x01_u8; 32]),
+        )
+        .into_bytes();
+
+        let mb = manifest_bytes.clone();
+        let (addr, server) = serve_with(move |_| vec![("/manifest.json".to_string(), mb)]).await;
+
+        let version = version_with_uri(&format!("http://{addr}/manifest.json"), &manifest_bytes);
+        let err = download_and_verify(7, dir.path(), &version).await;
+        server.abort();
+        let err = err.expect_err("no host-arch entry must abort");
+        assert!(
+            matches!(err, UpgradeError::Manager(ManagerError::Other(ref m)) if m.contains("no entry")),
+            "expected no-arch-match abort, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn manifest_per_asset_sha_mismatch_aborts() {
+        // Manifest integrity passes, host entry selected, but the downloaded
+        // asset's bytes don't match the entry's sha256 -> Sha256Mismatch.
+        let dir = TempDir::new().unwrap();
+        let served_asset = b"actual-bytes-on-server".to_vec();
+        // Manifest claims a sha that the asset does NOT have.
+        let lying_sha = sha256_hex(b"what-the-manifest-claims");
+
+        let captured: std::sync::Arc<std::sync::Mutex<Vec<u8>>> = Default::default();
+        let cap = captured.clone();
+        let asset2 = served_asset.clone();
+        let (addr, server) = serve_with(move |addr| {
+            let manifest = host_manifest(
+                &format!("http://{addr}/asset.tar.xz"),
+                &lying_sha,
+                &format!("http://{addr}/decoy"),
+            )
+            .into_bytes();
+            *cap.lock().unwrap() = manifest.clone();
+            vec![
+                ("/manifest.json".to_string(), manifest),
+                ("/asset.tar.xz".to_string(), asset2),
+            ]
+        })
+        .await;
+
+        let manifest_bytes = captured.lock().unwrap().clone();
+        let version = version_with_uri(&format!("http://{addr}/manifest.json"), &manifest_bytes);
+        let err = download_and_verify(7, dir.path(), &version).await;
+        server.abort();
+        let err = err.expect_err("per-asset sha mismatch must abort");
+        assert!(
+            matches!(err, UpgradeError::Sha256Mismatch { .. }),
+            "expected Sha256Mismatch on per-asset digest failure, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_raw_uri_path_still_works() {
+        // Regression: a non-manifest (raw tarball) URI must behave exactly as
+        // before — fetched literally, verified against the on-chain sha256.
+        let dir = TempDir::new().unwrap();
+        let raw = b"raw-genesis-v0-tarball-bytes".to_vec();
+
+        let raw2 = raw.clone();
+        let (addr, server) = serve_with(move |_| vec![("/binary.tar.xz".to_string(), raw2)]).await;
+        let mut version = version_for(&raw); // on-chain sha == sha256(raw)
+        version.binary_uri = format!("http://{addr}/binary.tar.xz");
+
+        let resolved = download_and_verify(1, dir.path(), &version).await;
+        server.abort();
+        let path = resolved.expect("legacy raw-uri swap should succeed");
+        assert_eq!(std::fs::read(&path).unwrap(), raw);
+    }
+
+    #[tokio::test]
+    async fn legacy_raw_uri_sha_mismatch_aborts() {
+        // Regression: raw mode still gates on the on-chain sha256.
+        let dir = TempDir::new().unwrap();
+        let (addr, server) =
+            serve_with(|_| vec![("/binary.tar.xz".to_string(), b"served-bytes".to_vec())]).await;
+        // on-chain sha pins DIFFERENT bytes.
+        let mut version = version_for(b"expected-bytes");
+        version.binary_uri = format!("http://{addr}/binary.tar.xz");
+
+        let err = download_and_verify(1, dir.path(), &version).await;
+        server.abort();
+        let err = err.expect_err("raw sha mismatch must abort");
+        assert!(
+            matches!(err, UpgradeError::Sha256Mismatch { .. }),
+            "expected Sha256Mismatch on raw digest failure, got {err:?}"
+        );
     }
 }


### PR DESCRIPTION
## Summary
Makes the manager binary upgrade-swap **architecture-aware** so cross-arch operators (e.g. aarch64) stop fetching the wrong-arch binary. Affects the operator-node upgrade flow.

## Change Class
- Selected class: D
- Why this class: touches `crates/manager/src/sources/` and the upgrade-swap fetch/verify (security-sensitive trust root).

## Behavior Contract
- Current behavior: `upgrade::swap::download_and_verify` fetches `BinaryVersion.binary_uri` literally + verifies against the single `version.sha256` — arch-blind; an aarch64 operator pulling an x86_64 URL runs the wrong binary.
- Intended behavior: if `binary_uri` is a `tangle-binary-manifest/v1` (`.json` suffix or bytes parse as the schema), pin the manifest bytes against the on-chain `version.sha256`, select the host arch entry (reusing `normalize_os`/`normalize_arch`), download it, verify its own per-asset sha256/blake3. Raw-tarball URIs keep prior behavior.
- Invariants: never run an unverified binary; manifest trusted to redirect only after its bytes match the on-chain sha256; selected asset gated against its own digest; no arch match aborts; arch-qualified cache key.
- Failure mode: fail-closed — any integrity or selection failure aborts the swap and keeps the running binary.
- Security impact: strengthens the multi-arch trust root; no new trust in unverified bytes.
- Compatibility impact: none on-chain; `binary_uri` semantics extended (manifest OR raw), backward-compatible; no ABI change.
- Rollback plan: revert the PR; raw-uri path unchanged, no state migration.

## Risk And Scope
Manager-only; no contract/ABI/watcher/chain changes. New `sources/manifest.rs` + a branch in `swap.rs`. Initial-fetch untouched.

## Verification
Commands run locally:
`cargo test -p blueprint-manager --lib upgrade::swap` (9 passed), `cargo test -p blueprint-manager --lib sources::manifest` (9 passed), `cargo test -p blueprint-manager --lib upgrade::` (32 passed), `cargo clippy -p blueprint-manager --all-targets` (clean), `cargo build -p blueprint-manager` (clean).
- Reproducer: manifest-mode tests against a real local HTTP server (mirrors `tests/blueprint_sources_e2e.rs`).
- Negative-path: manifest-integrity-failure abort, no-arch-match abort, per-asset sha mismatch abort, legacy raw-uri regression.

## Harness Evidence
`upgrade::swap` 9/9; `sources::manifest` 9/9; `upgrade::` 32/32; clippy + build clean. Re-run independently after authoring.

## Checklist
- [x] Tests added and passing
- [x] Clippy/fmt clean on touched files
- [x] No ABI/contract change
- [x] Backward-compatible (raw-uri regression test)
- [x] fail-closed on all error paths
