### PR TITLE
fix(networking): unify ProtocolMessage codec (send encoded fixint, receivers decoded varint)

### DIFF
--- a/crates/networking/extensions/agg-sig-gossip/src/protocol.rs
+++ b/crates/networking/extensions/agg-sig-gossip/src/protocol.rs
@@ -5,7 +5,6 @@ use crate::{
     protocol_state::{AggregationState, ProtocolRound},
     signature_weight::SignatureWeight,
 };
-use bincode::Options;
 use blueprint_core::{debug, error, warn};
 use blueprint_crypto::{aggregation::AggregatableSignature, hashing::blake3_256};
 use blueprint_gossip_primitives::DeduplicationCache;
@@ -286,10 +285,9 @@ where
         let routing = protocol_msg.routing.clone();
         let sender_id = routing.sender;
 
-        // Deserialize the message
-        let message = bincode::options()
-            .with_limit(blueprint_networking::types::MAX_MESSAGE_SIZE as u64)
-            .deserialize::<AggSigMessage<S>>(&protocol_msg.payload)?;
+        // Deserialize the message with the canonical wire codec
+        let message =
+            blueprint_networking::codec::deserialize::<AggSigMessage<S>>(&protocol_msg.payload)?;
 
         match message {
             AggSigMessage::SignatureShare {
@@ -578,7 +576,7 @@ where
         message: &AggSigMessage<S>,
         recipient: Option<PeerId>,
     ) -> Result<(), AggregationError> {
-        let payload = bincode::serialize(&message)?;
+        let payload = blueprint_networking::codec::serialize(&message)?;
 
         let routing = MessageRouting {
             message_id: 0,

--- a/crates/networking/extensions/agg-sig-gossip/src/tests/mod.rs
+++ b/crates/networking/extensions/agg-sig-gossip/src/tests/mod.rs
@@ -287,7 +287,6 @@ mod bls_tests {
 
     #[serial_test::serial]
     #[tokio::test]
-    #[ignore = "CI-flaky: libp2p BLS aggregation protocol hangs until protocol_timeout on shared GH runners. Runs locally via `cargo test -p blueprint-networking-agg-sig-gossip-extension -- --ignored`. See PR #1366."]
     async fn test_bls381_basic_aggregation() {
         run_signature_aggregation_test::<W3fBls381>(
             3,  // 3 nodes
@@ -300,7 +299,6 @@ mod bls_tests {
 
     #[serial_test::serial]
     #[tokio::test]
-    #[ignore = "CI-flaky: same as test_bls381_basic_aggregation. Runs locally via `cargo test -p blueprint-networking-agg-sig-gossip-extension -- --ignored`. See PR #1366."]
     async fn test_bls377_basic_aggregation() {
         run_signature_aggregation_test::<W3fBls377>(
             3,  // 3 nodes
@@ -319,7 +317,6 @@ mod bn254_tests {
 
     #[serial_test::serial]
     #[tokio::test]
-    #[ignore = "CI-flaky: same libp2p aggregation issue as the BLS variants. Runs locally via `cargo test -p blueprint-networking-agg-sig-gossip-extension -- --ignored`. See PR #1366."]
     async fn test_bn254_basic_aggregation() {
         run_signature_aggregation_test::<ArkBlsBn254>(
             3,  // 3 nodes
@@ -337,7 +334,6 @@ mod w3f_bls_tests {
 
     #[serial_test::serial]
     #[tokio::test]
-    #[ignore = "CI-flaky: same libp2p aggregation issue as the other BLS variants. Runs locally via `cargo test -p blueprint-networking-agg-sig-gossip-extension -- --ignored`. See PR #1366."]
     async fn test_w3f_bls381_basic_aggregation() {
         run_signature_aggregation_test::<W3fBls381>(
             3,  // 3 nodes
@@ -350,7 +346,6 @@ mod w3f_bls_tests {
 
     #[serial_test::serial]
     #[tokio::test]
-    #[ignore = "CI-flaky: same as test_w3f_bls381_basic_aggregation. Runs locally via `cargo test -p blueprint-networking-agg-sig-gossip-extension -- --ignored`. See PR #1366."]
     async fn test_w3f_bls377_basic_aggregation() {
         run_signature_aggregation_test::<W3fBls377>(
             3,  // 3 nodes

--- a/crates/networking/src/blueprint_protocol/behaviour.rs
+++ b/crates/networking/src/blueprint_protocol/behaviour.rs
@@ -3,8 +3,7 @@ use crate::blueprint_protocol::HandshakeMessage;
 use crate::discovery::PeerManager;
 use crate::discovery::peers::VerificationIdentifierKey;
 use crate::discovery::utils::get_address_from_compressed_pubkey;
-use crate::types::{MAX_MESSAGE_SIZE, ProtocolMessage};
-use bincode::Options;
+use crate::types::ProtocolMessage;
 use blueprint_core::{debug, error, info, warn};
 use blueprint_crypto::BytesEncoding;
 use blueprint_crypto::KeyType;
@@ -393,10 +392,8 @@ impl<K: KeyType> BlueprintProtocolBehaviour<K> {
 
                 debug!(%propagation_source, "Received gossip message");
 
-                // Deserialize with bounded size to prevent memory amplification
-                let Ok(protocol_message) = bincode::options()
-                    .with_limit(MAX_MESSAGE_SIZE as u64)
-                    .deserialize::<ProtocolMessage>(&message.data)
+                // Canonical codec: varint with bounded size to prevent memory amplification
+                let Ok(protocol_message) = crate::codec::decode_protocol_message(&message.data)
                 else {
                     warn!(%propagation_source, "Failed to deserialize gossip message");
                     return;

--- a/crates/networking/src/blueprint_protocol/handler.rs
+++ b/crates/networking/src/blueprint_protocol/handler.rs
@@ -1,14 +1,13 @@
 use std::time::{Duration, Instant};
 
 use alloy_primitives::Address;
-use bincode::Options;
 use blueprint_core::{debug, warn};
 use blueprint_crypto::{BytesEncoding, KeyType, hashing::keccak_256};
 use libp2p::{PeerId, request_response};
 
 use crate::blueprint_protocol::HandshakeMessage;
 use crate::discovery::peers::VerificationIdentifierKey;
-use crate::types::{MAX_MESSAGE_SIZE, ProtocolMessage};
+use crate::types::ProtocolMessage;
 
 use super::{BlueprintProtocolBehaviour, InstanceMessageRequest, InstanceMessageResponse};
 
@@ -193,23 +192,21 @@ impl<K: KeyType> BlueprintProtocolBehaviour<K> {
                     return;
                 }
 
-                let protocol_message: ProtocolMessage = match bincode::options()
-                    .with_limit(MAX_MESSAGE_SIZE as u64)
-                    .deserialize(&payload)
-                {
-                    Ok(message) => message,
-                    Err(e) => {
-                        warn!(%peer, "Failed to deserialize protocol message: {:?}", e);
-                        let response = InstanceMessageResponse::Error {
-                            code: 400,
-                            message: format!("Invalid protocol message: {:?}", e),
-                        };
-                        if let Err(e) = self.send_response(channel, response) {
-                            warn!(%peer, "Failed to send error response: {:?}", e);
+                let protocol_message: ProtocolMessage =
+                    match crate::codec::decode_protocol_message(&payload) {
+                        Ok(message) => message,
+                        Err(e) => {
+                            warn!(%peer, "Failed to deserialize protocol message: {:?}", e);
+                            let response = InstanceMessageResponse::Error {
+                                code: 400,
+                                message: format!("Invalid protocol message: {:?}", e),
+                            };
+                            if let Err(e) = self.send_response(channel, response) {
+                                warn!(%peer, "Failed to send error response: {:?}", e);
+                            }
+                            return;
                         }
-                        return;
-                    }
-                };
+                    };
 
                 debug!(%peer, %protocol, %protocol_message, "Received protocol request");
                 if let Err(e) = self.protocol_message_sender.send(protocol_message) {

--- a/crates/networking/src/codec.rs
+++ b/crates/networking/src/codec.rs
@@ -1,0 +1,129 @@
+//! Canonical wire codec for [`ProtocolMessage`] envelopes.
+//!
+//! Every encode site and every decode site MUST go through this module.
+//! With bincode 1.x, `bincode::serialize` (fixint encoding) and
+//! `bincode::options().deserialize` (varint encoding) are **incompatible**
+//! wire formats. Mixing them silently breaks the transport: senders produce
+//! bytes that no receiver can decode. Centralizing the `Options` construction
+//! here makes that divergence impossible.
+
+use crate::types::ProtocolMessage;
+use bincode::Options;
+use serde::{Serialize, de::DeserializeOwned};
+
+/// Maximum allowed size for a message payload
+pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+
+/// The single source of truth for the wire format: varint encoding with a
+/// size limit of [`MAX_MESSAGE_SIZE`], enforced on both encode and decode.
+fn wire_options() -> impl Options {
+    bincode::options().with_limit(MAX_MESSAGE_SIZE as u64)
+}
+
+/// Serialize a value with the canonical wire options.
+///
+/// # Errors
+///
+/// Fails if the encoded size would exceed [`MAX_MESSAGE_SIZE`] (so oversized
+/// sends fail fast at the sender instead of being dropped by receivers) or if
+/// serialization itself fails.
+pub fn serialize<T: Serialize + ?Sized>(value: &T) -> Result<Vec<u8>, bincode::Error> {
+    wire_options().serialize(value)
+}
+
+/// Deserialize a value with the canonical wire options.
+///
+/// # Errors
+///
+/// Fails if the input exceeds [`MAX_MESSAGE_SIZE`] or is not a valid encoding
+/// of `T`.
+pub fn deserialize<T: DeserializeOwned>(bytes: &[u8]) -> Result<T, bincode::Error> {
+    wire_options().deserialize(bytes)
+}
+
+/// Encode a [`ProtocolMessage`] envelope for the wire (gossip and direct P2P).
+///
+/// # Errors
+///
+/// See [`serialize`]
+pub fn encode_protocol_message(msg: &ProtocolMessage) -> Result<Vec<u8>, bincode::Error> {
+    serialize(msg)
+}
+
+/// Decode a [`ProtocolMessage`] envelope received from the wire.
+///
+/// # Errors
+///
+/// See [`deserialize`]
+pub fn decode_protocol_message(bytes: &[u8]) -> Result<ProtocolMessage, bincode::Error> {
+    deserialize(bytes)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::MessageRouting;
+    use libp2p::PeerId;
+
+    fn message(recipient: Option<PeerId>) -> ProtocolMessage {
+        ProtocolMessage {
+            protocol: "/test-protocol/1.0.0".to_string(),
+            routing: MessageRouting {
+                message_id: 42,
+                round_id: 7,
+                sender: PeerId::random(),
+                recipient,
+            },
+            payload: b"protocol payload bytes".to_vec(),
+        }
+    }
+
+    fn assert_round_trip(msg: &ProtocolMessage) {
+        let bytes = encode_protocol_message(msg).expect("encode failed");
+        let decoded = decode_protocol_message(&bytes).expect("decode failed");
+        assert_eq!(decoded.protocol, msg.protocol);
+        assert_eq!(decoded.payload, msg.payload);
+        assert_eq!(decoded.routing.message_id, msg.routing.message_id);
+        assert_eq!(decoded.routing.round_id, msg.routing.round_id);
+        assert_eq!(decoded.routing.sender, msg.routing.sender);
+        assert_eq!(decoded.routing.recipient, msg.routing.recipient);
+    }
+
+    #[test]
+    fn round_trip_broadcast_routing() {
+        assert_round_trip(&message(None));
+    }
+
+    #[test]
+    fn round_trip_direct_routing() {
+        assert_round_trip(&message(Some(PeerId::random())));
+    }
+
+    /// Regression test for the fixint/varint codec mismatch: bytes produced by
+    /// the send path must decode through the exact `Options` incantation the
+    /// receive paths (gossip + request-response) use. Before this codec module
+    /// existed, the sender used `bincode::serialize` (fixint) while receivers
+    /// used `bincode::options().with_limit(..)` (varint), so every message
+    /// sent through `NetworkServiceHandle::send` failed to decode.
+    #[test]
+    fn send_path_bytes_decode_via_receive_path_options() {
+        let msg = message(Some(PeerId::random()));
+        let bytes = encode_protocol_message(&msg).expect("encode failed");
+        let decoded = bincode::options()
+            .with_limit(MAX_MESSAGE_SIZE as u64)
+            .deserialize::<ProtocolMessage>(&bytes)
+            .expect("receive-path options must decode send-path bytes");
+        assert_eq!(decoded.payload, msg.payload);
+        assert_eq!(decoded.routing.message_id, msg.routing.message_id);
+    }
+
+    #[test]
+    fn oversized_message_fails_on_encode() {
+        let mut msg = message(None);
+        msg.payload = vec![0u8; MAX_MESSAGE_SIZE + 1];
+        assert!(
+            encode_protocol_message(&msg).is_err(),
+            "encoding must fail fast when the payload exceeds MAX_MESSAGE_SIZE"
+        );
+    }
+}

--- a/crates/networking/src/lib.rs
+++ b/crates/networking/src/lib.rs
@@ -2,6 +2,7 @@
 
 pub mod behaviours;
 pub mod blueprint_protocol;
+pub mod codec;
 pub mod discovery;
 pub mod error;
 pub mod service;

--- a/crates/networking/src/service_handle.rs
+++ b/crates/networking/src/service_handle.rs
@@ -151,7 +151,8 @@ impl<K: KeyType> NetworkServiceHandle<K> {
             payload: message.into(),
         };
 
-        let raw_payload = bincode::serialize(&protocol_message).map_err(|err| err.to_string())?;
+        let raw_payload = crate::codec::encode_protocol_message(&protocol_message)
+            .map_err(|err| err.to_string())?;
         match protocol_message.routing.recipient {
             Some(recipient) => {
                 let instance_message_request = InstanceMessageRequest::Protocol {

--- a/crates/networking/src/tests/blueprint_protocol.rs
+++ b/crates/networking/src/tests/blueprint_protocol.rs
@@ -59,7 +59,6 @@ fn extract_sum_from_verification(msg: &ProtocolMessage) -> u64 {
 
 #[tokio::test]
 #[serial_test::serial]
-#[ignore = "CI-flaky: libp2p summation protocol hangs until TEST_TIMEOUT on shared GH runners. Runs locally via `cargo test -p blueprint-networking -- --ignored`. See PR #1366."]
 async fn test_summation_protocol_basic() {
     setup_log();
     info!("Starting summation protocol test");
@@ -230,7 +229,6 @@ async fn test_summation_protocol_basic() {
 
 #[tokio::test]
 #[serial_test::serial]
-#[ignore = "CI-flaky: same libp2p summation issue as test_summation_protocol_basic. Runs locally via `cargo test -p blueprint-networking -- --ignored`. See PR #1366."]
 async fn test_summation_protocol_multi_node() {
     setup_log();
     info!("Starting multi-node summation protocol test");

--- a/crates/networking/src/tests/gossip.rs
+++ b/crates/networking/src/tests/gossip.rs
@@ -19,7 +19,6 @@ const PROTOCOL_NAME: &str = "/gossip/1.0.0";
 
 #[tokio::test]
 #[serial_test::serial]
-#[ignore = "CI-flaky: libp2p peer discovery + gossip convergence hangs until TEST_TIMEOUT on shared GH runners — protocol never settles in that environment. Tracked separately; test still runs locally via `cargo test -p blueprint-networking -- --ignored`. See discussion in PR #1366."]
 async fn test_gossip_between_verified_peers() {
     setup_log();
     info!("Starting gossip test between verified peers");
@@ -79,7 +78,6 @@ async fn test_gossip_between_verified_peers() {
 
 #[tokio::test]
 #[serial_test::serial]
-#[ignore = "CI-flaky: same libp2p convergence issue as test_gossip_between_verified_peers. Runs locally via `cargo test -p blueprint-networking -- --ignored`. See PR #1366."]
 async fn test_multi_node_gossip() {
     setup_log();
     info!("Starting multi-node gossip test");

--- a/crates/networking/src/types.rs
+++ b/crates/networking/src/types.rs
@@ -2,8 +2,7 @@ use libp2p::{PeerId, gossipsub::IdentTopic};
 use serde::{Deserialize, Serialize};
 use std::fmt::Display;
 
-/// Maximum allowed size for a message payload
-pub const MAX_MESSAGE_SIZE: usize = 16 * 1024 * 1024;
+pub use crate::codec::MAX_MESSAGE_SIZE;
 
 /// Type of message delivery mechanism
 #[derive(Debug, Clone)]


### PR DESCRIPTION
## Summary

- The networking transport encoded `ProtocolMessage` envelopes with `bincode::serialize` (fixint) on the send path but decoded them with `bincode::options()...deserialize` (varint) on the receive path. With bincode 1.x these are **incompatible wire formats**, so every gossip and direct-P2P message failed to deserialize on the receiver — silently — and the protocol hung until `protocol_timeout`. The same fixint/varint split existed independently in the `agg-sig-gossip` extension.
- Fix: a single canonical wire codec (`crates/networking/src/codec.rs`) — varint encoding with a `MAX_MESSAGE_SIZE` limit enforced on **both** encode and decode — and every encode/decode site in `blueprint_protocol` (behaviour, handler, service_handle, types) and `agg-sig-gossip` now routes through it. Five `#[ignore]`d BLS-aggregation tests that were *deterministically* broken by this (not flaky) are re-enabled.
- Affects every operator/runtime that relies on the networking gossip or direct-message path (e.g. the Surplus shared-CLOB mesh transport, which had to carry a private workaround for exactly this bug).

## Change Class

- `Class D` (protocol/security/metadata semantics)
- Selected class: Class D
- Why this class: it changes the on-wire encoding of `ProtocolMessage`, the networking layer's interop contract across every node.

## Behavior Contract

- Current behavior: send=fixint, receive=varint, so the receiver's decode always fails, gossip/direct messages are never delivered, and the protocol hangs to timeout (silently).
- Intended behavior: both sides use the canonical varint codec, messages decode, and gossip and direct P2P complete.
- Invariants that must hold: **every** encode site and **every** decode site goes through `codec::{serialize,deserialize}`; the wire format is varint + `MAX_MESSAGE_SIZE`, enforced symmetrically.
- Failure mode choice: **fail-closed** — an oversized or malformed message errors at the codec boundary (fast, explicit) rather than being silently dropped by a receiver.

## Risk And Scope

- Security impact: positive — the size limit bounds receive-side allocation (decode-bomb resistance); no auth/crypto surface touched.
- Compatibility impact: the on-wire format changes, **but the old format never decoded end-to-end** (decode failed 100% of the time), so there is no working deployment to break — this makes the transport function for the first time. No metadata/config/API changes.
- Migration notes: none.
- Rollback plan: revert this commit (returns to the silently-broken state).

## Verification

```bash
cargo test -p blueprint-networking --lib                       # codec round-trip + blueprint_protocol
cargo test -p blueprint-networking-agg-sig-gossip-extension    # 5 re-enabled BLS aggregation tests
```

Outcomes (confirmed on this PR's CI): `cargo test (blueprint-networking)` green; `cargo test (… blueprint-networking-agg-sig-gossip-extension …)` green — the five previously-`#[ignore]`d aggregation tests (`test_{bls381,bls377,bn254,w3f_bls381,w3f_bls377}_basic_aggregation`) pass with the codec unified, confirming the hang was the encoding mismatch, not libp2p convergence. Locally, `codec::tests::send_path_bytes_decode_via_receive_path_options` (the exact interop case) + the round-trip + oversize tests pass.

## Harness Evidence

- Reproducer added/updated: the five re-enabled aggregation tests are the reproducer — they hung pre-fix (undecodable shares, threshold never reached, timeout) and pass post-fix.
- Negative-path coverage added: `codec` enforces `MAX_MESSAGE_SIZE` on both encode and decode (`oversized_message_fails_on_encode`); `send_path_bytes_decode_via_receive_path_options` asserts send-path bytes decode via receive-path options (the bug's exact interop).
- Key assertions that prove the fix: `codec.rs` `round_trip_*` tests over `ProtocolMessage` envelopes, plus the aggregation tests reaching threshold instead of timing out.

## Checklist

- [x] I added or updated tests that reproduce the original issue.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input.
- [x] I evaluated compatibility/migration impact explicitly.
- [x] I validated local formatting, clippy, and relevant tests.
- [x] Docs/examples updated (n/a — internal wire format).

> Note: the failing `cargo test (… blueprint-auth, blueprint-clients)` job is a **pre-existing, unrelated** `tonic 0.13` API break in `crates/auth` tests (`Server::add_service`), present on `main` and untouched by this PR. Tracked/fixed separately.