### PR TITLE
fix(deps): bollard 0.20 + testcontainers 0.27.3 to clear the tokio-tar advisory

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1844,6 +1844,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "astral-tokio-tar"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b18457efd137254e016bbde5e1d88df61c4e1a5ae2223746e56123bac6af2463"
+dependencies = [
+ "futures-core",
+ "libc",
+ "portable-atomic",
+ "rustc-hash 2.1.2",
+ "rustix 1.1.4",
+ "tokio",
+ "tokio-stream",
+ "xattr",
+]
+
+[[package]]
 name = "async-channel"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4134,11 +4150,14 @@ dependencies = [
 
 [[package]]
 name = "bollard"
-version = "0.18.1"
+version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97ccca1260af6a459d75994ad5acc1651bcabcbdbc41467cc9786519ab854c30"
+checksum = "ee04c4c84f1f811b017f2fbb7dd8815c976e7ca98593de9c1e2afad0f636bff4"
 dependencies = [
+ "async-stream",
  "base64 0.22.1",
+ "bitflags 2.11.1",
+ "bollard-buildkit-proto",
  "bollard-stubs",
  "bytes",
  "futures-core",
@@ -4153,33 +4172,54 @@ dependencies = [
  "hyper-util",
  "hyperlocal",
  "log",
+ "num",
  "pin-project-lite",
+ "rand 0.9.4",
  "rustls",
  "rustls-native-certs 0.8.3",
- "rustls-pemfile",
  "rustls-pki-types",
  "serde",
  "serde_derive",
  "serde_json",
- "serde_repr",
  "serde_urlencoded",
  "thiserror 2.0.18",
+ "time",
  "tokio",
+ "tokio-stream",
  "tokio-util",
+ "tonic 0.14.5",
  "tower-service",
  "url",
  "winapi",
 ]
 
 [[package]]
-name = "bollard-stubs"
-version = "1.47.1-rc.27.3.1"
+name = "bollard-buildkit-proto"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f179cfbddb6e77a5472703d4b30436bff32929c0aa8a9008ecf23d1d3cdd0da"
+checksum = "85a885520bf6249ab931a764ffdb87b0ceef48e6e7d807cfdb21b751e086e1ad"
 dependencies = [
+ "prost 0.14.3",
+ "prost-types 0.14.3",
+ "tonic 0.14.5",
+ "tonic-prost",
+ "ureq",
+]
+
+[[package]]
+name = "bollard-stubs"
+version = "1.52.1-rc.29.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0a8ca8799131c1837d1282c3f81f31e76ceb0ce426e04a7fe1ccee3287c066"
+dependencies = [
+ "base64 0.22.1",
+ "bollard-buildkit-proto",
+ "bytes",
+ "prost 0.14.3",
  "serde",
+ "serde_json",
  "serde_repr",
- "serde_with",
+ "time",
 ]
 
 [[package]]
@@ -4835,7 +4875,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5317,7 +5357,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab67060fc6b8ef687992d439ca0fa36e7ed17e9a0b16b25b601e8757df720de"
 dependencies = [
  "data-encoding",
- "syn 1.0.109",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -5574,19 +5614,20 @@ dependencies = [
 
 [[package]]
 name = "docktopus"
-version = "0.4.0-alpha.3"
+version = "0.5.0-alpha.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c69f6f43a798df9c5649ba47c4dfc4b89f59004a1f83b83af61c7f40a5d6a901"
+checksum = "f0b22e60d38e7a019657934f57f92fe0948797b7fecc1d73568c685c4ddaa0de"
 dependencies = [
  "async-trait",
  "bollard",
+ "bytes",
  "cfg-if",
  "futures",
  "futures-util",
  "ipnet",
  "log",
  "regex",
- "reqwest 0.12.28",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_yaml",
@@ -5892,18 +5933,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "etcetera"
-version = "0.8.0"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
- "home",
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5996,6 +6036,17 @@ dependencies = [
  "bitflags 1.3.2",
  "byteorder",
  "log",
+]
+
+[[package]]
+name = "ferroid"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee93edf3c501f0035bbeffeccfed0b79e14c311f12195ec0e661e114a0f60da4"
+dependencies = [
+ "portable-atomic",
+ "rand 0.10.1",
+ "web-time",
 ]
 
 [[package]]
@@ -7226,22 +7277,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyper-tls"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
-dependencies = [
- "bytes",
- "http-body-util",
- "hyper 1.9.0",
- "hyper-util",
- "native-tls",
- "tokio",
- "tokio-native-tls",
- "tower-service",
-]
-
-[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7258,7 +7293,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -7293,7 +7328,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.61.2",
+ "windows-core 0.62.2",
 ]
 
 [[package]]
@@ -7703,7 +7738,7 @@ dependencies = [
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -9244,23 +9279,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "native-tls"
-version = "0.2.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465500e14ea162429d264d44189adc38b199b62b1c21eea9f69e4b73cb03bbf2"
-dependencies = [
- "libc",
- "log",
- "openssl",
- "openssl-probe 0.2.1",
- "openssl-sys",
- "schannel",
- "security-framework 3.7.0",
- "security-framework-sys",
- "tempfile",
-]
-
-[[package]]
 name = "neli"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9495,6 +9513,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "num"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "35bd024e8b2ff75562e5f34e7f4905839deb4b22955ef5e73d2fea1b9813cb23"
+dependencies = [
+ "num-bigint",
+ "num-complex",
+ "num-integer",
+ "num-iter",
+ "num-rational",
+ "num-traits",
+]
+
+[[package]]
 name = "num-bigint"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9519,6 +9551,15 @@ dependencies = [
  "rand 0.8.6",
  "smallvec",
  "zeroize",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -10776,7 +10817,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -10816,9 +10857,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.5.10",
+ "socket2 0.6.3",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11029,15 +11070,6 @@ checksum = "d3edd4d5d42c92f0a659926464d4cce56b562761267ecf0f469d85b7de384175"
 
 [[package]]
 name = "redox_syscall"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "567664f262709473930a4bf9e51bf2ebf3348f2e748ccc50dea20646858f8f29"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
-name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
@@ -11151,23 +11183,18 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64 0.22.1",
  "bytes",
- "encoding_rs",
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.13",
  "http 1.4.0",
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.9.0",
  "hyper-rustls",
- "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
- "mime",
  "mime_guess",
- "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -11178,7 +11205,6 @@ dependencies = [
  "serde_urlencoded",
  "sync_wrapper",
  "tokio",
- "tokio-native-tls",
  "tokio-rustls",
  "tower 0.5.3",
  "tower-http 0.6.11",
@@ -11585,7 +11611,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11598,7 +11624,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11679,7 +11705,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12768,7 +12794,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12838,18 +12864,21 @@ dependencies = [
 
 [[package]]
 name = "testcontainers"
-version = "0.23.3"
+version = "0.27.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59a4f01f39bb10fc2a5ab23eb0d888b1e2bb168c157f61a1b98e6c501c639c74"
+checksum = "bfd5785b5483672915ed5fe3cddf9f546802779fc1eceff0a6fb7321fac81c1e"
 dependencies = [
+ "astral-tokio-tar",
  "async-trait",
  "bollard",
- "bollard-stubs",
  "bytes",
  "docker_credential",
  "either",
  "etcetera",
+ "ferroid",
  "futures",
+ "http 1.4.0",
+ "itertools 0.14.0",
  "log",
  "memchr",
  "parse-display",
@@ -12860,7 +12889,6 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-stream",
- "tokio-tar",
  "tokio-util",
  "url",
 ]
@@ -13074,16 +13102,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-native-tls"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
-dependencies = [
- "native-tls",
- "tokio",
-]
-
-[[package]]
 name = "tokio-rustls"
 version = "0.26.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13103,21 +13121,6 @@ dependencies = [
  "pin-project-lite",
  "tokio",
  "tokio-util",
-]
-
-[[package]]
-name = "tokio-tar"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d5714c010ca3e5c27114c1cdeb9d14641ace49874aa5626d7149e47aedace75"
-dependencies = [
- "filetime",
- "futures-core",
- "libc",
- "redox_syscall 0.3.5",
- "tokio",
- "tokio-stream",
- "xattr",
 ]
 
 [[package]]
@@ -13906,6 +13909,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
 
 [[package]]
+name = "ureq"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dea7109cdcd5864d4eeb1b58a1648dc9bf520360d7af16ec26d0a9354bafcfc0"
+dependencies = [
+ "base64 0.22.1",
+ "log",
+ "percent-encoding",
+ "rustls",
+ "rustls-pki-types",
+ "ureq-proto",
+ "utf8-zero",
+]
+
+[[package]]
+name = "ureq-proto"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e994ba84b0bd1b1b0cf92878b7ef898a5c1760108fe7b6010327e274917a808c"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.4.0",
+ "httparse",
+ "log",
+]
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -13929,6 +13959,12 @@ name = "utf-8"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
+
+[[package]]
+name = "utf8-zero"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8c0a043c9540bae7c578c88f91dda8bd82e59ae27c21baca69c8b191aaf5a6e"
 
 [[package]]
 name = "utf8_iter"
@@ -14270,7 +14306,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -14482,15 +14518,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.48.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
-dependencies = [
- "windows-targets 0.48.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -14529,21 +14556,6 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
-dependencies = [
- "windows_aarch64_gnullvm 0.48.5",
- "windows_aarch64_msvc 0.48.5",
- "windows_i686_gnu 0.48.5",
- "windows_i686_msvc 0.48.5",
- "windows_x86_64_gnu 0.48.5",
- "windows_x86_64_gnullvm 0.48.5",
- "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -14588,12 +14600,6 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
-
-[[package]]
-name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -14606,12 +14612,6 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
-
-[[package]]
-name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -14621,12 +14621,6 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
-
-[[package]]
-name = "windows_i686_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -14648,12 +14642,6 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
-
-[[package]]
-name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -14663,12 +14651,6 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -14684,12 +14666,6 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
-
-[[package]]
-name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -14699,12 +14675,6 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
-
-[[package]]
-name = "windows_x86_64_msvc"
-version = "0.48.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -226,7 +226,7 @@ blueprint-metrics-rpc-calls = { version = "0.2.0-alpha.5", path = "./crates/metr
 
 cargo-tangle = { version = "0.5.0-alpha.13", path = "./cli", default-features = false }
 cargo_metadata = { version = "0.18.1" }
-bollard = { version = "0.18.0", features = ["ssl"] }
+bollard = { version = "0.20", features = ["ssl"] }
 
 # Round-based networking
 round-based = { version = "0.4.1", default-features = false }
@@ -354,7 +354,7 @@ nftables = { version = "0.6.3", default-features = false }
 # Development & Testing
 auto_impl = { version = "1.2.1", default-features = false }
 cargo_toml = { version = "0.21.0", default-features = false }
-docktopus = { version = "0.4.0-alpha.3", default-features = false }
+docktopus = { version = "0.5.0-alpha.2", default-features = false }
 itertools = { version = "0.14.0", default-features = false }
 paste = { version = "1.0.15", default-features = false }
 proc-macro2 = { version = "1.0", default-features = false }
@@ -444,7 +444,7 @@ zeroize = { version = "1.8.1", default-features = false }
 zerocopy = { version = "0.8", default-features = false }
 
 rust-bls-bn254 = { version = "0.2.1", default-features = false }
-testcontainers = { version = "0.23.1", default-features = false }
+testcontainers = { version = "0.27.3", default-features = false }
 
 # Metrics
 metrics = { version = "0.24.6", default-features = false }

--- a/crates/manager/src/metrics.rs
+++ b/crates/manager/src/metrics.rs
@@ -751,7 +751,7 @@ mod tests {
 
         let family = find_family("tangle_service_discovery_total");
         let metric = find_metric_with_label_value(&family, tag);
-        let count = metric.get_counter().get_value() as u64;
+        let count = metric.get_counter().value.unwrap_or_default() as u64;
         assert!(count >= 3, "expected >= 3 for '{tag}', got {count}");
     }
 
@@ -776,7 +776,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "success")
             })
             .expect("success metric not found");
-        assert!(success.get_counter().get_value() >= 1.0);
+        assert!(success.get_counter().value.unwrap_or_default() >= 1.0);
 
         let fail = family
             .get_metric()
@@ -786,7 +786,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "failed_spawn")
             })
             .expect("failed_spawn metric not found");
-        assert!(fail.get_counter().get_value() >= 2.0);
+        assert!(fail.get_counter().value.unwrap_or_default() >= 2.0);
     }
 
     #[test]
@@ -806,7 +806,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "success")
             })
             .expect("jobs success metric");
