### PR TITLE
fix(tangle): fail closed on aggregation policy errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3087,6 +3087,7 @@ dependencies = [
  "futures-core",
  "hex",
  "k256",
+ "mockito",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/clients/tangle/Cargo.toml
+++ b/crates/clients/tangle/Cargo.toml
@@ -59,6 +59,7 @@ blueprint-chain-setup-anvil = { path = "../../chain-setup/anvil" }
 blueprint-anvil-testing-utils = { path = "../../testing-utils/anvil" }
 anyhow = { workspace = true }
 hex = { workspace = true }
+mockito = { workspace = true }
 
 [features]
 default = ["std"]

--- a/crates/clients/tangle/src/client.rs
+++ b/crates/clients/tangle/src/client.rs
@@ -2677,6 +2677,8 @@ impl TangleClient {
     ///
     /// Queries the blueprint's service manager contract to determine if the specified
     /// job index requires aggregated BLS signatures instead of individual results.
+    /// A failed manager call is returned as an error so callers cannot submit through
+    /// the wrong path when the aggregation policy is unavailable.
     pub async fn requires_aggregation(&self, service_id: u64, job_index: u8) -> Result<bool> {
         let manager = match self.get_blueprint_manager(service_id).await? {
             Some(m) => m,
@@ -2684,10 +2686,10 @@ impl TangleClient {
         };
 
         let bsm = IBlueprintServiceManager::new(manager, Arc::clone(&self.provider));
-        match bsm.requiresAggregation(service_id, job_index).call().await {
-            Ok(required) => Ok(required),
-            Err(_) => Ok(false), // If call fails, assume no aggregation required
-        }
+        bsm.requiresAggregation(service_id, job_index)
+            .call()
+            .await
+            .map_err(|e| Error::Contract(e.to_string()))
     }
 
     /// Get the aggregation threshold configuration for a job
@@ -2695,6 +2697,8 @@ impl TangleClient {
     /// Returns (threshold_bps, threshold_type) where:
     /// - threshold_bps: Threshold in basis points (e.g., 6700 = 67%)
     /// - threshold_type: 0 = CountBased (% of operators), 1 = StakeWeighted (% of stake)
+    ///
+    /// A failed manager call is returned as an error instead of guessing a threshold.
     pub async fn get_aggregation_threshold(
         &self,
         service_id: u64,
@@ -2706,14 +2710,12 @@ impl TangleClient {
         };
 
         let bsm = IBlueprintServiceManager::new(manager, Arc::clone(&self.provider));
-        match bsm
+        let result = bsm
             .getAggregationThreshold(service_id, job_index)
             .call()
             .await
-        {
-            Ok(result) => Ok((result.thresholdBps, result.thresholdType)),
-            Err(_) => Ok((6700, 0)), // Default if call fails
-        }
+            .map_err(|e| Error::Contract(e.to_string()))?;
+        Ok((result.thresholdBps, result.thresholdType))
     }
 
     /// Get the aggregation configuration for a specific job

--- a/crates/clients/tangle/tests/aggregation_policy.rs
+++ b/crates/clients/tangle/tests/aggregation_policy.rs
@@ -1,0 +1,136 @@
+//! Regression coverage for fail-closed aggregation policy queries.
+
+use alloy_primitives::Address;
+use alloy_sol_types::SolCall;
+use blueprint_client_tangle::contracts::{ITangle, ITangleTypes};
+use blueprint_client_tangle::{Error, TangleClient, TangleClientConfig, TangleSettings};
+use blueprint_crypto::BytesEncoding;
+use blueprint_crypto::k256::{K256Ecdsa, K256SigningKey};
+use blueprint_keystore::backends::Backend;
+use blueprint_keystore::{Keystore, KeystoreConfig};
+use mockito::{Matcher, Server};
+use serde_json::{Value, json};
+use url::Url;
+
+const BLUEPRINT_ID: u64 = 7;
+const SERVICE_ID: u64 = 9;
+
+#[tokio::test]
+async fn manager_policy_query_errors_are_not_silently_downgraded() {
+    let mut server = Server::new_async().await;
+    let tangle = Address::repeat_byte(0xaa);
+    let manager = Address::repeat_byte(0xbb);
+
+    let service = ITangleTypes::Service {
+        blueprintId: BLUEPRINT_ID,
+        owner: Address::ZERO,
+        createdAt: 0,
+        ttl: 0,
+        terminatedAt: 0,
+        lastPaymentAt: 0,
+        operatorCount: 0,
+        minOperators: 0,
+        maxOperators: 0,
+        membership: ITangleTypes::MembershipModel::from_underlying(0).into(),
+        pricing: ITangleTypes::PricingModel::from_underlying(0).into(),
+        status: ITangleTypes::ServiceStatus::from_underlying(0).into(),
+        confidentiality: ITangleTypes::ConfidentialityPolicy::from_underlying(0).into(),
+    };
+    let blueprint = ITangleTypes::Blueprint {
+        owner: Address::ZERO,
+        manager,
+        createdAt: 0,
+        membership: ITangleTypes::MembershipModel::from_underlying(0).into(),
+        pricing: ITangleTypes::PricingModel::from_underlying(0).into(),
+        active: true,
+    };
+    let service_response = format!(
+        "0x{}",
+        hex::encode(ITangle::getServiceCall::abi_encode_returns(&service))
+    );
+    let blueprint_response = format!(
+        "0x{}",
+        hex::encode(ITangle::getBlueprintCall::abi_encode_returns(&blueprint))
+    );
+
+    let tangle_hex = format!("{tangle:#x}");
+    let manager_hex = format!("{manager:#x}");
+    let service_response_for_rpc = service_response.clone();
+    let blueprint_response_for_rpc = blueprint_response.clone();
+    let policy_mock = server
+        .mock("POST", "/")
+        .match_body(Matcher::Any)
+        .with_body_from_request(move |request| {
+            let body: Value = serde_json::from_slice(request.body().unwrap()).unwrap();
+            let id = body["id"].clone();
+
+            if body["method"] != "eth_call" {
+                return serde_json::to_vec(&json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "result": "0x1"
+                }))
+                .unwrap();
+            }
+
+            let call = &body["params"][0];
+            let to = call["to"].as_str().unwrap();
+            let data = call
+                .get("data")
+                .or_else(|| call.get("input"))
+                .and_then(Value::as_str)
+                .unwrap();
+
+            let response = if to.eq_ignore_ascii_case(&tangle_hex) && data.starts_with("0x3dc0d5fe")
+            {
+                json!({"jsonrpc": "2.0", "id": id, "result": service_response_for_rpc})
+            } else if to.eq_ignore_ascii_case(&tangle_hex) && data.starts_with("0xb7696dbb") {
+                json!({"jsonrpc": "2.0", "id": id, "result": blueprint_response_for_rpc})
+            } else if to.eq_ignore_ascii_case(&manager_hex) {
+                json!({
+                    "jsonrpc": "2.0",
+                    "id": id,
+                    "error": {"code": 3, "message": "manager policy unavailable"}
+                })
+            } else {
+                panic!("unexpected JSON-RPC call: {body}");
+            };
+
+            serde_json::to_vec(&response).unwrap()
+        })
+        .expect(6)
+        .create_async()
+        .await;
+
+    let keystore = Keystore::new(KeystoreConfig::new().in_memory(true)).unwrap();
+    let secret = K256SigningKey::from_bytes(&[1u8; 32]).unwrap();
+    keystore.insert::<K256Ecdsa>(&secret).unwrap();
+    let rpc_url = Url::parse(&server.url()).unwrap();
+    let settings = TangleSettings {
+        blueprint_id: BLUEPRINT_ID,
+        service_id: Some(SERVICE_ID),
+        tangle_contract: tangle,
+        staking_contract: Address::ZERO,
+        status_registry_contract: Address::ZERO,
+    };
+    let config = TangleClientConfig::new(rpc_url.clone(), rpc_url, "memory://", settings);
+    let client = TangleClient::with_keystore(config, keystore).await.unwrap();
+
+    let error = client
+        .requires_aggregation(SERVICE_ID, 4)
+        .await
+        .expect_err("a failed manager query must not mean no aggregation");
+    assert!(
+        matches!(error, Error::Contract(message) if message.contains("manager policy unavailable"))
+    );
+
+    let error = client
+        .get_aggregation_threshold(SERVICE_ID, 4)
+        .await
+        .expect_err("a failed threshold query must not use a guessed threshold");
+    assert!(
+        matches!(error, Error::Contract(message) if message.contains("manager policy unavailable"))
+    );
+
+    policy_mock.assert_async().await;
+}

--- a/crates/tangle-extra/src/aggregating_consumer.rs
+++ b/crates/tangle-extra/src/aggregating_consumer.rs
@@ -91,6 +91,25 @@ impl State {
     fn is_waiting(&self) -> bool {
         matches!(self, State::WaitingForResult)
     }
+
+    fn poll_submission(
+        &mut self,
+        cx: &mut Context<'_>,
+    ) -> Poll<Result<(), AggregatingConsumerError>> {
+        let State::ProcessingSubmission(future) = self else {
+            return Poll::Ready(Ok(()));
+        };
+
+        match future.as_mut().poll(cx) {
+            Poll::Ready(result) => {
+                // A completed future must never remain in the state machine. The
+                // next flush poll would otherwise poll it again and panic.
+                *self = State::WaitingForResult;
+                Poll::Ready(result)
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
 }
 
 /// Configuration for the aggregation service
@@ -641,10 +660,8 @@ impl Sink<JobResult> for AggregatingConsumer {
 
                     *state = State::ProcessingSubmission(fut);
                 }
-                State::ProcessingSubmission(future) => match future.as_mut().poll(cx) {
-                    Poll::Ready(Ok(())) => {
-                        *state = State::WaitingForResult;
-                    }
+                State::ProcessingSubmission(_) => match state.poll_submission(cx) {
+                    Poll::Ready(Ok(())) => {}
                     Poll::Ready(Err(e)) => return Poll::Ready(Err(e.into())),
                     Poll::Pending => return Poll::Pending,
                 },
@@ -1304,7 +1321,9 @@ pub mod integration {
 #[cfg(test)]
 mod tests {
     use super::integration::*;
+    use super::{AggregatingConsumerError, State};
     use blueprint_client_tangle::ThresholdType;
+    use core::task::{Context, Poll};
 
     // ═══════════════════════════════════════════════════════════════════════════
     // create_signing_message tests
@@ -1354,6 +1373,29 @@ mod tests {
     fn test_create_signing_message_empty_output() {
         let msg = create_signing_message(1, 2, b"");
         assert_eq!(msg.len(), 48);
+    }
+
+    #[test]
+    fn failed_submission_resets_state_for_next_job() {
+        let waker = futures_util::task::noop_waker();
+        let mut cx = Context::from_waker(&waker);
+        let mut state = State::ProcessingSubmission(Box::pin(async {
+            Err(AggregatingConsumerError::Client("duplicate".to_string()))
+        }));
+
+        assert!(matches!(
+            state.poll_submission(&mut cx),
+            Poll::Ready(Err(AggregatingConsumerError::Client(message)))
+                if message == "duplicate"
+        ));
+        assert!(state.is_waiting());
+
+        state = State::ProcessingSubmission(Box::pin(async { Ok(()) }));
+        assert!(matches!(
+            state.poll_submission(&mut cx),
+            Poll::Ready(Ok(()))
+        ));
+        assert!(state.is_waiting());
     }
 
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

Reset the aggregating consumer after every completed submission future.
Propagate service-manager aggregation policy errors instead of selecting an unsafe fallback.

## Change Class

Selected class: Class D

This change modifies protocol result routing and aggregation policy handling.

## Behavior Contract

The consumer returns the original submission error to its sink caller.
After an error, the consumer returns to its waiting state and can process the next job.
When a blueprint manager exists, aggregation and threshold query failures remain errors.
No failed policy query may silently select direct submission or a guessed threshold.
Failure mode choice (`fail-closed`): policy uncertainty must stop submission.

## Risk And Scope

Security impact: prevents a direct result from bypassing a required aggregated result path.
Compatibility impact: successful queries and the public client API remain unchanged.
Migration notes: none; this is a runtime bug fix.
Rollback plan: revert commit `afe04160` if a downstream policy depends on the old fallback.

## Verification

- `cargo test -p blueprint-tangle-extra --lib aggregating_consumer::tests::failed_submission_resets_state_for_next_job -- --nocapture`
- `cargo test -p blueprint-tangle-extra --features aggregation --lib aggregating_consumer::tests::failed_submission_resets_state_for_next_job -- --nocapture`
- `cargo test -p blueprint-client-tangle --test aggregation_policy -- --nocapture --test-threads=1`
- `cargo test -p blueprint-client-tangle --lib`
- `cargo clippy -p blueprint-client-tangle --tests --all-features -- -D warnings`
- `cargo clippy -p blueprint-tangle-extra --lib --all-features -- -D warnings`

## Harness Evidence

Reproducer added: the sink state test polls a failed future, checks the returned error, and processes a second future.
Negative-path coverage added: the JSON-RPC test returns manager errors for both policy methods.
Key assertions that prove the fix: failed futures reset to `WaitingForResult`; manager errors remain `Error::Contract`.

## Checklist

- [x] Added regression tests for the failed submission state and policy query errors.
- [x] Ran focused unit tests and all-feature clippy checks.
- [x] Preserved the existing public API and error return behavior.