### PR TITLE
chore(release): cargo-tangle + blueprint-manager 0.x-alpha.9 (arch-aware swap + arm64-linux binary)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3417,7 +3417,7 @@ dependencies = [
 
 [[package]]
 name = "blueprint-manager"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 dependencies = [
  "alloy-contract",
  "alloy-network 1.8.3",
@@ -4387,7 +4387,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-tangle"
-version = "0.5.0-alpha.8"
+version = "0.5.0-alpha.9"
 dependencies = [
  "alloy-contract",
  "alloy-dyn-abi",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ blueprint-producers-extra = { version = "0.2.0-alpha.5", path = "crates/producer
 blueprint-tangle-aggregation-svc = { version = "0.2.0-alpha.8", path = "crates/tangle-aggregation-svc", default-features = false }
 
 # Blueprint utils
-blueprint-manager = { version = "0.4.0-alpha.8", path = "./crates/manager", default-features = false }
+blueprint-manager = { version = "0.4.0-alpha.9", path = "./crates/manager", default-features = false }
 blueprint-manager-bridge = { version = "0.2.0-alpha.7", path = "./crates/manager/bridge", default-features = false }
 blueprint-remote-providers = { version = "0.2.0-alpha.8", path = "./crates/blueprint-remote-providers", default-features = false }
 blueprint-faas = { version = "0.2.0-alpha.5", path = "./crates/blueprint-faas", default-features = false }

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-tangle"
-version = "0.5.0-alpha.8"
+version = "0.5.0-alpha.9"
 description = "A command-line tool to create and deploy blueprints on Tangle Network"
 authors.workspace = true
 edition.workspace = true

--- a/crates/manager/Cargo.toml
+++ b/crates/manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blueprint-manager"
-version = "0.4.0-alpha.8"
+version = "0.4.0-alpha.9"
 description = "Tangle Blueprint manager and Runner"
 authors.workspace = true
 edition.workspace = true

--- a/dist-workspace.toml
+++ b/dist-workspace.toml
@@ -16,7 +16,7 @@ installers = ["shell"]
 # shipping Intel Macs in 2023, and Rosetta 2 runs the aarch64 binary
 # transparently on the remaining Intel users. Add back only if a real
 # user reports an aarch64-on-Intel regression.
-targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu"]
+targets = ["aarch64-apple-darwin", "x86_64-unknown-linux-gnu", "aarch64-unknown-linux-gnu"]
 # Path that installers should place binaries in
 install-path = "CARGO_HOME"
 # Whether to install an updater program
@@ -33,3 +33,4 @@ global = "ubuntu-latest"
 # Custom runners to use for each target platform
 aarch64-apple-darwin = "macos-15"
 x86_64-unknown-linux-gnu = "ubuntu-latest"
+aarch64-unknown-linux-gnu = "ubuntu-24.04-arm"


### PR DESCRIPTION
## Summary

Release the arch-aware upgrade-swap fix (#1446) to crates.io and to operator binaries by bumping the two crates that carry it, and add an aarch64-linux build target so arm64 Linux operators get a prebuilt `cargo-tangle`.

- `blueprint-manager` 0.4.0-alpha.8 → **0.4.0-alpha.9**
- `cargo-tangle` 0.5.0-alpha.8 → **0.5.0-alpha.9** (bundles the manager)
- cargo-dist: add `aarch64-unknown-linux-gnu` (built on `ubuntu-24.04-arm`)

This affects the operator/manager flow: operators who `cargo install cargo-tangle` (or auto-update) pick up the manifest-aware binary swap.

## Change Class

- Selected class: Class C (CLI + crate version bump, cross-boundary release)
- This is a version/release change touching `cli/` and `crates/manager/` plus the workspace `Cargo.toml`/`Cargo.lock` and `dist-workspace.toml`. No source logic changes.

## Behavior Contract

- Before: `blueprint-manager`/`cargo-tangle` published at alpha.8 still fetch the on-chain `binaryUri` literally during an upgrade swap (the #1446 fix is merged but unreleased). arm64-linux operators have no prebuilt CLI.
- After: alpha.9 is published; the swap resolves the operator's platform from the `tangle-binary-manifest/v1` and verifies the per-arch asset. A prebuilt `cargo-tangle` exists for `aarch64-unknown-linux-gnu`.
- Invariant preserved: the on-chain `BinaryVersion.sha256` still gates the fetched manifest, and each resolved per-arch asset is verified against its manifest entry. No protocol/ABI change. Append-only version semantics unchanged.

## Risk and Scope

- Blast radius: release plumbing only. `blueprint-sdk`/`blueprint-runner` are unchanged, so downstream blueprint repos need no bump.
- Failure mode: fail-closed — if the manifest hash or per-arch asset hash mismatches, the swap aborts (unchanged from #1446).
- Compatibility: no API/metadata/config change. Legacy raw-uri binaries still resolve via the unchanged legacy path.
- Rollback: yank alpha.9 on crates.io and/or `setActiveBinaryVersion` back; operators stay on alpha.8. Revert this PR to restore the prior dist target set.

## Verification

- cargo-dist accepted the new target: the `plan` job passed on this PR, emitting an `artifacts_matrix` that includes `aarch64-unknown-linux-gnu` on `ubuntu-24.04-arm`.
- Local lock + resolution sync:

```bash
cargo update -p blueprint-manager -p cargo-tangle   # lock now pins alpha.9
grep -A1 '^name = "blueprint-manager"' Cargo.lock    # version = "0.4.0-alpha.9"
```

## Harness Evidence

The underlying logic (manifest-aware swap) was verified in #1446 by its own unit suites, which I re-ran locally before that merge: `upgrade::swap` 9/9, `sources::manifest` 9/9, full `upgrade::` 32/32 (`cargo test -p blueprint-manager upgrade:: sources::manifest`). This PR adds no new logic — it bumps versions and adds a build target — so the existing manager test suite is the relevant evidence, and CI re-runs `cargo test (blueprint-manager)` here.

## Checklist

- [x] Versions bumped consistently (package versions + workspace dep + `Cargo.lock`)
- [x] No source/logic changes beyond version + dist target
- [x] Downstream impact assessed (none — manager-only)
- [x] Rollback path documented
- [x] `dist plan` validated the new target in CI