-        assert!(success.get_counter().get_value() >= 2.0);
+        assert!(success.get_counter().value.unwrap_or_default() >= 2.0);
 
         let failed = family
             .get_metric()
@@ -816,7 +816,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "failed")
             })
             .expect("jobs failed metric");
-        assert!(failed.get_counter().get_value() >= 1.0);
+        assert!(failed.get_counter().value.unwrap_or_default() >= 1.0);
     }
 
     // ── 7. IntGauge set / inc / dec ────────────────────────────────────
@@ -841,7 +841,7 @@ mod tests {
         // Verify through gathered output.
         let family = find_family("tangle_active_services");
         let metric = &family.get_metric()[0];
-        let val = metric.get_gauge().get_value() as i64;
+        let val = metric.get_gauge().value.unwrap_or_default() as i64;
         assert_eq!(val, 9, "gathered gauge value should be 9");
     }
 }

--- a/crates/qos/src/servers/common.rs
+++ b/crates/qos/src/servers/common.rs
@@ -1,13 +1,15 @@
 use blueprint_core::{debug, error, info, warn};
 use bollard::{
     Docker,
-    container::{
-        Config, CreateContainerOptions, ListContainersOptions, LogsOptions, RemoveContainerOptions,
-        StartContainerOptions, StopContainerOptions,
+    models::{
+        ContainerCreateBody, HealthConfig, HealthStatusEnum, HostConfig, NetworkConnectRequest,
+        NetworkCreateRequest, PortBinding,
     },
-    image::CreateImageOptions,
-    models::{HealthConfig, HealthStatusEnum, HostConfig, PortBinding},
-    network::{ConnectNetworkOptions, CreateNetworkOptions, InspectNetworkOptions},
+    query_parameters::{
+        CreateContainerOptionsBuilder, CreateImageOptionsBuilder, InspectContainerOptions,
+        InspectNetworkOptions, ListContainersOptions, LogsOptionsBuilder,
+        RemoveContainerOptionsBuilder, StartContainerOptions, StopContainerOptions,
+    },
 };
 use futures::StreamExt;
 use std::{collections::HashMap, default::Default};
@@ -67,10 +69,7 @@ impl DockerManager {
         }
 
         info!("Pulling image '{}'...", image);
-        let options = Some(CreateImageOptions {
-            from_image: image,
-            ..Default::default()
-        });
+        let options = Some(CreateImageOptionsBuilder::new().from_image(image).build());
 
         let mut stream = self.docker.create_image(options, None, None);
         while let Some(pull_result) = stream.next().await {
@@ -158,23 +157,17 @@ impl DockerManager {
             start_interval: Some(1_000_000_000),
         });
 
-        let cmd_slices: Option<Vec<&str>> =
-            cmd.as_ref().map(|v| v.iter().map(AsRef::as_ref).collect());
-
-        let config = Config {
-            image: Some(image),
-            env: Some(env.iter().map(AsRef::as_ref).collect()),
+        let config = ContainerCreateBody {
+            image: Some(image.to_string()),
+            env: Some(env),
             host_config: Some(host_config),
             healthcheck: health_config,
-            cmd: cmd_slices,
+            cmd,
             ..Default::default()
         };
 
         info!("Creating container '{}' from image '{}'", name, image);
-        let options = Some(CreateContainerOptions {
-            name: name.to_string(),
-            platform: None,
-        });
+        let options = Some(CreateContainerOptionsBuilder::new().name(name).build());
 
         let container_id = match self.docker.create_container(options, config).await {
             Ok(response) => response.id,
@@ -188,7 +181,7 @@ impl DockerManager {
         info!("Starting container '{}' (ID: {})", name, &container_id);
         if let Err(e) = self
             .docker
-            .start_container(&container_id, None::<StartContainerOptions<String>>)
+            .start_container(&container_id, None::<StartContainerOptions>)
             .await
         {
             let err_msg = format!("Failed to start container '{}': {}", name, e);
@@ -209,7 +202,7 @@ impl DockerManager {
     ///
     /// Returns an error if the container cannot be cleaned up
     async fn cleanup_container_by_name(&self, name: &str) -> Result<()> {
-        let list_options = ListContainersOptions::<String>::default();
+        let list_options = ListContainersOptions::default();
 
         let containers = self
             .docker
@@ -262,10 +255,7 @@ impl DockerManager {
         self.docker
             .remove_container(
                 container_id,
-                Some(RemoveContainerOptions {
-                    force: true,
-                    ..Default::default()
-                }),
+                Some(RemoveContainerOptionsBuilder::new().force(true).build()),
             )
             .await
             .map_err(|e| {
@@ -285,7 +275,7 @@ impl DockerManager {
     pub async fn create_network(&self, network_name: &str) -> Result<()> {
         match self
             .docker
-            .inspect_network(network_name, None::<InspectNetworkOptions<String>>)
+            .inspect_network(network_name, None::<InspectNetworkOptions>)
             .await
         {
             Ok(_) => {
@@ -296,8 +286,8 @@ impl DockerManager {
                 status_code: 404, ..
             }) => {
                 info!("Creating Docker network: '{}'", network_name);
-                let options = CreateNetworkOptions {
-                    name: network_name,
+                let options = NetworkCreateRequest {
+                    name: network_name.to_string(),
                     ..Default::default()
                 };
                 self.docker
@@ -325,8 +315,8 @@ impl DockerManager {
             "Connecting container '{}' to network '{}'",
             container_name, network_name
         );
-        let options = ConnectNetworkOptions {
-            container: container_name,
+        let options = NetworkConnectRequest {
+            container: container_name.to_string(),
             ..Default::default()
         };
         self.docker
@@ -343,7 +333,7 @@ impl DockerManager {
     pub async fn is_container_running(&self, container_id: &str) -> Result<bool> {
         let container = self
             .docker
-            .inspect_container(container_id, None)
+            .inspect_container(container_id, None::<InspectContainerOptions>)
             .await
             .map_err(|e| Error::DockerOperation(e.to_string()))?;
 
@@ -356,12 +346,13 @@ impl DockerManager {
     ///
     /// Returns an error if the container is not healthy within the timeout period
     pub async fn dump_container_logs(&self, container_id: &str) {
-        let options = Some(LogsOptions {
-            stdout: true,
-            stderr: true,
-            tail: "all".to_string(),
-            ..Default::default()
-        });
+        let options = Some(
+            LogsOptionsBuilder::new()
+                .stdout(true)
+                .stderr(true)
+                .tail("all")
+                .build(),
+        );
         error!("Dumping logs for container {}:", container_id);
         let mut logs_stream = self.docker.logs(container_id, options);
         while let Some(log_result) = logs_stream.next().await {
@@ -401,7 +392,10 @@ impl DockerManager {
         let start = Instant::now();
 
         while start.elapsed() < timeout {
-            let inspect_result = self.docker.inspect_container(container_id, None).await;
+            let inspect_result = self
+                .docker
+                .inspect_container(container_id, None::<InspectContainerOptions>)
+                .await;
 
             match inspect_result {
                 Ok(container) => {


### PR DESCRIPTION
## Summary

- Clears **RUSTSEC-2025-0111** (`tokio-tar` PAX header desynchronization, **HIGH**) by moving the workspace to `bollard` 0.20 + `testcontainers` 0.27.3. Measured with `cargo audit` on the real workspace lock: **9 advisories → 8**.
- Also fixes 6 **pre-existing** protobuf-3 breakages in `crates/manager/src/metrics.rs` that fail CI clippy independent of this change.
- Affects the **developer/CI** flow: `testcontainers` is a dev-dependency; `bollard` is used by `blueprint-qos` for container control.

## Change Class

- `Class A` (docs/tooling only)
- `Class B` (single-crate behavior)
- `Class C` (cross-crate/runtime behavior)
- `Class D` (protocol/security/metadata semantics)
- Selected class: Class D
- Why this class: resolves a published security advisory and changes a dependency used for container lifecycle control.

## Behavior Contract

- Current behavior: `tokio-tar` 0.3.1 present (HIGH advisory); `metrics.rs` does not compile under CI clippy.
- Intended behavior: no tar-family advisory of any kind; workspace and tests compile clean.
- Invariants that must hold: container create/start/stop/logs/network behavior in `blueprint-qos` is unchanged — only the option-struct *shape* changed, not semantics.
- Failure mode choice (`fail-closed` or `fail-open`): **fail-closed** — every change is compile-verified; deprecations are errors under `-D warnings`.

### Why the cheaper path is a regression
`testcontainers` dropped `tokio-tar` at 0.26 in favour of `astral-tokio-tar` — but `astral-tokio-tar` 0.5.x carries **four advisories of its own**, including RUSTSEC-2026-0145, the *same* PAX-desync bug class:

| testcontainers | tar dependency |
|---|---|
| 0.23 – 0.25.0 | `tokio-tar` ^0.3.1 — the current HIGH |
| 0.25.1 – 0.27.1 | `astral-tokio-tar` ^0.5.6 — **4 advisories** |
| **0.27.2+** | `astral-tokio-tar` ^0.6.0 → resolves **0.6.4, clean** |
| 0.26.x | requires `bollard` ^0.19.4 |
| 0.27.x | requires `bollard` ^0.20.0 |

Measured on the real lock: bollard 0.19 + tc 0.26.3 = **12** advisories (net worse); bollard 0.20 + tc 0.27.3 = **8**, zero tar advisories.

### Why this needed a docktopus release
`bollard` exact-pins `bollard-stubs`, and every stubs release shares major 1 — so two bollard majors cannot coexist, and whatever `docktopus` pins *is* the workspace's bollard. No published docktopus ever allowed 0.20, even though its `main` has carried `bollard = "0.20"` since its #73. Released as **docktopus 0.5.0-alpha.2**; this PR depends on it.

## Risk and Scope

- Security impact: **positive** — removes a HIGH advisory without introducing the `astral-tokio-tar` 0.5.x set.
- Compatibility impact: `blueprint-qos`'s bollard call sites are rewritten to the 0.19/0.20 API (option structs moved to `bollard::query_parameters` typed builders and `bollard::models`; `NetworkConnectRequest.container` went `Option<String>` → `String`). No public API of any blueprint crate changes. `testcontainers` 0.23 → 0.27.3 required **zero** source changes across all five consumers.
- Migration notes: consumers pinning `docktopus` must move to `0.5.0-alpha.2`.
- Rollback plan: revert the commit; docktopus 0.5.0-alpha.2 remains published and harmless.

## Verification

```bash
cargo clippy --workspace --tests --examples -- -D warnings   # exit 0
cargo clippy --workspace --all-features -- -D warnings       # exit 0
cargo fmt --all -- --check                                   # exit 0
cargo check --workspace --all-features                       # clean

grep -A1 '^name = "tokio-tar"' Cargo.lock          # absent
grep -A1 '^name = "astral-tokio-tar"' Cargo.lock   # 0.6.4
```

## Harness Evidence

- Reproducer added/updated: n/a — dependency/security change; `cargo audit` on the lockfile is the check (9 → 8).
- Negative-path coverage added: the three candidate lock states were each audited rather than assumed, which is what surfaced that bollard 0.19 makes things worse (12).
- Key assertions that prove the fix: `tokio-tar` absent from `Cargo.lock`; `astral-tokio-tar` resolves 0.6.4; all CI gates exit 0.

### Included pre-existing fix
`crates/manager/src/metrics.rs` — protobuf 3.x moved `MessageField` accessors, so `.get_counter().get_value()` is now `.get_counter().value`, typed `Option<f64>`. Six sites. This is the same class #1480 fixed in `qos`; `manager` was missed, and it fails CI clippy regardless of this PR.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue. — n/a; `cargo audit` on the lock is the reproducer.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input. — n/a; each candidate lock state was audited instead.
- [x] I documented behavior or interface changes in docs/examples when needed. — no public API change.
- [x] I evaluated compatibility/migration impact explicitly. — see Risk and Scope.
- [x] I validated local formatting, clippy, and relevant tests. — all four gates exit 0.
