### PR TITLE
fix(tangle): align BLS aggregation with TNT 0.19

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3223,6 +3223,7 @@ dependencies = [
  "serde_bytes",
  "serde_json",
  "sha2 0.10.9",
+ "sha3 0.10.9",
  "thiserror 2.0.18",
  "zeroize",
 ]
@@ -4012,6 +4013,9 @@ dependencies = [
  "alloy-signer-local",
  "alloy-sol-types",
  "anyhow",
+ "ark-bn254 0.6.0",
+ "ark-ff 0.6.0",
+ "ark-serialize 0.6.0",
  "blueprint-anvil-testing-utils",
  "blueprint-chain-setup-anvil",
  "blueprint-client-tangle",

--- a/crates/crypto/bn254/Cargo.toml
+++ b/crates/crypto/bn254/Cargo.toml
@@ -22,6 +22,7 @@ thiserror = { workspace = true }
 num-bigint = { workspace = true, features = ["serde"] }
 num-traits = { workspace = true }
 sha2 = { workspace = true }
+sha3 = { workspace = true }
 hex = { workspace = true, features = ["alloc"] }
 zeroize = { workspace = true }
 
@@ -43,6 +44,7 @@ std = [
 	"num-bigint/std",
 	"num-traits/std",
 	"sha2/std",
+	"sha3/std",
 ]
 aggregation = []
 

--- a/crates/crypto/bn254/src/error.rs
+++ b/crates/crypto/bn254/src/error.rs
@@ -11,6 +11,8 @@ pub enum Bn254Error {
     SignatureNotInSubgroup,
     #[error("Invalid input: {0}")]
     InvalidInput(String),
+    #[error("Tangle hash-to-curve did not find a point within 256 attempts")]
+    HashToPointFailed,
 }
 
 pub type Result<T> = blueprint_std::result::Result<T, Bn254Error>;

--- a/crates/crypto/bn254/src/lib.rs
+++ b/crates/crypto/bn254/src/lib.rs
@@ -24,6 +24,7 @@ use blueprint_std::{
 use num_bigint::BigUint;
 use serde::{Deserialize, Serialize};
 use sha2::{Digest, Sha256};
+use sha3::Keccak256;
 
 /// Serialize this to a vector of bytes.
 pub fn to_bytes<T: CanonicalSerialize>(elt: T) -> Vec<u8> {
@@ -74,6 +75,65 @@ fn hash_to_curve(digest: &[u8]) -> G1Affine {
         // x = x + 1
         x += one;
     }
+}
+
+/// Map a Tangle contract message to G1 with the TNT core algorithm.
+///
+/// TNT core uses Keccak-256, then tries at most 256 consecutive x values.
+/// Its modular square root selects a specific y coordinate, so Arkworks'
+/// canonical `sqrt` result is not interchangeable here.
+fn hash_to_curve_tangle(message: &[u8]) -> Result<G1Affine> {
+    let one = Fq::one();
+    let three = Fq::from(3u64);
+    let digest = Keccak256::digest(message);
+    let mut x = Fq::from_be_bytes_mod_order(&digest);
+
+    // (P_MOD + 1) / 4 in little-endian 64-bit limbs.
+    const SQRT_EXPONENT: [u64; 4] = [
+        0x4f08_2305_b61f_3f52,
+        0x65e0_5aa4_5a1c_72a3,
+        0x6e14_116d_a060_5617,
+        0x0c19_139c_b84c_680a,
+    ];
+
+    for _ in 0..256 {
+        let mut y_squared = x;
+        y_squared.square_in_place();
+        y_squared *= x;
+        y_squared += three;
+
+        let y = y_squared.pow(SQRT_EXPONENT);
+        if y * y == y_squared {
+            return Ok(G1Projective::new(x, y, Fq::one()).into_affine());
+        }
+        x += one;
+    }
+
+    Err(Bn254Error::HashToPointFailed)
+}
+
+/// Sign the exact byte message verified by TNT core's BN254 library.
+pub fn sign_tangle(sk: Fr, message: &[u8]) -> Result<G1Affine> {
+    let point = hash_to_curve_tangle(message)?;
+    let signature = point.mul_bigint(BigInteger256::from(sk)).into_affine();
+
+    if !signature.is_on_curve() || !signature.is_in_correct_subgroup_assuming_on_curve() {
+        return Err(Bn254Error::SignatureNotInSubgroup);
+    }
+
+    Ok(signature)
+}
+
+/// Verify a signature with the exact TNT core BN254 hash-to-curve algorithm.
+pub fn verify_tangle(public_key: G2Affine, message: &[u8], signature: G1Affine) -> bool {
+    if !signature.is_in_correct_subgroup_assuming_on_curve() || !signature.is_on_curve() {
+        return false;
+    }
+
+    let Ok(point) = hash_to_curve_tangle(message) else {
+        return false;
+    };
+    Bn254::pairing(point, public_key) == Bn254::pairing(signature, G2Affine::generator())
 }
 
 pub fn sign(sk: Fr, message: &[u8]) -> Result<G1Affine> {
@@ -165,6 +225,25 @@ macro_rules! impl_ark_serde {
 impl_ark_serde!(ArkBlsBn254Public, G2Affine);
 impl_ark_serde!(ArkBlsBn254Secret, Fr);
 impl_ark_serde!(ArkBlsBn254Signature, G1Affine);
+
+impl ArkBlsBn254 {
+    /// Sign a message for TNT core contracts without changing the key format.
+    pub fn sign_tangle_with_secret(
+        secret: &ArkBlsBn254Secret,
+        message: &[u8],
+    ) -> Result<ArkBlsBn254Signature> {
+        sign_tangle(secret.0, message).map(ArkBlsBn254Signature)
+    }
+
+    /// Verify a signature with TNT core's contract-compatible algorithm.
+    pub fn verify_tangle(
+        public_key: &ArkBlsBn254Public,
+        message: &[u8],
+        signature: &ArkBlsBn254Signature,
+    ) -> bool {
+        verify_tangle(public_key.0, message, signature.0)
+    }
+}
 
 impl zeroize::Zeroize for ArkBlsBn254Secret {
     fn zeroize(&mut self) {

--- a/crates/crypto/bn254/src/tests.rs
+++ b/crates/crypto/bn254/src/tests.rs
@@ -1,6 +1,6 @@
 use super::*;
 use crate::{ArkBlsBn254, ArkBlsBn254Public, ArkBlsBn254Secret, ArkBlsBn254Signature};
-use ark_ff::UniformRand;
+use ark_ff::{BigInteger, UniformRand};
 use blueprint_crypto_core::{KeyType, aggregation::AggregatableSignature};
 use blueprint_crypto_hashing::keccak_256;
 use blueprint_std::string::ToString;
@@ -193,6 +193,38 @@ fn test_hash_to_curve_edge_cases() {
     // Verify different inputs produce different points
     assert_ne!(point_empty, point_large);
     assert_ne!(point_zeros, point_ones);
+}
+
+#[test]
+fn tangle_hash_matches_tnt_core_vector() {
+    let point = hash_to_curve_tangle(b"tangle-contract-vector").unwrap();
+    let x = BigUint::from_bytes_be(&point.x.into_bigint().to_bytes_be());
+    let y = BigUint::from_bytes_be(&point.y.into_bigint().to_bytes_be());
+
+    assert_eq!(
+        x.to_string(),
+        "8630366872340651833967109127856105872559859851806905963807929583534657100522"
+    );
+    assert_eq!(
+        y.to_string(),
+        "5551485564850950662282219342050295766753172156192689017209662521169626690927"
+    );
+}
+
+#[test]
+fn tangle_signatures_use_the_contract_algorithm_only() {
+    let secret = ArkBlsBn254::generate_with_seed(Some(b"tangle-signing-vector")).unwrap();
+    let public = ArkBlsBn254::public_from_secret(&secret);
+    let message = b"contract-domain-message";
+    let signature = ArkBlsBn254::sign_tangle_with_secret(&secret, message).unwrap();
+
+    assert!(ArkBlsBn254::verify_tangle(&public, message, &signature));
+    assert!(!ArkBlsBn254::verify(&public, message, &signature));
+    assert!(!ArkBlsBn254::verify_tangle(
+        &public,
+        b"different-message",
+        &signature
+    ));
 }
 
 #[test]

--- a/crates/tangle-aggregation-svc/src/api.rs
+++ b/crates/tangle-aggregation-svc/src/api.rs
@@ -58,13 +58,27 @@ async fn init_task(
         ..Default::default()
     };
 
-    match service.init_task_with_config(
-        req.service_id,
-        req.call_id,
-        req.output,
-        req.operator_count,
-        config,
-    ) {
+    let result = if req.message.is_empty() {
+        service.init_task_with_config(
+            req.service_id,
+            req.call_id,
+            req.output,
+            req.operator_count,
+            config,
+        )
+    } else {
+        service.init_task_with_message_config(
+            req.service_id,
+            req.call_id,
+            req.output,
+            req.message,
+            req.signature_scheme,
+            req.operator_count,
+            config,
+        )
+    };
+
+    match result {
         Ok(()) => Json(InitTaskResponse {
             success: true,
             error: None,

--- a/crates/tangle-aggregation-svc/src/client.rs
+++ b/crates/tangle-aggregation-svc/src/client.rs
@@ -103,6 +103,31 @@ impl AggregationServiceClient {
         operator_count: u32,
         threshold: ThresholdConfig,
     ) -> Result<(), ClientError> {
+        let message = crate::service::create_signing_message(service_id, call_id, output);
+        self.init_task_with_message(
+            service_id,
+            call_id,
+            output,
+            &message,
+            Bn254SignatureScheme::ArkworksSha256,
+            operator_count,
+            threshold,
+        )
+        .await
+    }
+
+    /// Initialize a task with an explicit signed message and algorithm.
+    #[allow(clippy::too_many_arguments)]
+    pub async fn init_task_with_message(
+        &self,
+        service_id: u64,
+        call_id: u64,
+        output: &[u8],
+        message: &[u8],
+        signature_scheme: Bn254SignatureScheme,
+        operator_count: u32,
+        threshold: ThresholdConfig,
+    ) -> Result<(), ClientError> {
         let url = format!("{}/v1/tasks/init", self.base_url);
         let request = InitTaskRequest {
             service_id,
@@ -110,6 +135,8 @@ impl AggregationServiceClient {
             operator_count,
             threshold,
             output: output.to_vec(),
+            message: message.to_vec(),
+            signature_scheme,
         };
 
         let response: InitTaskResponse = self

--- a/crates/tangle-aggregation-svc/src/persistence.rs
+++ b/crates/tangle-aggregation-svc/src/persistence.rs
@@ -17,7 +17,7 @@
 //! ```
 
 use crate::state::ThresholdType;
-use crate::types::TaskId;
+use crate::types::{Bn254SignatureScheme, TaskId};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -52,6 +52,12 @@ pub struct PersistedTaskState {
     /// The output being signed
     #[serde(with = "hex_bytes")]
     pub output: Vec<u8>,
+    /// Exact signed message.
+    #[serde(default, with = "hex_bytes")]
+    pub message: Vec<u8>,
+    /// Hash-to-curve algorithm for the signed message.
+    #[serde(default)]
+    pub signature_scheme: Bn254SignatureScheme,
     /// Number of operators in the service
     pub operator_count: u32,
     /// Threshold type
@@ -299,6 +305,8 @@ mod tests {
             service_id: 1,
             call_id: 100,
             output: vec![1, 2, 3, 4],
+            message: vec![5, 6, 7, 8],
+            signature_scheme: Bn254SignatureScheme::TangleKeccak256,
             operator_count: 5,
             threshold_type: PersistedThresholdType::Count(3),
             signer_bitmap: "0x7".to_string(), // operators 0, 1, 2 signed

--- a/crates/tangle-aggregation-svc/src/service.rs
+++ b/crates/tangle-aggregation-svc/src/service.rs
@@ -166,16 +166,49 @@ impl AggregationService {
         operator_count: u32,
         config: TaskConfig,
     ) -> Result<(), ServiceError> {
+        let message = create_signing_message(service_id, call_id, &output);
+        self.init_task_with_message_config(
+            service_id,
+            call_id,
+            output,
+            message,
+            Bn254SignatureScheme::ArkworksSha256,
+            operator_count,
+            config,
+        )
+    }
+
+    /// Initialize a task with an explicit signed message and algorithm.
+    #[allow(clippy::too_many_arguments)]
+    pub fn init_task_with_message_config(
+        &self,
+        service_id: u64,
+        call_id: u64,
+        output: Vec<u8>,
+        message: Vec<u8>,
+        signature_scheme: Bn254SignatureScheme,
+        operator_count: u32,
+        config: TaskConfig,
+    ) -> Result<(), ServiceError> {
         info!(
             service_id,
             call_id,
             operator_count,
+            ?signature_scheme,
             ?config.threshold_type,
             "Initializing aggregation task"
         );
 
         self.state
-            .init_task_with_config(service_id, call_id, output, operator_count, config)
+            .init_task_with_message_config(
+                service_id,
+                call_id,
+                output,
+                message,
+                signature_scheme,
+                operator_count,
+                config,
+            )
             .map_err(|e| ServiceError::Other(e.to_string()))
     }
 
@@ -223,10 +256,20 @@ impl AggregationService {
 
         // Optionally verify the signature
         if self.config.verify_on_submit {
-            // Create the message that should have been signed
-            let message = create_signing_message(req.service_id, req.call_id, &req.output);
+            let (message, signature_scheme) = self
+                .state
+                .get_task_signature_context(req.service_id, req.call_id)
+                .ok_or(ServiceError::TaskNotFound)?;
+            let verified = match signature_scheme {
+                Bn254SignatureScheme::ArkworksSha256 => {
+                    ArkBlsBn254::verify(&public_key, &message, &signature)
+                }
+                Bn254SignatureScheme::TangleKeccak256 => {
+                    ArkBlsBn254::verify_tangle(&public_key, &message, &signature)
+                }
+            };
 
-            if !ArkBlsBn254::verify(&public_key, &message, &signature) {
+            if !verified {
                 warn!(
                     service_id = req.service_id,
                     call_id = req.call_id,
@@ -392,9 +435,9 @@ impl AggregationService {
     }
 }
 
-/// Create the message that operators sign
+/// Create the historical message used by direct aggregation-service callers.
 ///
-/// Format: serviceId (8 bytes BE) || callId (8 bytes BE) || keccak256(output)
+/// Tangle consumers use their complete contract domain message instead.
 pub fn create_signing_message(service_id: u64, call_id: u64, output: &[u8]) -> Vec<u8> {
     use alloy_primitives::keccak256;
 
@@ -440,6 +483,14 @@ pub struct ServiceStats {
 mod tests {
     use super::*;
     use alloy_primitives::keccak256;
+    use ark_serialize::CanonicalSerialize;
+    use blueprint_crypto_core::KeyType;
+
+    fn serialize_point(point: &impl CanonicalSerialize) -> Vec<u8> {
+        let mut bytes = Vec::new();
+        point.serialize_compressed(&mut bytes).unwrap();
+        bytes
+    }
 
     #[test]
     fn test_create_signing_message() {
@@ -500,6 +551,64 @@ mod tests {
         assert!(config.default_task_ttl.is_none());
         assert!(config.cleanup_interval.is_none());
         assert!(!config.auto_cleanup_submitted);
+    }
+
+    #[test]
+    fn default_service_verifies_only_the_declared_tangle_scheme() {
+        let service = AggregationService::default();
+        let output = vec![1, 2, 3];
+        let message = b"TANGLE_BLS_AGG_v1 test domain".to_vec();
+        service
+            .init_task_with_message_config(
+                1,
+                100,
+                output.clone(),
+                message.clone(),
+                Bn254SignatureScheme::TangleKeccak256,
+                1,
+                TaskConfig::default(),
+            )
+            .unwrap();
+
+        let secret = ArkBlsBn254::generate_with_seed(Some(b"tangle-sidecar-test")).unwrap();
+        let public = ArkBlsBn254::public_from_secret(&secret);
+        let signature = ArkBlsBn254::sign_tangle_with_secret(&secret, &message).unwrap();
+        let response = service
+            .submit_signature(SubmitSignatureRequest {
+                service_id: 1,
+                call_id: 100,
+                operator_index: 0,
+                output: output.clone(),
+                signature: serialize_point(&signature.0),
+                public_key: serialize_point(&public.0),
+            })
+            .unwrap();
+        assert!(response.threshold_met);
+
+        service
+            .init_task_with_message_config(
+                1,
+                101,
+                output.clone(),
+                message.clone(),
+                Bn254SignatureScheme::TangleKeccak256,
+                1,
+                TaskConfig::default(),
+            )
+            .unwrap();
+        let mut legacy_secret = secret.clone();
+        let legacy_signature = ArkBlsBn254::sign_with_secret(&mut legacy_secret, &message).unwrap();
+        let error = service
+            .submit_signature(SubmitSignatureRequest {
+                service_id: 1,
+                call_id: 101,
+                operator_index: 0,
+                output,
+                signature: serialize_point(&legacy_signature.0),
+                public_key: serialize_point(&public.0),
+            })
+            .unwrap_err();
+        assert!(matches!(error, ServiceError::VerificationFailed));
     }
 
     #[test]

--- a/crates/tangle-aggregation-svc/src/state.rs
+++ b/crates/tangle-aggregation-svc/src/state.rs
@@ -1,6 +1,6 @@
 //! In-memory aggregation state management
 
-use crate::types::TaskId;
+use crate::types::{Bn254SignatureScheme, TaskId};
 use alloy_primitives::U256;
 use blueprint_crypto_bn254::{ArkBlsBn254Public, ArkBlsBn254Signature};
 use parking_lot::RwLock;
@@ -50,6 +50,10 @@ pub struct TaskState {
     pub call_id: u64,
     /// The output being signed
     pub output: Vec<u8>,
+    /// Exact bytes signed by every operator.
+    pub message: Vec<u8>,
+    /// Hash-to-curve algorithm for the message.
+    pub signature_scheme: Bn254SignatureScheme,
     /// Number of operators in the service
     pub operator_count: u32,
     /// Threshold type and value
@@ -102,6 +106,32 @@ impl TaskState {
         operator_stakes: Option<HashMap<u32, u64>>,
         ttl: Option<Duration>,
     ) -> Self {
+        Self::with_message_config(
+            service_id,
+            call_id,
+            output.clone(),
+            output,
+            Bn254SignatureScheme::ArkworksSha256,
+            operator_count,
+            threshold_type,
+            operator_stakes,
+            ttl,
+        )
+    }
+
+    /// Create task state with an explicit signed message and algorithm.
+    #[allow(clippy::too_many_arguments)]
+    pub fn with_message_config(
+        service_id: u64,
+        call_id: u64,
+        output: Vec<u8>,
+        message: Vec<u8>,
+        signature_scheme: Bn254SignatureScheme,
+        operator_count: u32,
+        threshold_type: ThresholdType,
+        operator_stakes: Option<HashMap<u32, u64>>,
+        ttl: Option<Duration>,
+    ) -> Self {
         let now = Instant::now();
         let expires_at = ttl.map(|d| now + d);
 
@@ -120,6 +150,8 @@ impl TaskState {
             service_id,
             call_id,
             output,
+            message,
+            signature_scheme,
             operator_count,
             threshold_type,
             signer_bitmap: U256::ZERO,
@@ -348,11 +380,58 @@ impl AggregationState {
         Ok(())
     }
 
+    /// Initialize a task with an explicit signed message and algorithm.
+    #[allow(clippy::too_many_arguments)]
+    pub fn init_task_with_message_config(
+        &self,
+        service_id: u64,
+        call_id: u64,
+        output: Vec<u8>,
+        message: Vec<u8>,
+        signature_scheme: Bn254SignatureScheme,
+        operator_count: u32,
+        config: TaskConfig,
+    ) -> Result<(), &'static str> {
+        let task_id = TaskId::new(service_id, call_id);
+        let mut tasks = self.tasks.write();
+
+        if tasks.contains_key(&task_id) {
+            return Err("Task already exists");
+        }
+
+        let state = TaskState::with_message_config(
+            service_id,
+            call_id,
+            output,
+            message,
+            signature_scheme,
+            operator_count,
+            config.threshold_type,
+            config.operator_stakes,
+            config.ttl,
+        );
+        tasks.insert(task_id, state);
+        Ok(())
+    }
+
     /// Get the expected output for a task (for validation)
     pub fn get_task_output(&self, service_id: u64, call_id: u64) -> Option<Vec<u8>> {
         let task_id = TaskId::new(service_id, call_id);
         let tasks = self.tasks.read();
         tasks.get(&task_id).map(|t| t.output.clone())
+    }
+
+    /// Get the exact signed message and algorithm for a task.
+    pub fn get_task_signature_context(
+        &self,
+        service_id: u64,
+        call_id: u64,
+    ) -> Option<(Vec<u8>, Bn254SignatureScheme)> {
+        let task_id = TaskId::new(service_id, call_id);
+        let tasks = self.tasks.read();
+        tasks
+            .get(&task_id)
+            .map(|task| (task.message.clone(), task.signature_scheme))
     }
 
     /// Submit a signature for a task

--- a/crates/tangle-aggregation-svc/src/types.rs
+++ b/crates/tangle-aggregation-svc/src/types.rs
@@ -43,6 +43,22 @@ pub struct OperatorStake {
     pub stake: u64,
 }
 
+/// BN254 hash-to-curve algorithm used for a task.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum Bn254SignatureScheme {
+    /// The historical Arkworks SHA-256 implementation.
+    ArkworksSha256,
+    /// The Keccak try-and-increment algorithm in TNT core.
+    TangleKeccak256,
+}
+
+impl Default for Bn254SignatureScheme {
+    fn default() -> Self {
+        Self::ArkworksSha256
+    }
+}
+
 /// Request to submit a signature for aggregation
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SubmitSignatureRequest {
@@ -124,6 +140,12 @@ pub struct InitTaskRequest {
     /// The output to be signed
     #[serde(with = "hex_bytes")]
     pub output: Vec<u8>,
+    /// Exact bytes every operator must sign.
+    #[serde(default, with = "hex_bytes")]
+    pub message: Vec<u8>,
+    /// Hash-to-curve algorithm for the message.
+    #[serde(default)]
+    pub signature_scheme: Bn254SignatureScheme,
 }
 
 /// Response after initializing a task
@@ -170,5 +192,24 @@ mod hex_bytes {
         let s = String::deserialize(deserializer)?;
         let s = s.strip_prefix("0x").unwrap_or(&s);
         hex::decode(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn legacy_init_request_uses_legacy_signature_defaults() {
+        let request: InitTaskRequest = serde_json::from_str(
+            r#"{"service_id":1,"call_id":2,"operator_count":1,"threshold":{"type":"count","required_signers":1},"output":"0x0102"}"#,
+        )
+        .unwrap();
+
+        assert!(request.message.is_empty());
+        assert_eq!(
+            request.signature_scheme,
+            Bn254SignatureScheme::ArkworksSha256
+        );
     }
 }

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -19,6 +19,9 @@ blueprint-client-tangle.workspace = true
 blueprint-tangle-aggregation-svc = { workspace = true, features = ["client"], optional = true }
 blueprint-crypto-bn254 = { workspace = true, optional = true }
 blueprint-crypto-core = { workspace = true, optional = true }
+ark-bn254 = { workspace = true, optional = true }
+ark-ff = { workspace = true, optional = true }
+ark-serialize = { workspace = true, optional = true }
 
 # P2P aggregation dependencies
 blueprint-networking = { workspace = true, optional = true }
@@ -33,6 +36,7 @@ alloy = { workspace = true, features = ["sol-types", "contract", "provider-http"
 alloy-primitives.workspace = true
 alloy-sol-types.workspace = true
 alloy-rpc-types = { workspace = true }
+alloy-provider = { workspace = true, optional = true }
 
 bytes.workspace = true
 futures-core.workspace = true
@@ -70,7 +74,15 @@ std = [
     "blueprint-std/std",
     "blueprint-client-tangle/std",
 ]
-aggregation = ["blueprint-tangle-aggregation-svc", "blueprint-crypto-bn254", "blueprint-crypto-core"]
+aggregation = [
+    "blueprint-tangle-aggregation-svc",
+    "blueprint-crypto-bn254",
+    "blueprint-crypto-core",
+    "ark-bn254",
+    "ark-ff",
+    "ark-serialize",
+    "alloy-provider",
+]
 p2p-aggregation = [
     "blueprint-networking",
     "blueprint-networking-agg-sig-gossip-extension",

--- a/crates/tangle-extra/src/aggregating_consumer.rs
+++ b/crates/tangle-extra/src/aggregating_consumer.rs
@@ -22,6 +22,8 @@
 use crate::aggregation::AggregationError;
 use crate::extract;
 use alloy_primitives::{Address, Bytes};
+#[cfg(feature = "aggregation")]
+use alloy_provider::Provider;
 use blueprint_client_tangle::{AggregationConfig, OperatorMetadata, TangleClient, ThresholdType};
 use blueprint_core::JobResult;
 use blueprint_core::error::BoxError;
@@ -702,6 +704,7 @@ async fn submit_job_result(
 struct AggregationTaskInit {
     operator_count: u32,
     threshold: ThresholdConfig,
+    operators: Vec<Address>,
 }
 
 #[cfg(feature = "aggregation")]
@@ -810,6 +813,7 @@ async fn prepare_aggregation_task(
     Ok(AggregationTaskInit {
         operator_count,
         threshold,
+        operators: operators.operators,
     })
 }
 
@@ -860,8 +864,8 @@ async fn submit_aggregated_result(
     agg: AggregationServiceConfig,
 ) -> Result<(), AggregatingConsumerError> {
     use blueprint_crypto_bn254::ArkBlsBn254;
-    use blueprint_crypto_core::{BytesEncoding, KeyType};
-    use blueprint_tangle_aggregation_svc::{SubmitSignatureRequest, create_signing_message};
+    use blueprint_crypto_core::BytesEncoding;
+    use blueprint_tangle_aggregation_svc::SubmitSignatureRequest;
 
     let task_init =
         prepare_aggregation_task(&cache, &client, service_id, job_index, &config).await?;
@@ -884,12 +888,21 @@ async fn submit_aggregated_result(
         call_id
     );
 
-    // Create the message to sign
-    let message = create_signing_message(service_id, call_id, &output);
+    let chain_id = client
+        .provider()
+        .get_chain_id()
+        .await
+        .map_err(|error| AggregatingConsumerError::Client(error.to_string()))?;
+    let message = crate::aggregation::tangle_signing_message(
+        chain_id,
+        client.tangle_address(),
+        service_id,
+        call_id,
+        &task_init.operators,
+        &output,
+    );
 
-    // Sign with BLS key - we need a mutable clone since sign_with_secret takes &mut
-    let mut secret_clone = (*agg.bls_secret).clone();
-    let signature = ArkBlsBn254::sign_with_secret(&mut secret_clone, &message)
+    let signature = ArkBlsBn254::sign_tangle_with_secret(&agg.bls_secret, &message)
         .map_err(|e| AggregatingConsumerError::Bls(e.to_string()))?;
 
     // Get public key and signature bytes using BytesEncoding trait
@@ -913,10 +926,12 @@ async fn submit_aggregated_result(
     for (idx, service_client) in agg.clients.iter().enumerate() {
         // Try to initialize the task (may already exist from another operator)
         let _ = service_client
-            .init_task(
+            .init_task_with_message(
                 service_id,
                 call_id,
                 output.as_ref(),
+                &message,
+                blueprint_tangle_aggregation_svc::Bn254SignatureScheme::TangleKeccak256,
                 task_init.operator_count,
                 task_init.threshold.clone(),
             )
@@ -1078,6 +1093,9 @@ async fn submit_aggregated_to_chain_with_result(
     result: blueprint_tangle_aggregation_svc::AggregatedResultResponse,
 ) -> Result<(), AggregatingConsumerError> {
     use crate::aggregation::{AggregatedResult, G1Point, G2Point, SignerBitmap};
+    use ark_bn254::{G1Affine, G2Affine};
+    use ark_ff::{BigInteger, PrimeField};
+    use ark_serialize::CanonicalDeserialize;
 
     if client.config.dry_run {
         blueprint_core::info!(
@@ -1096,11 +1114,23 @@ async fn submit_aggregated_to_chain_with_result(
         call_id
     );
 
-    // Parse the signature and pubkey from the response
-    let signature = G1Point::from_bytes(&result.aggregated_signature)
-        .ok_or_else(|| AggregatingConsumerError::Bls("Invalid aggregated signature".to_string()))?;
-    let pubkey = G2Point::from_bytes(&result.aggregated_pubkey)
-        .ok_or_else(|| AggregatingConsumerError::Bls("Invalid aggregated pubkey".to_string()))?;
+    let signature = G1Affine::deserialize_compressed(&mut result.aggregated_signature.as_slice())
+        .map_err(|_| {
+        AggregatingConsumerError::Bls("Invalid aggregated signature".to_string())
+    })?;
+    let pubkey = G2Affine::deserialize_compressed(&mut result.aggregated_pubkey.as_slice())
+        .map_err(|_| AggregatingConsumerError::Bls("Invalid aggregated pubkey".to_string()))?;
+    let field_to_u256 = |field: &ark_bn254::Fq| {
+        alloy_primitives::U256::from_be_slice(&field.into_bigint().to_bytes_be())
+    };
+    let signature = G1Point::new(field_to_u256(&signature.x), field_to_u256(&signature.y));
+    // EIP-197 encodes Fp2 coordinates in c1,c0 order.
+    let pubkey = G2Point::new(
+        field_to_u256(&pubkey.x.c1),
+        field_to_u256(&pubkey.x.c0),
+        field_to_u256(&pubkey.y.c1),
+        field_to_u256(&pubkey.y.c0),
+    );
 
     let aggregated = AggregatedResult::new(
         service_id,

--- a/crates/tangle-extra/src/aggregation.rs
+++ b/crates/tangle-extra/src/aggregation.rs
@@ -28,12 +28,43 @@
 //! result.submit(&client).await?;
 //! ```
 
-use alloy_primitives::{Bytes, U256};
+use alloy_primitives::{Address, Bytes, U256, keccak256};
+use alloy_sol_types::{SolType, SolValue, sol_data};
 use blueprint_client_tangle::TangleClient;
 use blueprint_std::format;
 use blueprint_std::string::String;
 use blueprint_std::sync::Arc;
 use thiserror::Error;
+
+/// Build the exact message verified by TNT core v0.19 `JobsAggregation`.
+pub fn tangle_signing_message(
+    chain_id: u64,
+    tangle_address: Address,
+    service_id: u64,
+    call_id: u64,
+    operators: &[Address],
+    output: &[u8],
+) -> Vec<u8> {
+    type Message = (
+        sol_data::String,
+        sol_data::Uint<256>,
+        sol_data::Address,
+        sol_data::Uint<64>,
+        sol_data::Uint<64>,
+        sol_data::FixedBytes<32>,
+        sol_data::FixedBytes<32>,
+    );
+
+    Message::abi_encode(&(
+        "TANGLE_BLS_AGG_v1".to_owned(),
+        U256::from(chain_id),
+        tangle_address,
+        service_id,
+        call_id,
+        keccak256(operators.abi_encode()),
+        keccak256(output),
+    ))
+}
 
 /// Error types for aggregation operations
 #[derive(Debug, Error)]
@@ -270,6 +301,42 @@ pub const JOB_INDEX_KEY: &str = "tangle.job_index";
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn tangle_message_binds_every_contract_domain_field() {
+        let tangle = Address::repeat_byte(0x11);
+        let operators = [Address::repeat_byte(0x22), Address::repeat_byte(0x33)];
+        let baseline = tangle_signing_message(1, tangle, 2, 3, &operators, b"output");
+
+        assert_eq!(
+            baseline,
+            tangle_signing_message(1, tangle, 2, 3, &operators, b"output")
+        );
+        assert_ne!(
+            baseline,
+            tangle_signing_message(2, tangle, 2, 3, &operators, b"output")
+        );
+        assert_ne!(
+            baseline,
+            tangle_signing_message(1, Address::repeat_byte(0x12), 2, 3, &operators, b"output")
+        );
+        assert_ne!(
+            baseline,
+            tangle_signing_message(1, tangle, 4, 3, &operators, b"output")
+        );
+        assert_ne!(
+            baseline,
+            tangle_signing_message(1, tangle, 2, 4, &operators, b"output")
+        );
+        assert_ne!(
+            baseline,
+            tangle_signing_message(1, tangle, 2, 3, &operators[..1], b"output")
+        );
+        assert_ne!(
+            baseline,
+            tangle_signing_message(1, tangle, 2, 3, &operators, b"different")
+        );
+    }
 
     // ═══════════════════════════════════════════════════════════════════════════
     // SignerBitmap tests


### PR DESCRIPTION
## Summary

- TNT core 0.19 verifies Keccak hash-to-curve signatures over a complete ABI domain message.
- The SDK produced SHA-256 signatures over a legacy message and forwarded compressed Arkworks points to Solidity.
- This change adds an explicit TNT signing mode across crypto, aggregation service, and Tangle consumer code.
- Tangle operators can now produce the signature and point layout that the deployed contract verifies.

## Change Class

- Selected class: Class D
- Why this class: The change corrects protocol signature semantics at the on-chain boundary.

## Behavior Contract

- Current behavior: TNT 0.19 rejects aggregated results produced by the SDK.
- Intended behavior: Tangle consumers sign the complete contract domain and submit EIP-197 coordinates.
- Invariants that must hold: Historical Arkworks SHA-256 callers keep their existing behavior. Tangle mode binds chain, contract, service, call, operator order, and output. The service verifies only the signature mode declared at task creation. Older task-init JSON maps to the historical mode.
- Failure mode choice (`fail-closed` or `fail-open`) and rationale: Fail-closed. A wrong message, wrong signature mode, malformed compressed point, or signature mismatch returns an error before chain submission.

## Risk And Scope

- Security impact: Positive. Contract-bound signatures prevent replay across deployments, calls, operator sets, and outputs.
- Compatibility impact (APIs, metadata format, configs): The new Rust methods are additive. Existing methods retain SHA-256 behavior. New JSON fields have defaults, so older task-init clients remain valid.
- Migration notes (if any): Tangle consumers should use the explicit TNT signing mode. Existing non-Tangle consumers need no change.
- Rollback plan: Revert this commit. The historical signing and service paths remain isolated and unchanged.

## Verification

```bash
cargo test -p blueprint-crypto-bn254
cargo test -p blueprint-tangle-aggregation-svc --features client
cargo test -p blueprint-tangle-extra --features aggregation
cargo clippy -p blueprint-crypto-bn254 -p blueprint-tangle-aggregation-svc -p blueprint-tangle-extra --features blueprint-tangle-aggregation-svc/client,blueprint-tangle-extra/aggregation --all-targets -- -D warnings
git diff --check
```

- Crypto: 18 passed.
- Aggregation service: 45 unit and 15 integration checks passed.
- Tangle extra: 102 unit and 9 integration checks passed. The integration set uses Anvil.
- Targeted clippy exited 0. The workspace emits an existing renamed-lint warning.
- Diff check exited 0.

## Harness Evidence

- Reproducer added/updated: A fixed Solidity coordinate vector proves the TNT hash-to-curve output. Service and Tangle message tests cover the cross-crate path.
- Negative-path coverage added: A TNT task rejects a valid legacy signature. A changed domain field changes the signed message. Older init JSON still decodes to legacy mode.
- Key assertions that prove the fix: The TNT vector matches both coordinates. TNT signatures pass TNT verification and fail historical verification. The service accepts only the declared mode.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input.
- [x] I documented behavior or interface changes in docs/examples when needed.
- [x] I evaluated compatibility/migration impact explicitly.
- [x] I validated local formatting, clippy, and relevant tests.