### PR TITLE
docs: Tangle is an EVM protocol, not a chain to target

### DIFF
--- a/CHECKLIST-LAUNCH.md
+++ b/CHECKLIST-LAUNCH.md
@@ -9,6 +9,6 @@ Readiness: **0%** (0 ready, 0 partial, 9 missing out of 9 items). Alpha state.
 - [ ] Benchmark suite (throughput, latency, deploy time per blueprint shape)
 - [ ] Blueprint CLI polish (`cli/` in workspace)
 - [ ] Reference blueprint with real economics (fee flow, bond, worst-case loss)
-- [ ] Multi-chain deploy proof (Tangle + Tempo + Arc + Robinhood from same source)
+- [ ] Multi-chain deploy proof (same Tangle contracts deployed to Base + Tempo + Arc + Robinhood)
 - [ ] Slashing condition spec published
 - [ ] Security audit of SDK crate surface

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
 
 ## Overview
 
-The Blueprint SDK is a modular Rust toolkit for building decentralized services—called Blueprints—that run across networks like [Tangle] and standard EVM chains.
+The Blueprint SDK is a modular Rust toolkit for building decentralized services—called Blueprints—that run against [Tangle], an EVM protocol deployed on EVM chains.
 
 Blueprints turn complex on-chain and off-chain infrastructure into reproducible, deployable units of logic—think Infrastructure-as-Code for crypto systems.
 With one SDK, you can design anything from oracles and MPC networks to agent-based AI services or zk-proof markets, and deploy them seamlessly.
@@ -57,7 +57,7 @@ tools for networking and testing.
     * [`blueprint-crypto-sr25519`] - Utilities for working with sr25519 signatures and keys
 * [`blueprint-keystore`] - Flexible keystore implementation, supporting local and remote signers
 * [`blueprint-macros`] - Utility macros for simplifying blueprint development
-* [`blueprint-manager`] - A program executor that connects to the [Tangle] network and runs protocols dynamically on the fly
+* [`blueprint-manager`] - A program executor that connects to a [Tangle] deployment and runs protocols dynamically on the fly
     * [`blueprint-manager-bridge`] - IPC bridge for manager-blueprint communication
 * [`blueprint-metrics`] (**Meta-crate**) Utilities for collecting metrics
     * [`blueprint-metrics-rpc-calls`] - Utilities for collecting metrics from RPC calls
@@ -253,7 +253,7 @@ rendering.
 
 ### Deploying to Testnet/Mainnet
 
-When targeting real [Tangle] networks, provide a blueprint definition manifest that mirrors the on-chain schema. The file can be JSON, YAML, or TOML and must describe the blueprint metadata, jobs, and artifact sources (container images or native binaries). Once authored, pass it via `--definition`:
+When targeting a live [Tangle] deployment, provide a blueprint definition manifest that mirrors the on-chain schema. The file can be JSON, YAML, or TOML and must describe the blueprint metadata, jobs, and artifact sources (container images or native binaries). Once authored, pass it via `--definition`:
 
 ```bash
 cargo tangle blueprint deploy tangle \


### PR DESCRIPTION
## Summary

- There is **no Tangle blockchain**. Tangle Network is the tnt-core **EVM protocol**, deployed onto EVM chains (Base, Tempo, Arc, Robinhood). The docs described it as a network you deploy *to*, "alongside standard EVM chains" — which sends a reader looking for a Tangle chain that doesn't exist, and hides that a blueprint runs against a Tangle **deployment** on whichever chain hosts it.
- Affects the **reader/developer** flow: this is the front-page mental model of what the product is.

## Change Class

- `Class A` (docs/tooling only)
- `Class B` (single-crate behavior)
- `Class C` (cross-crate/runtime behavior)
- `Class D` (protocol/security/metadata semantics)
- Selected class: Class A
- Why this class: two markdown files. No code, no manifests, no CI.

## Behavior Contract

- Current behavior: docs present Tangle as a network peer to "standard EVM chains", and the launch checklist lists Tangle as one deploy target among Tempo/Arc/Robinhood.
- Intended behavior: Tangle is the protocol; chains are what it deploys onto.
- Invariants that must hold: no doc implies a Tangle L1 exists.
- Failure mode choice (`fail-closed` or `fail-open`): n/a — documentation.

## What changed
| before | after |
|---|---|
| "run across networks like [Tangle] and standard EVM chains" | "run against [Tangle], an EVM protocol deployed on EVM chains" |
| manager "connects to the [Tangle] network" | manager "connects to a [Tangle] deployment" |
| "When targeting real [Tangle] networks" | "When targeting a live [Tangle] deployment" |
| checklist: "Tangle + Tempo + Arc + Robinhood from same source" | "same Tangle contracts deployed to Base + Tempo + Arc + Robinhood" |

`blueprint-client-tangle`'s description already read "the [Tangle] EVM contracts" — correct, unchanged.

I introduced the checklist wording in #1486; this corrects it.

## Risk and Scope

- Security impact: none.
- Compatibility impact: none — documentation only.
- Migration notes: none.
- Rollback plan: revert the commit.

## Verification

```bash
grep -n "networks like\|Tangle\] network\|real \[Tangle\] networks" README.md   # no matches
grep -n "Multi-chain deploy proof" CHECKLIST-LAUNCH.md                          # lists chains only
```

## Harness Evidence

- Reproducer added/updated: n/a — documentation accuracy, verified by grep.
- Negative-path coverage added: n/a.
- Key assertions that prove the fix: no remaining phrasing positions Tangle as a chain or network to deploy *to*.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue. — n/a; docs-only.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input. — n/a.
- [x] I documented behavior or interface changes in docs/examples when needed. — this PR is that update.
- [x] I evaluated compatibility/migration impact explicitly. — none; no code touched.
- [x] I validated local formatting, clippy, and relevant tests. — n/a for markdown; grep-verified.
