### PR TITLE
fix(ci): dry run should report skipped crates, not fail on them

### DIFF
--- a/.github/workflows/publish-crates.yml
+++ b/.github/workflows/publish-crates.yml
@@ -65,14 +65,15 @@ jobs:
       - name: Dry run
         if: ${{ inputs.dry_run }}
         run: |
-          # Report what a real run would publish, and pre-check the failure that
-          # actually kills a batch mid-flight: a crate whose target version is
-          # already on crates.io. `batch-publish.sh` publishes in topological
-          # order with a 60s post-burst delay, so a collision late in the list
-          # can strand the fleet half-published. A full `cargo publish
-          # --dry-run` per crate is NOT usable here — dry-run still resolves
-          # dependencies from the registry, so every crate that depends on a
-          # sibling being published in this same batch would fail spuriously.
+          # Report the publish plan: which crates a real run would publish and
+          # which it would skip. `batch-publish.sh` checks the sparse index per
+          # crate and skips any version already live, so an already-published
+          # version is NOT a failure — release-plz bumps only what changed while
+          # this workflow enumerates every publishable workspace member, so a
+          # partial overlap is the normal case. A full `cargo publish --dry-run`
+          # per crate is NOT usable here: dry-run still resolves dependencies
+          # from the registry, so every crate depending on a sibling published in
+          # this same batch would fail spuriously.
           python3 - <<'PY'
           import json, urllib.request, subprocess, sys
 
@@ -101,14 +102,16 @@ jobs:
               else:
                   print(f"  {n} {v}  ok")
 
-          if collisions:
-              print()
-              print("These versions already exist on crates.io — a real run would fail "
-                    "on them and could leave the fleet half-published. Bump them (or "
-                    "drop them from the batch) before publishing:")
-              for n, v in collisions:
-                  print(f"  - {n} {v}")
-              sys.exit(1)
           print()
-          print("No version collisions. A real run would proceed.")
+          if collisions:
+              print(f"{len(collisions)} crate(s) are already at their target version and "
+                    "will be SKIPPED by batch-publish.sh (it checks the sparse index "
+                    "before publishing each crate). This is normal: release-plz only "
+                    "bumps crates that changed, while this workflow enumerates every "
+                    "publishable workspace member.")
+              for n, v in collisions:
+                  print(f"  skip: {n} {v}")
+              print()
+          print(f"A real run would publish {len(names) - len(collisions)} crate(s) and "
+                f"skip {len(collisions)}.")
           PY


### PR DESCRIPTION
## Summary

- The collision pre-check I added in #1477 was **wrong**. It fails the dry run whenever any crate's target version is already on crates.io, claiming a real run "would fail on them and could leave the fleet half-published."
- `batch-publish.sh` does **not** fail on those — it checks the sparse index per crate and skips any version already live. Affects the **release** flow: the gate blocks a normal, healthy release.

## Change Class

- `Class A` (docs/tooling only)
- `Class B` (single-crate behavior)
- `Class C` (cross-crate/runtime behavior)
- `Class D` (protocol/security/metadata semantics)
- Selected class: Class A
- Why this class: one CI workflow step. No crate source, no dependencies.

## Behavior Contract

- Current behavior: dry run exits 1 when any target version already exists, blocking the release.
- Intended behavior: dry run reports the plan — how many crates would be published, which would be skipped — and exits 0.
- Invariants that must hold: the dry run must never mutate crates.io, and must not fail on the normal case.
- Failure mode choice (`fail-closed` or `fail-open`): deliberately **not** fail-closed here. There is no failure to close against — the publisher skips already-live versions by design.

### Why the original check was wrong
```bash
if version_is_live "$package" "$target_version"; then
    echo "✓ $package $target_version already in sparse index (skipped)"
```
A partial overlap is the **normal** case: release-plz bumps only the crates that changed, while this workflow enumerates every publishable workspace member. The first real dry run after #1477 flagged **7 of 52** crates and failed — `blueprint-core`, `blueprint-macros`, `blueprint-metrics`, `blueprint-metrics-rpc-calls`, `blueprint-producers-extra`, `blueprint-profiling`, `blueprint-router` — every one of which a real run would simply skip.

**A gate that fails on the normal case gets disabled, which is worse than no gate.**

## Risk and Scope

- Security impact: none. The dry run still never publishes — that's enforced by the `${{ !inputs.dry_run }}` / `${{ inputs.dry_run }}` boolean guards, also from #1477, which remain correct and are what stops a dry run from mutating the registry.
- Compatibility impact: none.
- Migration notes: none.
- Rollback plan: revert the commit.

## Verification

Observed on run [30786405695](https://github.com/tangle-network/blueprint/actions/runs/30786405695), the first dry run after the guard fix:
```
DRY RUN — would publish 52 crate(s):
  blueprint-core 0.2.0-alpha.5  ALREADY PUBLISHED
  ...
```
→ exited 1 on 7 crates that `batch-publish.sh` skips by design.

After this change the same input reports the plan and exits 0.

## Harness Evidence

- Reproducer added/updated: the failing run above is the reproducer; the dry-run step is itself the check.
- Negative-path coverage added: n/a — this removes an incorrect failure path.
- Key assertions that prove the fix: no `sys.exit(1)` remains in the dry-run step; the publish step's boolean guard is untouched.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue. — n/a; the CI run is the reproducer.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input. — n/a; this removes a wrong negative path.
- [x] I documented behavior or interface changes in docs/examples when needed. — rationale is inline in the workflow.
- [x] I evaluated compatibility/migration impact explicitly. — see Risk and Scope.
- [x] I validated local formatting, clippy, and relevant tests. — YAML structure verified (heredoc balanced, no tabs).
