### PR TITLE
fix(ci): drop the stale eigensdk hakari exclusion that breaks Release-plz

### DIFF
--- a/.config/hakari.toml
+++ b/.config/hakari.toml
@@ -7,7 +7,3 @@ platforms = [
     "aarch64-apple-darwin",
 ]
 
-[traversal-excludes]
-third-party = [
-    { name = "eigensdk" },
-]


### PR DESCRIPTION
## Summary

- **Release-plz has failed on every push since 2026-07-28 — 8 consecutive runs** — so no release PR has been generated in days. It dies at its `Disable Hakari` step before doing anything.
- Cause is a stale `[traversal-excludes]` entry for `eigensdk`, which no longer exists in the workspace. Affects the **release** flow for every crate in the repo.

## Change Class

- `Class A` (docs/tooling only)
- `Class B` (single-crate behavior)
- `Class C` (cross-crate/runtime behavior)
- `Class D` (protocol/security/metadata semantics)
- Selected class: Class A
- Why this class: one line removed from a CI tooling config. No crate source, no dependencies, no runtime behavior.

## Behavior Contract

- Current behavior: `cargo hakari disable` aborts, taking the whole Release-plz job with it:
  ```
  error resolving Hakari config at .config/hakari.toml
    unknown elements: resolving hakari traversal-excludes
      * unknown third-party:
        - { name = "eigensdk", version = "*", source = crates.io }
  ```
- Intended behavior: the config resolves and Release-plz proceeds to generate release PRs.
- Invariants that must hold: hakari behavior for every crate still in the graph is unchanged — only an exclusion for an absent crate is dropped.
- Failure mode choice (`fail-closed` or `fail-open`): **fail-closed** — hakari treats an unknown exclusion as a hard error, which is why this took the job down rather than warning.

### Self-inflicted, and worth naming
Removing EigenLayer support deleted `eigensdk` from the workspace but left this exclusion behind. Every `Cargo.toml` reference was swept; this config was missed.

## Risk and Scope

- Security impact: none.
- Compatibility impact: none — an exclusion for a crate absent from the dependency graph has no effect on resolution.
- Migration notes: none.
- Rollback plan: revert the commit (restores the broken state).

## Verification

The exact commands the workflow runs, on a clean checkout of `main` + this change:

```bash
cargo hakari disable        # info: no changes detected      exit 0
cargo hakari remove-deps -y # info: no operations to perform  exit 0
```

Before this change both aborted with the config-resolution error above.

## Harness Evidence

- Reproducer added/updated: reproduced on a pristine `origin/main` worktree — `cargo hakari verify` fails identically to CI, confirming it isn't a runner-environment issue.
- Negative-path coverage added: n/a — config-only change; the failing command is itself the check.
- Key assertions that prove the fix: both hakari commands exit 0; `grep -c eigensdk .config/hakari.toml` → 0.

Note: `cargo hakari verify` still reports `workspace-hack` as out of date after the recent dependency churn. That is **separate and pre-existing**, and does not block Release-plz, which disables and strips `workspace-hack` anyway.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue. — n/a; the failing hakari command is the reproducer.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input. — n/a for a config removal.
- [x] I documented behavior or interface changes in docs/examples when needed. — no interface change.
- [x] I evaluated compatibility/migration impact explicitly. — see Risk and Scope.
- [x] I validated local formatting, clippy, and relevant tests. — both workflow commands verified exit 0 locally.
