### PR TITLE
fix(deps): clear the gix advisories via cargo-generate; MSRV 1.91 -> 1.93

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -768,7 +768,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 1.8.3",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -789,7 +789,7 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 2.0.5",
  "alloy-sol-types",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "serde",
  "serde_json",
  "serde_with",
@@ -1080,7 +1080,7 @@ checksum = "e8597d36d546e1dab822345ad563243ec3920e199322cb554ce56c8ef1a1e2e7"
 dependencies = [
  "alloy-json-rpc 1.8.3",
  "alloy-transport 1.8.3",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "opentelemetry 0.31.0",
  "opentelemetry-http 0.31.0",
  "reqwest 0.13.2",
@@ -1098,7 +1098,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b273587487921274f4f5d0ef2c7ef36944dcbb75a4e2318e69eae822bd263f91"
 dependencies = [
  "alloy-transport 2.0.5",
- "itertools 0.14.0",
+ "itertools 0.13.0",
  "url",
 ]
 
@@ -1973,9 +1973,9 @@ dependencies = [
 
 [[package]]
 name = "auth-git2"
-version = "0.5.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4888bf91cce63baf1670512d0f12b5d636179a4abbad6504812ac8ab124b3efe"
+checksum = "aec364a6ee335b23a7e77703100f5103965810f91a9ef6319a004a7e7b8e2b66"
 dependencies = [
  "dirs",
  "git2",
@@ -4347,9 +4347,9 @@ dependencies = [
 
 [[package]]
 name = "cargo-generate"
-version = "0.23.8"
+version = "0.23.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c3b0a106ac22b8fcd7dee8fb5b21c9276564866d954244324a7bdd346ebdb68"
+checksum = "235b52703f238dadd90a745ab9e192982211cfb8203059b1814fd92bd4f8a9ea"
 dependencies = [
  "anstyle",
  "anyhow",
@@ -4362,6 +4362,7 @@ dependencies = [
  "fs-err",
  "git2",
  "gix-config",
+ "gix-hash",
  "heck",
  "home",
  "ignore",
@@ -4383,7 +4384,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "time",
- "toml 0.9.12+spec-1.1.0",
+ "toml 1.1.2+spec-1.1.0",
  "walkdir",
 ]
 
@@ -4452,17 +4453,18 @@ dependencies = [
 
 [[package]]
 name = "cargo-util-schemas"
-version = "0.10.2"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f714efe9b56ea4bed06b499396e77b68db663a55b16dc3f144d5a5a0dc19788c"
+checksum = "73d08f8ffc65abe86dffd3497839adee21cbe3f3b19c17987aa5267998adcf77"
 dependencies = [
+ "jiff",
  "semver 1.0.28",
  "serde",
  "serde-untagged",
  "serde-value",
  "thiserror 2.0.18",
  "toml 0.9.12+spec-1.1.0",
- "unicode-xid",
+ "unicode-ident",
  "url",
 ]
 
@@ -4643,9 +4645,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.61"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52fa72306bb30daf11bc97773431628e5b4916e97aaa74b7d3f625d4d495da02"
+checksum = "301b56658598e48f3648647ac6fc887be7e7108eddfa4e9b63fcf3ec58c0cadf"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -4663,9 +4665,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.61"
+version = "4.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2071365c5c56eae7d77414029dde2f4f4ba151cf68d5a3261c9a40de428ace93"
+checksum = "94a65403d1a1bd28f7dc68eb8506e8874808ee5eecb59298de588e2e1407a078"
 dependencies = [
  "anstream",
  "anstyle",
@@ -4676,14 +4678,14 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.61"
+version = "4.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dec5be1eea072311774b7b84ded287adbd9f293f9d23456817605c6042f4f5e0"
+checksum = "d012d2b9d65aca7f18f4d9878a045bc17899bba951561ba5ec3c2ba1eed9a061"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -4835,7 +4837,7 @@ version = "3.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf9468729b8cbcea668e36183cb69d317348c2e08e994829fb56ebfdfbaac34"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5337,6 +5339,37 @@ name = "deadpool-runtime"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
+name = "defmt"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2953bfe4f93bbd20cc71198842756f77d161884c99ebbabc41d80231ded88d1"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bad9c72e7ca2137e0dc3813245a0d282fd6daad32fd800af018306a9169b5fe8"
+dependencies = [
+ "defmt-parser",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "der"
@@ -5892,7 +5925,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -6119,9 +6152,9 @@ dependencies = [
 
 [[package]]
 name = "fs-err"
-version = "3.2.2"
+version = "3.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf68cef89750956493a66a10f512b9e58d9db21f2a573c079c0bdf1207a54a7"
+checksum = "b91aa448ca50d7e79433bdf3ee8d99215430d2ec02ade5aefab2a073a1822e8a"
 dependencies = [
  "autocfg",
 ]
@@ -6432,9 +6465,9 @@ checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
 
 [[package]]
 name = "git2"
-version = "0.20.4"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b88256088d75a56f8ecfa070513a775dd9107f6530ef14919dac831af9cfe2b"
+checksum = "ddddbf932745a6be37109b6112d3ee09696106f848449069d3a57bba937ab82e"
 dependencies = [
  "bitflags 2.11.1",
  "libc",
@@ -6447,23 +6480,20 @@ dependencies = [
 
 [[package]]
 name = "gix-actor"
-version = "0.36.1"
+version = "0.41.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "636ca0d7bf8f7ad8ba84a5dda8312c8944b275be09d88b072e08f57d3e47c1e8"
+checksum = "33f9308ad6fd35b2a865cbe4117ac61b2be59e4a9ef1621c7a9794f7c8e52c5b"
 dependencies = [
  "bstr",
  "gix-date",
- "gix-utils",
- "itoa",
- "thiserror 2.0.18",
- "winnow 0.7.15",
+ "gix-error",
 ]
 
 [[package]]
 name = "gix-config"
-version = "0.48.0"
+version = "0.56.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9419284839421488b5ab9b9b88386bdc1e159a986c08e17ffa3e9a5cd2b139f5"
+checksum = "8c01848aebd21c67f6ba41f1de8efd46ae96df21f001954a3c9e1517e514d410"
 dependencies = [
  "bstr",
  "gix-config-value",
@@ -6472,18 +6502,16 @@ dependencies = [
  "gix-path",
  "gix-ref",
  "gix-sec",
- "memchr",
  "smallvec",
  "thiserror 2.0.18",
  "unicode-bom",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-config-value"
-version = "0.15.3"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c489abb061c74b0c3ad790e24a606ef968cebab48ec673d6a891ece7d5aef64"
+checksum = "ed42168329552f6c2e5df09665c104199d45d84bedb53683738a49b57fe1baab"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -6494,22 +6522,30 @@ dependencies = [
 
 [[package]]
 name = "gix-date"
-version = "0.11.1"
+version = "0.15.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0a1259955c76335c9d1a8c511811b10dbc800ffeeca3daea1e0aadd0c98f6b7"
+checksum = "7e47b9e8cdc688296609b706428de570f88b1e0eed7156dde7b4a89d26fa4567"
 dependencies = [
  "bstr",
+ "gix-error",
  "itoa",
  "jiff",
- "smallvec",
- "thiserror 2.0.18",
+]
+
+[[package]]
+name = "gix-error"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9292309fd944e71b2a3c96d3c03a6feb8852db646febdde7cbb9f79cb5f329"
+dependencies = [
+ "bstr",
 ]
 
 [[package]]
 name = "gix-features"
-version = "0.44.1"
+version = "0.48.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfa64593d1586135102307fb57fb3a9d3868b6b1f45a4da1352cce5070f8916a"
+checksum = "1849ae154d38bc403185be14fa871e38e3c93ee606875d94e207fdb9fba52dbc"
 dependencies = [
  "gix-path",
  "gix-trace",
@@ -6521,9 +6557,9 @@ dependencies = [
 
 [[package]]
 name = "gix-fs"
-version = "0.17.0"
+version = "0.21.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f1ecd896258cdc5ccd94d18386d17906b8de265ad2ecf68e3bea6b007f6a28f"
+checksum = "6cdff46db8798e47e2f727d84b9379aac5add3dd3d9d0b07bb4d7d5d640771fe"
 dependencies = [
  "bstr",
  "fastrand",
@@ -6535,9 +6571,9 @@ dependencies = [
 
 [[package]]
 name = "gix-glob"
-version = "0.22.1"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "74254992150b0a88fdb3ad47635ab649512dff2cbbefca7916bb459894fc9d56"
+checksum = "d1fcb8ef5b16bcf874abe9b68d8abb3c0493c876d367ab824151f30a0f3f3756"
 dependencies = [
  "bitflags 2.11.1",
  "bstr",
@@ -6547,9 +6583,9 @@ dependencies = [
 
 [[package]]
 name = "gix-hash"
-version = "0.20.1"
+version = "0.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "826036a9bee95945b0be1e2394c64cd4289916c34a639818f8fd5153906985c1"
+checksum = "cb0926d3819c837750b4e03c7754901e73f68b8c9b690753a6372a1bed4eedce"
 dependencies = [
  "faster-hex",
  "gix-features",
@@ -6559,20 +6595,20 @@ dependencies = [
 
 [[package]]
 name = "gix-hashtable"
-version = "0.10.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27d4a3ea9640da504a2657fef3419c517fd71f1767ad8935298bcc805edd195"
+checksum = "b0e30b93eea8718baf7d8153fcb938e2926175bbf18097c09f1c01b6f0be0563"
 dependencies = [
  "gix-hash",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "parking_lot",
 ]
 
 [[package]]
 name = "gix-lock"
-version = "19.0.0"
+version = "23.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "729d7857429a66023bc0c29d60fa21d0d6ae8862f33c1937ba89e0f74dd5c67f"
+checksum = "65c9dedd9e90b0d47624d2ed241d394e09294118364e87b9b7e5f1fe755f3c2c"
 dependencies = [
  "gix-tempfile",
  "gix-utils",
@@ -6581,9 +6617,9 @@ dependencies = [
 
 [[package]]
 name = "gix-object"
-version = "0.52.0"
+version = "0.60.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84743d1091c501a56f00d7f4c595cb30f20fcef6503b32ac0a1ff3817efd7b5d"
+checksum = "a38075a95d7cc5df8afd38e72c617026c1456952207a4120a7f55a3fbf93b4d7"
 dependencies = [
  "bstr",
  "gix-actor",
@@ -6591,20 +6627,18 @@ dependencies = [
  "gix-features",
  "gix-hash",
  "gix-hashtable",
- "gix-path",
  "gix-utils",
  "gix-validate",
  "itoa",
  "smallvec",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-path"
-version = "0.10.22"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cb06c3e4f8eed6e24fd915fa93145e28a511f4ea0e768bae16673e05ed3f366"
+checksum = "1ed3e8d7a82e886e17a72e03d4ba0c13db6f2219b6cd4e2900b4cae426ec20c9"
 dependencies = [
  "bstr",
  "gix-trace",
@@ -6614,9 +6648,9 @@ dependencies = [
 
 [[package]]
 name = "gix-ref"
-version = "0.55.0"
+version = "0.63.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51330a32f173c8e831731dfef8e93a748c23c057f4b028841f222564cad84cb"
+checksum = "d8ba9cc15f558b274c99349b83130f5ec83459660828fde9718bbbb43a726167"
 dependencies = [
  "gix-actor",
  "gix-features",
@@ -6630,14 +6664,13 @@ dependencies = [
  "gix-validate",
  "memmap2",
  "thiserror 2.0.18",
- "winnow 0.7.15",
 ]
 
 [[package]]
 name = "gix-sec"
-version = "0.12.2"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea9962ed6d9114f7f100efe038752f41283c225bb507a2888903ac593dffa6be"
+checksum = "af4fe6c152c1d50aea36f299825702cd37e303307832fec1d0fdd5844e47ce2f"
 dependencies = [
  "bitflags 2.11.1",
  "gix-path",
@@ -6647,9 +6680,9 @@ dependencies = [
 
 [[package]]
 name = "gix-tempfile"
-version = "19.0.1"
+version = "23.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e265fc6b54e57693232a79d84038381ebfda7b1a3b1b8a9320d4d5fe6e820086"
+checksum = "6ef60812443484e67bf84e444cc71b4c78ae62deb822221774a4fa0c57fdb17f"
 dependencies = [
  "gix-fs",
  "libc",
@@ -6659,28 +6692,28 @@ dependencies = [
 
 [[package]]
 name = "gix-trace"
-version = "0.1.18"
+version = "0.1.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f69a13643b8437d4ca6845e08143e847a36ca82903eed13303475d0ae8b162e0"
+checksum = "be3eb81d9dc914335923e50d52829c551feefd6a72d176c4130c546b67a60814"
 
 [[package]]
 name = "gix-utils"
-version = "0.3.1"
+version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befcdbdfb1238d2854591f760a48711bed85e72d80a10e8f2f93f656746ef7c5"
+checksum = "b1795bd2a970ca8b2185318c2abb97d955c71992f1cf28de73ad3b593a9f3ce8"
 dependencies = [
  "fastrand",
+ "getrandom 0.4.2",
  "unicode-normalization",
 ]
 
 [[package]]
 name = "gix-validate"
-version = "0.10.1"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b1e63a5b516e970a594f870ed4571a8fdcb8a344e7bd407a20db8bd61dbfde4"
+checksum = "9a034e84d1e04e1b1f20f51f12491da230b6ac8b925d0c8e1b89bcd87a7c5ccc"
 dependencies = [
  "bstr",
- "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -7693,25 +7726,37 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jiff"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a3546dc96b6d42c5f24902af9e2538e82e39ad350b0c766eb3fbf2d8f3d8359"
+checksum = "668b7183bd07af9a4885f5c35b0cc5c83c4607a913c16b7e17291832910d2dcc"
 dependencies = [
+ "defmt",
+ "jiff-core",
  "jiff-static",
  "jiff-tzdb-platform",
  "log",
  "portable-atomic",
  "portable-atomic-util",
  "serde_core",
- "windows-sys 0.52.0",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jiff-core"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7feca88439efe53da3754500c1851dedf3cb36c524dd5cf8225cc0794de95d09"
+dependencies = [
+ "defmt",
 ]
 
 [[package]]
 name = "jiff-static"
-version = "0.2.23"
+version = "0.2.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8c8b344124222efd714b73bb41f8b5120b27a7cc1c75593a6ff768d9d05aa4"
+checksum = "3a69dcb3a21cfb32ce1cd056169337ca284af0766dd766e7878819b251a49204"
 dependencies = [
+ "jiff-core",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -8147,9 +8192,9 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libgit2-sys"
-version = "0.18.3+1.9.2"
+version = "0.18.7+1.9.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9b3acc4b91781bb0b3386669d325163746af5f6e4f73e6d2d630e09a35f3487"
+checksum = "23c7391e4b9f4ffab1a624223cc1d7385ff9a678f490768add717de7ea2f4d89"
 dependencies = [
  "cc",
  "libc",
@@ -10511,9 +10556,9 @@ dependencies = [
 
 [[package]]
 name = "prodash"
-version = "30.0.1"
+version = "31.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a6efc566849d3d9d737c5cb06cc50e48950ebe3d3f9d70631490fff3a07b139"
+checksum = "962200e2d7d551451297d9fdce85138374019ada198e30ea9ede38034e27604c"
 dependencies = [
  "parking_lot",
 ]
@@ -10604,7 +10649,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
 dependencies = [
  "heck",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "log",
  "multimap",
  "once_cell",
@@ -10624,7 +10669,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10637,7 +10682,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.10.5",
  "proc-macro2",
  "quote",
  "syn 2.0.117",
@@ -10818,7 +10863,7 @@ dependencies = [
  "once_cell",
  "socket2 0.5.10",
  "tracing",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11254,26 +11299,26 @@ dependencies = [
 
 [[package]]
 name = "rhai"
-version = "1.23.6"
+version = "1.25.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4e35aaaa439a5bda2f8d15251bc375e4edfac75f9865734644782c9701b5709"
+checksum = "dd4dd0f8c36625202a4ba553c416c19b719947cd2a31d1bda06126e4a5727daf"
 dependencies = [
  "ahash 0.8.12",
  "bitflags 2.11.1",
- "instant",
  "num-traits",
  "once_cell",
  "rhai_codegen",
  "smallvec",
  "smartstring",
  "thin-vec",
+ "web-time",
 ]
 
 [[package]]
 name = "rhai_codegen"
-version = "3.1.0"
+version = "3.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4322a2a4e8cf30771dd9f27f7f37ca9ac8fe812dddd811096a98483080dabe6"
+checksum = "3cd3a7535e50bf36857e7be7bec276d334e8c2dfa469c2201226fd01638ea5ca"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -11585,7 +11630,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.4.15",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -11598,7 +11643,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys 0.12.1",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -11679,7 +11724,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -12643,6 +12688,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "syn"
+version = "3.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
 name = "syn-solidity"
 version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -12768,7 +12824,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix 1.1.4",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -13192,13 +13248,9 @@ version = "0.9.12+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
 dependencies = [
- "indexmap 2.14.0",
  "serde_core",
  "serde_spanned 1.1.1",
  "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -14270,7 +14322,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition = "2024"
 license = "MIT OR Apache-2.0"
 homepage = "https://tangle.tools"
 repository = "https://github.com/tangle-network/blueprint"
-rust-version = "1.91"
+rust-version = "1.93"
 
 [workspace.lints.rust]
 rust_2018_idioms = { level = "deny", priority = -1 }
@@ -252,7 +252,7 @@ tower-http = { version = "0.7", default-features = false }
 async-stream = { version = "0.3.6", default-features = false }
 
 # CLI & Configuration
-cargo-generate = { version = "0.23.7", default-features = false }
+cargo-generate = { version = "0.23.12", default-features = false }
 clap = { version = "4.5.60", features = ["derive", "env"] }
 clap-cargo = { version = "0.18", default-features = false }
 toml = { version = "1.0", default-features = false, features = ["parse", "display", "serde"] }

--- a/crates/auth/src/tests/grpc_proxy_tests.rs
+++ b/crates/auth/src/tests/grpc_proxy_tests.rs
@@ -505,13 +505,11 @@ async fn grpc_only_allows_proxy_injected_headers() {
         let response = client.echo(request).await;
         // Note: These headers should be allowed at the gRPC level
         // The real security check happens in our proxy header processing
-        if response.is_ok() {
-            println!("Header {header_name} was allowed at gRPC level");
-        } else {
-            println!(
-                "Header {header_name} was rejected at gRPC level: {:?}",
-                response.unwrap_err()
-            );
+        match response {
+            Ok(_) => println!("Header {header_name} was allowed at gRPC level"),
+            Err(err) => {
+                println!("Header {header_name} was rejected at gRPC level: {err:?}")
+            }
         }
     }
 

--- a/crates/blueprint-faas/src/digitalocean/mod.rs
+++ b/crates/blueprint-faas/src/digitalocean/mod.rs
@@ -289,48 +289,49 @@ impl FaasExecutor for DigitalOceanExecutor {
             .send()
             .await;
 
-        let function_url =
-            if update_response.is_ok() && update_response.as_ref().unwrap().status().is_success() {
-                info!(function = %function_name, "Updated existing function");
-                update_response
-                    .unwrap()
-                    .json::<FunctionResponse>()
-                    .await
-                    .map_err(|e| FaasError::SerializationError(e.to_string()))?
-                    .trigger
-                    .url
-            } else {
-                // Create new function
-                debug!(function = %function_name, "Creating new function");
+        let updated_ok = match update_response {
+            Ok(resp) if resp.status().is_success() => Some(resp),
+            _ => None,
+        };
+        let function_url = if let Some(resp) = updated_ok {
+            info!(function = %function_name, "Updated existing function");
+            resp.json::<FunctionResponse>()
+                .await
+                .map_err(|e| FaasError::SerializationError(e.to_string()))?
+                .trigger
+                .url
+        } else {
+            // Create new function
+            debug!(function = %function_name, "Creating new function");
 
-                let create_url = self.api_endpoint("triggers");
-                let response = self
-                    .client
-                    .post(&create_url)
-                    .bearer_auth(&self.api_token)
-                    .json(&function_spec)
-                    .send()
-                    .await
-                    .map_err(|e| {
-                        FaasError::InfrastructureError(format!("Failed to create function: {}", e))
-                    })?;
+            let create_url = self.api_endpoint("triggers");
+            let response = self
+                .client
+                .post(&create_url)
+                .bearer_auth(&self.api_token)
+                .json(&function_spec)
+                .send()
+                .await
+                .map_err(|e| {
+                    FaasError::InfrastructureError(format!("Failed to create function: {}", e))
+                })?;
 
-                if !response.status().is_success() {
-                    let error_text = response.text().await.unwrap_or_default();
-                    return Err(FaasError::InfrastructureError(format!(
-                        "Failed to create function: {}",
-                        error_text
-                    )));
-                }
+            if !response.status().is_success() {
+                let error_text = response.text().await.unwrap_or_default();
+                return Err(FaasError::InfrastructureError(format!(
+                    "Failed to create function: {}",
+                    error_text
+                )));
+            }
 
-                let data: FunctionResponse = response
-                    .json()
-                    .await
-                    .map_err(|e| FaasError::SerializationError(e.to_string()))?;
+            let data: FunctionResponse = response
+                .json()
+                .await
+                .map_err(|e| FaasError::SerializationError(e.to_string()))?;
 
-                info!(function = %function_name, "Created new function");
-                data.trigger.url
-            };
+            info!(function = %function_name, "Created new function");
+            data.trigger.url
+        };
 
         Ok(FaasDeployment {
             function_id: function_name.clone(),

--- a/crates/keystore/src/lib.rs
+++ b/crates/keystore/src/lib.rs
@@ -15,6 +15,12 @@ macro_rules! cfg_remote {
     };
 }
 
+// Re-exported for the remote-backend modules; whether any call site is compiled
+// depends on the feature combination, so this is unused in some builds.
+#[allow(
+    unused_imports,
+    reason = "macro is consumed only under the remote/ledger feature combinations"
+)]
 pub(crate) use cfg_remote;
 
 pub mod error;

--- a/crates/manager/src/metrics.rs
+++ b/crates/manager/src/metrics.rs
@@ -751,7 +751,7 @@ mod tests {
 
         let family = find_family("tangle_service_discovery_total");
         let metric = find_metric_with_label_value(&family, tag);
-        let count = metric.get_counter().get_value() as u64;
+        let count = metric.get_counter().value.unwrap_or_default() as u64;
         assert!(count >= 3, "expected >= 3 for '{tag}', got {count}");
     }
 
@@ -776,7 +776,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "success")
             })
             .expect("success metric not found");
-        assert!(success.get_counter().get_value() >= 1.0);
+        assert!(success.get_counter().value.unwrap_or_default() >= 1.0);
 
         let fail = family
             .get_metric()
@@ -786,7 +786,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "failed_spawn")
             })
             .expect("failed_spawn metric not found");
-        assert!(fail.get_counter().get_value() >= 2.0);
+        assert!(fail.get_counter().value.unwrap_or_default() >= 2.0);
     }
 
     #[test]
@@ -806,7 +806,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "success")
             })
             .expect("jobs success metric");
-        assert!(success.get_counter().get_value() >= 2.0);
+        assert!(success.get_counter().value.unwrap_or_default() >= 2.0);
 
         let failed = family
             .get_metric()
@@ -816,7 +816,7 @@ mod tests {
                     && m.get_label().iter().any(|l| l.value() == "failed")
             })
             .expect("jobs failed metric");
-        assert!(failed.get_counter().get_value() >= 1.0);
+        assert!(failed.get_counter().value.unwrap_or_default() >= 1.0);
     }
 
     // ── 7. IntGauge set / inc / dec ────────────────────────────────────
@@ -841,7 +841,7 @@ mod tests {
         // Verify through gathered output.
         let family = find_family("tangle_active_services");
         let metric = &family.get_metric()[0];
-        let val = metric.get_gauge().get_value() as i64;
+        let val = metric.get_gauge().value.unwrap_or_default() as i64;
         assert_eq!(val, 9, "gathered gauge value should be 9");
     }
 }

--- a/crates/pricing-engine/src/cloud/vm.rs
+++ b/crates/pricing-engine/src/cloud/vm.rs
@@ -551,8 +551,7 @@ mod tests {
             .await;
 
         // May succeed or fail depending on network
-        if result.is_ok() {
-            let instance = result.unwrap();
+        if let Ok(instance) = result {
             assert!(instance.hourly_price <= 0.10);
             assert!(instance.vcpus >= 2.0);
             assert!(instance.memory_gb >= 4.0);
@@ -567,8 +566,7 @@ mod tests {
         let result = fetcher.fetch_aws_instances("us-east-1").await;
 
         // Should succeed with public API
-        if result.is_ok() {
-            let instances = result.unwrap();
+        if let Ok(instances) = result {
             assert!(!instances.is_empty());
             // Verify we got actual pricing data
             assert!(instances.iter().any(|i| i.hourly_price > 0.0));

--- a/examples/incredible-squaring/incredible-squaring-lib/tests/integration.rs
+++ b/examples/incredible-squaring/incredible-squaring-lib/tests/integration.rs
@@ -614,14 +614,15 @@ async fn test_duplicate_submission_handling() -> Result<()> {
     // The service should either:
     // - Reject the duplicate (error), OR
     // - Accept but not double-count (signatures_collected still 1)
-    if response2.is_ok() {
-        assert_eq!(
-            status.signatures_collected, 1,
-            "Duplicate should not be double-counted"
-        );
-        println!("  Duplicate was accepted but not double-counted");
-    } else {
-        println!("  Duplicate was rejected: {:?}", response2.unwrap_err());
+    match response2 {
+        Ok(_) => {
+            assert_eq!(
+                status.signatures_collected, 1,
+                "Duplicate should not be double-counted"
+            );
+            println!("  Duplicate was accepted but not double-counted");
+        }
+        Err(err) => println!("  Duplicate was rejected: {err:?}"),
     }
 
     // Verify bitmap only has operator 0 once

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.91" # Update the workspace rust-version as well
+channel = "1.93" # Update the workspace rust-version as well
 components = ["cargo", "rustfmt", "clippy", "rust-src"]
 profile = "minimal"


### PR DESCRIPTION
## Summary

- Clears the two remaining **lockfile-fixable** advisories: `gix-fs` 0.17.0 → **0.21.2** (HIGH — symlink prefix-reuse worktree escape on checkout) and `gix-date` 0.11.1 → **0.15.6** (MEDIUM).
- Reached via the **parent** (`cargo-generate` 0.23.7 → 0.23.12), not a blanket update. MSRV moves **1.91 → 1.93** as a consequence.
- Affects the **developer/CI** flow. Contributors need rustc 1.93 (`rust-toolchain.toml` pins it, so `rustup` handles it automatically).

## Change Class

- `Class A` (docs/tooling only)
- `Class B` (single-crate behavior)
- `Class C` (cross-crate/runtime behavior)
- `Class D` (protocol/security/metadata semantics)
- Selected class: Class D
- Why this class: resolves published security advisories and raises the workspace MSRV, which every consumer must meet.

## Behavior Contract

- Current behavior: `gix-fs` 0.17.0 / `gix-date` 0.11.1 present with open advisories; MSRV 1.91.
- Intended behavior: both on patched versions; MSRV 1.93; no runtime behavior change.
- Invariants that must hold: **`alloy` stays on 1.8.3** — the on-chain stack must not move; no public API changes.
- Failure mode choice (`fail-closed` or `fail-open`): **fail-closed** — every change is compile-verified on 1.93 across the workspace with all features.

### Why the parent, not a blanket update
`cargo update -p gix-fs` moves **nothing** — gix is parent-pinned. The only lockfile-wide alternative changes **309 packages with 39 semver-major bumps, including `alloy` 1.8.3 → 2.1.1**. Bumping the entire Ethereum stack to patch a scaffolding tool is the wrong trade. Bumping `cargo-generate` instead changes **33 packages** and leaves `alloy` alone.

| approach | packages changed | semver-major | alloy |
|---|---|---|---|
| blanket `cargo update` | 309 | 39 | **1.8.3 → 2.1.1** |
| **cargo-generate bump (this PR)** | **33** | 8 (all gix/git2 family) | **1.8.3 unchanged** |

### Scope of the advisory (for weighing risk)
`gix` reaches this workspace **only** through `cargo-generate` → `cargo-tangle`, i.e. `cargo tangle blueprint create` cloning a template repo. The escape requires checking out a **malicious template**. It is a developer-tool exposure, not the operator path that moves funds — real, but not operator-critical.

### Why MSRV must move
`cargo-generate` 0.23.12 depends on `cargo-util-schemas` 0.13, which requires **rustc 1.93**. It cannot be pinned back — its parent requires `^0.13`. rustc **1.93.1** is comfortably behind stable (**1.97.1**), so this is a conservative floor, not a bleeding-edge one.

## Risk and Scope

- Security impact: **positive** — clears one HIGH and one MEDIUM.
- Compatibility impact: contributors and CI need rustc ≥ 1.93; `rust-toolchain.toml` pins it so `rustup` installs it automatically. No crate's public API changes.
- Migration notes: none beyond the toolchain.
- Rollback plan: revert the commit (restores MSRV 1.91 and the vulnerable gix versions).

### Pre-existing issues the newer clippy surfaced (all fixed properly, none suppressed)
CI's lanes never compiled these paths, so they had accumulated silently:
- **5×** `is_ok()` followed by `unwrap()`/`unwrap_err()` → `if let` / `match` — `pricing-engine/src/cloud/vm.rs` (×2), `auth/src/tests/grpc_proxy_tests.rs`, `incredible-squaring .../integration.rs`, `blueprint-faas/src/digitalocean/mod.rs`.
- **6×** protobuf-3 `MessageField` accessors in `manager/src/metrics.rs` — `.get_counter().get_value()` → `.get_counter().value`, typed `Option<f64>`.
- `keystore`'s `cfg_remote` re-export **annotated, not deleted** — the macro is consumed only under the remote/ledger feature combinations, so removing it would break builds the default lane never compiles.

## Verification

```bash
rustup run 1.93 cargo check  --workspace --all-features                       # clean
rustup run 1.93 cargo clippy --workspace --tests --examples -- -D warnings    # exit 0
rustup run 1.93 cargo clippy --workspace --all-features   -- -D warnings      # exit 0
rustup run 1.93 cargo fmt --all -- --check                                    # exit 0

grep -A1 '^name = "gix-fs"'   Cargo.lock   # 0.21.2
grep -A1 '^name = "gix-date"' Cargo.lock   # 0.15.6
grep -A1 '^name = "alloy"'    Cargo.lock   # 1.8.3 — unchanged
```

## Harness Evidence

- Reproducer added/updated: n/a — dependency/security change; the lockfile versions and `cargo audit` are the check.
- Negative-path coverage added: the blanket-update alternative was built and measured rather than assumed, which is what exposed the alloy 1→2 blast radius and drove the parent-bump approach.
- Key assertions that prove the fix: `gix-fs` 0.21.2 and `gix-date` 0.15.6 in `Cargo.lock`; `alloy` still 1.8.3; all three gates exit 0 on rustc 1.93.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue. — n/a; lockfile versions are the check.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input. — n/a; the rejected alternative was measured instead.
- [x] I documented behavior or interface changes in docs/examples when needed. — MSRV change recorded in `rust-toolchain.toml` and the workspace `rust-version`.
- [x] I evaluated compatibility/migration impact explicitly. — see Risk and Scope.
- [x] I validated local formatting, clippy, and relevant tests. — all gates exit 0 on 1.93.
