### PR TITLE
fix(release): batch-publish waits on the sparse index, not the web API

### DIFF
--- a/.github/scripts/batch-publish.sh
+++ b/.github/scripts/batch-publish.sh
@@ -149,6 +149,39 @@ echo ""
 # Track failures for retry
 declare -a failed_packages=()
 
+# crates.io SPARSE-INDEX path for a crate name. `cargo publish` resolves a
+# crate's dependencies against the sparse index (index.crates.io), which
+# propagates SLOWER than the web API. The old check polled the web API, so the
+# script would declare a dep "live" and move on while cargo still couldn't see
+# it — every dependent then failed "failed to select a version" and the run
+# stalled at the first no-progress pass. We must wait on the sparse index.
+sparse_index_path() {
+    local name="$1" len=${#name}
+    if   ((len == 1)); then echo "1/$name"
+    elif ((len == 2)); then echo "2/$name"
+    elif ((len == 3)); then echo "3/${name:0:1}/$name"
+    else echo "${name:0:2}/${name:2:2}/$name"
+    fi
+}
+
+# Is this exact version visible in the sparse index (i.e. cargo-resolvable)?
+version_is_live() {
+    local name="$1" version="$2"
+    curl -fsSL --max-time 10 "https://index.crates.io/$(sparse_index_path "$name")" 2>/dev/null \
+        | grep -q "\"vers\":\"$version\""
+}
+
+# Poll the sparse index until the version is resolvable (or timeout), so a
+# just-published dependency is visible before its dependents publish next.
+wait_until_live() {
+    local name="$1" version="$2" max="${3:-300}" waited=0
+    while ((waited < max)); do
+        version_is_live "$name" "$version" && return 0
+        sleep 15; waited=$((waited + 15))
+    done
+    return 1
+}
+
 # Publish packages in topological order
 for ((i=0; i<total_packages; i++)); do
     package="${topo_order[$i]}"
@@ -168,40 +201,24 @@ for ((i=0; i<total_packages; i++)); do
         continue
     fi
 
-    version_is_live() {
-        local name="$1" version="$2"
-        local body
-        body=$(curl -fsSL --max-time 10 "https://crates.io/api/v1/crates/$name/$version" 2>/dev/null || echo "")
-        [[ -n "$body" ]] && echo "$body" | grep -q "\"num\":\"$version\""
-    }
-
     run_publish() {
         # Always echo the real output so silent rejections are auditable.
         cargo publish --package "$package" --allow-dirty --no-verify 2>&1
     }
 
     if version_is_live "$package" "$target_version"; then
-        echo "✓ $package $target_version already on crates.io (skipped)"
+        echo "✓ $package $target_version already in sparse index (skipped)"
     else
         output=$(run_publish || true)
         echo "$output" | tail -8
-        # Registry needs a moment to index a just-uploaded version.
-        sleep 15
-        if version_is_live "$package" "$target_version"; then
-            echo "✓ $package $target_version now live on crates.io"
+        # Wait for the SPARSE INDEX to show the version so dependents (published
+        # next, in topo order) can resolve it. Polls up to 5 min, exits early.
+        if wait_until_live "$package" "$target_version" 300; then
+            echo "✓ $package $target_version live in sparse index"
         else
-            echo "⚠ First attempt did not land $package $target_version; waiting 30s and retrying..."
-            sleep 30
-            output=$(run_publish || true)
-            echo "$output" | tail -8
-            sleep 15
-            if version_is_live "$package" "$target_version"; then
-                echo "✓ $package $target_version live after retry"
-            else
-                echo "✗ $package $target_version still missing from crates.io after retry"
-                failed_packages+=("$package")
-                echo "Continuing with remaining packages..."
-            fi
+            echo "✗ $package $target_version not in sparse index after 5min"
+            failed_packages+=("$package")
+            echo "Continuing with remaining packages..."
         fi
     fi
 
@@ -250,12 +267,11 @@ if ((${#failed_packages[@]} > 0)); then
                 continue
             fi
             if version_is_live "$package" "$target_version"; then
-                echo "✓ $package $target_version already on crates.io"
+                echo "✓ $package $target_version already in sparse index"
             else
                 output=$(run_publish || true)
                 echo "$output" | tail -8
-                sleep 15
-                if version_is_live "$package" "$target_version"; then
+                if wait_until_live "$package" "$target_version" 300; then
                     echo "✓ $package $target_version now live"
                 else
                     echo "✗ $package $target_version still missing after publish attempt"


### PR DESCRIPTION
## Summary

- The crates.io batch publish stalled at its first no-progress pass, leaving ~55 crates (including `blueprint-sdk`) unpublished after a release. Workspace versions are consistent — this is a propagation-timing bug in `batch-publish.sh`, not a version bug.
- `cargo publish` resolves a crate's dependencies against the **sparse index** (`index.crates.io`), which propagates slower than the crates.io **web API**. The old `version_is_live` polled the web API, declared a just-published dependency "live", and moved on while cargo still couldn't see it — so every dependent failed `failed to select a version for X = ^alpha.N` and the retry loop bailed on its no-progress guard.
- Fix: check **and wait on the sparse index** (the same source cargo reads), in both the main pass and the retry loop.

## Change Class

- `Class A` (docs/tooling only)
- Selected class: Class A
- Why this class: a single CI release script under `.github/`; no library/runtime code.

## Behavior Contract

- Current behavior: the publisher polls the web API, moves on before the sparse index has the version, dependents can't resolve it, the run stalls and exits 1 with dozens of crates unpublished.
- Intended behavior: after publishing a crate, poll the sparse index until the exact version is visible (up to 5 min, exits early), so a dependency is provably cargo-resolvable before its dependents publish next in topo order.
- Invariants that must hold: publish order stays topological (leaves first); a crate already in the sparse index is skipped; the run only reports success when every version is sparse-index-live.
- Failure mode choice: fail-closed — a version that never appears in the sparse index within the timeout is recorded as failed rather than silently assumed published.

## Risk And Scope

- Security impact: none.
- Compatibility impact: none — only the publish script's readiness check changes; no crate contents or versions change.
- Migration notes: none.
- Rollback plan: revert the one script.

## Verification

```bash
bash -n .github/scripts/batch-publish.sh   # syntax
# sparse_index_path + version_is_live correctly detect a live version:
curl -fsSL https://index.crates.io/bl/ue/blueprint-networking | grep '"vers":"0.2.0-alpha.8"'
```

Outcome: syntax clean; the new sparse-index path (`bl/ue/blueprint-networking`) and check correctly report `blueprint-networking 0.2.0-alpha.8` as live. The next `publish-crates.yml` run is the end-to-end proof (it should now converge the remaining crates).

## Harness Evidence

- Reproducer added/updated: the stalled publish run is the reproducer; the sparse-index wait removes the cascade that caused it.
- Negative-path coverage added: `wait_until_live` bounds the wait and records a genuine miss as failed (no false success).
- Key assertions that prove the fix: the sparse-index check resolves a known-live version; dependents now publish because their deps are sparse-index-visible first.

## Checklist

- [x] I evaluated compatibility/migration impact explicitly.
- [x] I validated script syntax and the sparse-index check against a live version.
- [x] No crate contents, versions, or runtime behavior are affected.