### PR TITLE
fix(qos): compile with Prometheus protobuf metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11599,6 +11599,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.5",
  "procfs",
+ "protobuf",
  "thiserror 2.0.18",
 ]
 
@@ -11729,12 +11730,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "protobuf"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d65a1d4ddae7d8b5de68153b48f6aa3bba8cb002b243dbdbc55a5afbc98f99f4"
+dependencies = [
+ "once_cell",
+ "protobuf-support",
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "protobuf-src"
 version = "2.1.1+27.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6217c3504da19b85a3a4b2e9a5183d635822d83507ba0986624b5c05b83bfc40"
 dependencies = [
  "cmake",
+]
+
+[[package]]
+name = "protobuf-support"
+version = "3.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
+dependencies = [
+ "thiserror 1.0.69",
 ]
 
 [[package]]

--- a/crates/qos/Cargo.toml
+++ b/crates/qos/Cargo.toml
@@ -30,7 +30,7 @@ tonic = { workspace = true, features = ["transport", "codegen", "prost", "router
 prost = { workspace = true, features = ["prost-derive"] }
 sysinfo = { workspace = true, features = ["system", "disk", "network"] }
 rand = { workspace = true }
-prometheus = { workspace = true, features = ["process"] }
+prometheus = { workspace = true, features = ["process", "protobuf"] }
 opentelemetry = { workspace = true, features = ["metrics"] }
 opentelemetry-prometheus = { workspace = true }
 opentelemetry-semantic-conventions = { workspace = true, features = ["semconv_experimental"] }

--- a/crates/qos/src/metrics/prometheus/server.rs
+++ b/crates/qos/src/metrics/prometheus/server.rs
@@ -158,10 +158,10 @@ async fn metrics_handler(State(state): State<ServerState>) -> Response {
         for m in mf.get_metric() {
             match mf.get_field_type() {
                 prometheus::proto::MetricType::COUNTER => {
-                    info!("      Counter Value: {}", m.get_counter().get_value());
+                    info!("      Counter Value: {}", m.get_counter().value());
                 }
                 prometheus::proto::MetricType::GAUGE => {
-                    info!("      Gauge Value: {}", m.get_gauge().get_value());
+                    info!("      Gauge Value: {}", m.get_gauge().value());
                 }
                 prometheus::proto::MetricType::HISTOGRAM => {
                     let hist = m.get_histogram();


### PR DESCRIPTION
## Summary
- enable the Prometheus protobuf API in blueprint-qos
- use current generated value accessors for counter and gauge metrics
- keep Cargo.lock aligned on protobuf 3.7.2

## Why
blueprint-qos failed to compile when a consumer enabled the Prometheus protobuf feature. The generated counter and gauge values use value() under that feature, while the crate still called get_value().

## Verification
- cargo check -p blueprint-qos
- cargo +nightly-2026-02-24 fmt --all -- --check
- clean merge-tree against current origin/main

The broader library test compile was attempted but the host ran out of disk while building test-only native dependencies.