### PR TITLE
fix(release): mark incredible-squaring example lib publish=false

### DIFF
--- a/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
+++ b/examples/incredible-squaring/incredible-squaring-lib/Cargo.toml
@@ -2,6 +2,11 @@
 name = "incredible-squaring-blueprint-lib"
 version = "0.2.0-alpha.9"
 description = "Example Tangle blueprint demonstrating job processing across local/FaaS execution and single/multi-operator aggregation."
+# Example crate — never published to crates.io (matches its sibling -bin and the
+# other examples). Without this, release-plz tries to `cargo package` it for its
+# equality check and fails on workspace `edition` inheritance, breaking every
+# release-plz run on main.
+publish = false
 edition.workspace = true
 license.workspace = true
 homepage.workspace = true


### PR DESCRIPTION
## Summary

- release-plz fails on every push to `main` ("failed to determine next versions" → cannot `cargo package` `incredible-squaring-blueprint-lib`, error inheriting `edition` from the workspace root). This has blocked all releases.
- Root cause: that example library is the **only** example workspace member missing `publish = false`, so release-plz treats it as a publishable crate and tries to package it in isolation, where workspace `edition` inheritance breaks. Its sibling `-bin` and every other example already set `publish = false`.
- Fix: add `publish = false` to the example lib. release-plz then skips it and the release run proceeds.

## Change Class

- `Class B` (single-crate behavior)
- Selected class: Class B
- Why this class: a single example crate's manifest gains a publish flag — local blast radius, no cross-crate or runtime change.

## Behavior Contract

- Current behavior: release-plz aborts on `main` because it attempts to package a never-published example crate and fails on workspace edition inheritance.
- Intended behavior: release-plz skips the example crate (publish=false) and completes version determination for the publishable crates.
- Invariants that must hold: example crates are never published to crates.io; the example bin still builds against the lib by path.
- Failure mode choice: fail-closed — release tooling now refuses to package a non-publishable crate rather than erroring opaquely mid-run.

## Risk And Scope

- Security impact: none.
- Compatibility impact: none — the crate was never published; no consumer depends on it from crates.io. The example bin consumes it by path, unchanged.
- Migration notes: none.
- Rollback plan: revert the one-line change.

## Verification

```bash
# release-plz re-runs on the merge to main; it now passes the example crate
# instead of aborting. Locally, the manifest remains valid and the example
# bin builds against the lib by path.
cargo build -p incredible-squaring-blueprint-bin
```

Outcome: the example workspace member set is now uniform (every example is `publish = false`); release-plz no longer tries to `cargo package` this crate.

## Harness Evidence

- Reproducer added/updated: the failing release-plz run on the #1454 merge is the reproducer; the fix removes the crate from release-plz's packaging set.
- Negative-path coverage added: n/a — this is a release-tooling manifest flag, not a code path.
- Key assertions that prove the fix: the crate now matches its sibling `-bin` and all other examples (`publish = false`), the case release-plz already handles cleanly.

## Checklist

- [x] I evaluated compatibility/migration impact explicitly.
- [x] I validated the change matches the established pattern for every other example crate.
- [x] No publishable crate or runtime behavior is affected.