### PR TITLE
fix(aggregation-svc): persist task state across restarts

### DIFF
--- a/crates/tangle-aggregation-svc/src/persistence.rs
+++ b/crates/tangle-aggregation-svc/src/persistence.rs
@@ -7,20 +7,26 @@
 //! ## Usage
 //!
 //! ```rust,ignore
-//! use blueprint_tangle_aggregation_svc::persistence::{PersistenceBackend, FilePersistence};
+//! use blueprint_tangle_aggregation_svc::{
+//!     persistence::{FilePersistence, PersistenceBackend},
+//!     AggregationService,
+//! };
 //!
 //! // Create file-based persistence
 //! let persistence = FilePersistence::new("/var/lib/aggregation/state.json");
 //!
 //! // Create service with persistence
-//! let service = AggregationService::with_persistence(config, persistence);
+//! let service = AggregationService::with_persistence(config, persistence)?;
 //! ```
 
-use crate::state::ThresholdType;
+use crate::state::{TaskState, ThresholdType};
 use crate::types::{Bn254SignatureScheme, TaskId};
+use alloy_primitives::U256;
+use ark_bn254::{G1Affine, G2Affine};
+use ark_serialize::{CanonicalDeserialize, CanonicalSerialize};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
 
 /// Error type for persistence operations
 #[derive(Debug, thiserror::Error)]
@@ -102,6 +108,165 @@ impl From<PersistedThresholdType> for ThresholdType {
             PersistedThresholdType::Count(n) => ThresholdType::Count(n),
             PersistedThresholdType::StakeWeighted(n) => ThresholdType::StakeWeighted(n),
         }
+    }
+}
+
+impl TryFrom<&TaskState> for PersistedTaskState {
+    type Error = PersistenceError;
+
+    fn try_from(task: &TaskState) -> Result<Self> {
+        let signatures = task
+            .signatures
+            .iter()
+            .map(|(index, signature)| Ok((*index, encode_point(&signature.0)?)))
+            .collect::<Result<HashMap<_, _>>>()?;
+        let public_keys = task
+            .public_keys
+            .iter()
+            .map(|(index, public_key)| Ok((*index, encode_point(&public_key.0)?)))
+            .collect::<Result<HashMap<_, _>>>()?;
+
+        Ok(Self {
+            service_id: task.service_id,
+            call_id: task.call_id,
+            output: task.output.clone(),
+            message: task.message.clone(),
+            signature_scheme: task.signature_scheme,
+            operator_count: task.operator_count,
+            threshold_type: task.threshold_type.into(),
+            signer_bitmap: format!("{:#x}", task.signer_bitmap),
+            signatures,
+            public_keys,
+            operator_stakes: task.operator_stakes.clone(),
+            total_stake: task.total_stake,
+            submitted: task.submitted,
+            created_at_ms: instant_to_millis(task.created_at),
+            expires_at_ms: task.expires_at.map(instant_to_millis),
+        })
+    }
+}
+
+impl TryFrom<PersistedTaskState> for TaskState {
+    type Error = PersistenceError;
+
+    fn try_from(persisted: PersistedTaskState) -> Result<Self> {
+        let signer_bitmap = parse_u256(&persisted.signer_bitmap)?;
+        let threshold_type = persisted.threshold_type.into();
+        let mut task = TaskState::with_message_config(
+            persisted.service_id,
+            persisted.call_id,
+            persisted.output,
+            persisted.message,
+            persisted.signature_scheme,
+            persisted.operator_count,
+            threshold_type,
+            Some(persisted.operator_stakes.clone()),
+            None,
+        );
+
+        if task.total_stake != persisted.total_stake {
+            return Err(PersistenceError::Serialization(format!(
+                "task {}:{} has inconsistent total stake",
+                task.service_id, task.call_id
+            )));
+        }
+
+        if persisted.signatures.len() != persisted.public_keys.len() {
+            return Err(PersistenceError::Serialization(format!(
+                "task {}:{} has an incomplete signature/public-key pair",
+                task.service_id, task.call_id
+            )));
+        }
+
+        let mut indices: Vec<_> = persisted.signatures.keys().copied().collect();
+        indices.sort_unstable();
+        for index in indices {
+            let signature = decode_signature(
+                persisted
+                    .signatures
+                    .get(&index)
+                    .ok_or_else(|| missing_entry("signature", index))?,
+            )?;
+            let public_key = decode_public_key(
+                persisted
+                    .public_keys
+                    .get(&index)
+                    .ok_or_else(|| missing_entry("public key", index))?,
+            )?;
+            task.add_signature(index, signature, public_key)
+                .map_err(|error| PersistenceError::Serialization(error.to_string()))?;
+        }
+
+        if task.signer_bitmap != signer_bitmap {
+            return Err(PersistenceError::Serialization(format!(
+                "task {}:{} has an inconsistent signer bitmap",
+                task.service_id, task.call_id
+            )));
+        }
+
+        task.submitted = persisted.submitted;
+        task.created_at = millis_to_instant(persisted.created_at_ms);
+        task.expires_at = persisted.expires_at_ms.map(millis_to_instant);
+        Ok(task)
+    }
+}
+
+fn encode_point(point: &impl CanonicalSerialize) -> Result<String> {
+    let mut bytes = Vec::new();
+    point
+        .serialize_compressed(&mut bytes)
+        .map_err(|error| PersistenceError::Serialization(error.to_string()))?;
+    Ok(format!("0x{}", hex::encode(bytes)))
+}
+
+fn decode_bytes(value: &str) -> Result<Vec<u8>> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    hex::decode(value).map_err(|error| PersistenceError::Serialization(error.to_string()))
+}
+
+fn decode_signature(value: &str) -> Result<blueprint_crypto_bn254::ArkBlsBn254Signature> {
+    Ok(blueprint_crypto_bn254::ArkBlsBn254Signature(
+        G1Affine::deserialize_compressed(&*decode_bytes(value)?)
+            .map_err(|error| PersistenceError::Serialization(error.to_string()))?,
+    ))
+}
+
+fn decode_public_key(value: &str) -> Result<blueprint_crypto_bn254::ArkBlsBn254Public> {
+    Ok(blueprint_crypto_bn254::ArkBlsBn254Public(
+        G2Affine::deserialize_compressed(&*decode_bytes(value)?)
+            .map_err(|error| PersistenceError::Serialization(error.to_string()))?,
+    ))
+}
+
+fn parse_u256(value: &str) -> Result<U256> {
+    let value = value.strip_prefix("0x").unwrap_or(value);
+    U256::from_str_radix(value, 16)
+        .map_err(|error| PersistenceError::Serialization(error.to_string()))
+}
+
+fn missing_entry(kind: &str, index: u32) -> PersistenceError {
+    PersistenceError::Serialization(format!("missing {kind} for operator {index}"))
+}
+
+fn instant_to_millis(instant: Instant) -> u64 {
+    let now = Instant::now();
+    let now_ms = now_millis();
+    if instant >= now {
+        now_ms.saturating_add(instant.duration_since(now).as_millis() as u64)
+    } else {
+        now_ms.saturating_sub(now.duration_since(instant).as_millis() as u64)
+    }
+}
+
+fn millis_to_instant(timestamp_ms: u64) -> Instant {
+    let now = Instant::now();
+    let now_ms = now_millis();
+    if timestamp_ms >= now_ms {
+        now.checked_add(Duration::from_millis(timestamp_ms - now_ms))
+            .unwrap_or(now)
+    } else {
+        now.checked_sub(Duration::from_millis(now_ms - timestamp_ms))
+            .unwrap_or(now)
     }
 }
 

--- a/crates/tangle-aggregation-svc/src/service.rs
+++ b/crates/tangle-aggregation-svc/src/service.rs
@@ -1,11 +1,13 @@
 //! Main aggregation service logic
 
+use crate::persistence::{NoPersistence, PersistedTaskState, PersistenceBackend, PersistenceError};
 use crate::state::{AggregationState, TaskConfig, ThresholdType};
 use crate::types::*;
 use alloy_primitives::U256;
 use ark_serialize::CanonicalDeserialize;
 use blueprint_crypto_bn254::{ArkBlsBn254, ArkBlsBn254Public, ArkBlsBn254Signature};
 use blueprint_crypto_core::{aggregation::AggregatableSignature, KeyType};
+use parking_lot::Mutex;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror::Error;
@@ -76,10 +78,29 @@ impl ServiceConfig {
 }
 
 /// The main aggregation service
-#[derive(Debug)]
 pub struct AggregationService {
     state: AggregationState,
     config: ServiceConfig,
+    persistence: Arc<dyn PersistenceBackend>,
+    mutation_lock: Mutex<()>,
+}
+
+impl std::fmt::Debug for AggregationService {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("AggregationService")
+            .field("state", &self.state)
+            .field("config", &self.config)
+            .field("persistence", &"configured")
+            .finish()
+    }
+}
+
+#[derive(Clone, Copy)]
+enum CleanupKind {
+    All,
+    Expired,
+    Submitted,
 }
 
 impl AggregationService {
@@ -88,12 +109,138 @@ impl AggregationService {
         Self {
             state: AggregationState::new(),
             config,
+            persistence: Arc::new(NoPersistence),
+            mutation_lock: Mutex::new(()),
         }
+    }
+
+    /// Create a service backed by a persistence implementation.
+    ///
+    /// Existing tasks are loaded before the service is returned. A malformed
+    /// or unreadable store fails construction instead of silently starting
+    /// with an empty task set.
+    pub fn with_persistence<P>(config: ServiceConfig, persistence: P) -> Result<Self, ServiceError>
+    where
+        P: PersistenceBackend + 'static,
+    {
+        let persistence = Arc::new(persistence);
+        let state = AggregationState::new();
+        let persisted = persistence
+            .load_all_tasks()
+            .map_err(Self::persistence_error)?;
+        state.restore(persisted).map_err(Self::persistence_error)?;
+
+        Ok(Self {
+            state,
+            config,
+            persistence,
+            mutation_lock: Mutex::new(()),
+        })
     }
 
     /// Create a new aggregation service wrapped in Arc
     pub fn new_shared(config: ServiceConfig) -> Arc<Self> {
         Arc::new(Self::new(config))
+    }
+
+    fn persistence_error(error: PersistenceError) -> ServiceError {
+        ServiceError::Other(format!("persistence error: {error}"))
+    }
+
+    fn snapshot(&self) -> Result<Vec<PersistedTaskState>, ServiceError> {
+        self.state.snapshot().map_err(Self::persistence_error)
+    }
+
+    fn persist_task(&self, service_id: u64, call_id: u64) -> Result<(), ServiceError> {
+        let task = self
+            .snapshot()?
+            .into_iter()
+            .find(|task| task.service_id == service_id && task.call_id == call_id)
+            .ok_or(ServiceError::TaskNotFound)?;
+        self.persistence
+            .save_task(&task)
+            .map_err(Self::persistence_error)?;
+        self.persistence.flush().map_err(Self::persistence_error)
+    }
+
+    fn restore_persisted_task(&self, before: &[PersistedTaskState], task_id: &TaskId) {
+        let result = match before
+            .iter()
+            .find(|task| task.service_id == task_id.service_id && task.call_id == task_id.call_id)
+        {
+            Some(task) => self.persistence.save_task(task),
+            None => self.persistence.delete_task(task_id),
+        };
+        if let Err(error) = result {
+            warn!(%error, service_id = task_id.service_id, call_id = task_id.call_id, "failed to restore persisted aggregation task");
+            return;
+        }
+        if let Err(error) = self.persistence.flush() {
+            warn!(%error, service_id = task_id.service_id, call_id = task_id.call_id, "failed to flush restored aggregation task");
+        }
+    }
+
+    fn restore_persisted_tasks(&self, tasks: &[PersistedTaskState]) {
+        for task in tasks {
+            if let Err(error) = self.persistence.save_task(task) {
+                warn!(%error, service_id = task.service_id, call_id = task.call_id, "failed to restore persisted aggregation task");
+            }
+        }
+        if let Err(error) = self.persistence.flush() {
+            warn!(%error, "failed to flush restored aggregation tasks");
+        }
+    }
+
+    fn restore_snapshot(&self, snapshot: Vec<PersistedTaskState>) {
+        if let Err(error) = self.state.restore(snapshot) {
+            warn!(%error, "failed to restore in-memory aggregation state after persistence error");
+        }
+    }
+
+    fn cleanup_with_persistence(&self, kind: CleanupKind) -> Result<usize, ServiceError> {
+        let _guard = self.mutation_lock.lock();
+        let before = self.snapshot()?;
+        let removed = match kind {
+            CleanupKind::All => self.state.cleanup(),
+            CleanupKind::Expired => self.state.cleanup_expired(),
+            CleanupKind::Submitted => self.state.cleanup_submitted(),
+        };
+        if removed == 0 {
+            return Ok(0);
+        }
+
+        let after = match self.snapshot() {
+            Ok(after) => after,
+            Err(error) => {
+                self.restore_snapshot(before);
+                return Err(error);
+            }
+        };
+        let remaining = after
+            .iter()
+            .map(|task| (task.service_id, task.call_id))
+            .collect::<std::collections::HashSet<_>>();
+        let removed_tasks: Vec<_> = before
+            .iter()
+            .filter(|task| !remaining.contains(&(task.service_id, task.call_id)))
+            .cloned()
+            .collect();
+        for (index, task) in removed_tasks.iter().enumerate() {
+            if let Err(error) = self
+                .persistence
+                .delete_task(&TaskId::new(task.service_id, task.call_id))
+            {
+                self.restore_persisted_tasks(&removed_tasks[..=index]);
+                self.restore_snapshot(before);
+                return Err(Self::persistence_error(error));
+            }
+        }
+        if let Err(error) = self.persistence.flush() {
+            self.restore_persisted_tasks(&removed_tasks);
+            self.restore_snapshot(before);
+            return Err(Self::persistence_error(error));
+        }
+        Ok(removed)
     }
 
     /// Start the background cleanup worker
@@ -110,13 +257,17 @@ impl AggregationService {
             loop {
                 tokio::select! {
                     _ = interval_timer.tick() => {
-                        let removed = if service.config.auto_cleanup_submitted {
-                            service.state.cleanup()
+                        let result = if service.config.auto_cleanup_submitted {
+                            service.cleanup_with_persistence(CleanupKind::All)
                         } else {
-                            service.state.cleanup_expired()
+                            service.cleanup_with_persistence(CleanupKind::Expired)
                         };
-                        if removed > 0 {
+                        match result {
+                            Ok(removed) if removed > 0 => {
                             debug!(removed, "Cleaned up tasks");
+                            }
+                            Ok(_) => {}
+                            Err(error) => warn!(%error, "failed to persist aggregation cleanup"),
                         }
                     }
                     _ = shutdown_rx.changed() => {
@@ -199,7 +350,10 @@ impl AggregationService {
             "Initializing aggregation task"
         );
 
-        self.state
+        let _guard = self.mutation_lock.lock();
+        let before = self.snapshot()?;
+        let result = self
+            .state
             .init_task_with_message_config(
                 service_id,
                 call_id,
@@ -209,7 +363,14 @@ impl AggregationService {
                 operator_count,
                 config,
             )
-            .map_err(|e| ServiceError::Other(e.to_string()))
+            .map_err(|e| ServiceError::Other(e.to_string()));
+        result?;
+        if let Err(error) = self.persist_task(service_id, call_id) {
+            self.restore_persisted_task(&before, &TaskId::new(service_id, call_id));
+            self.restore_snapshot(before);
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Submit a signature for aggregation
@@ -217,6 +378,8 @@ impl AggregationService {
         &self,
         req: SubmitSignatureRequest,
     ) -> Result<SubmitSignatureResponse, ServiceError> {
+        let _guard = self.mutation_lock.lock();
+        let before = self.snapshot()?;
         debug!(
             service_id = req.service_id,
             call_id = req.call_id,
@@ -301,6 +464,12 @@ impl AggregationService {
                 public_key,
             )
             .map_err(|e| ServiceError::Other(e.to_string()))?;
+
+        if let Err(error) = self.persist_task(req.service_id, req.call_id) {
+            self.restore_persisted_task(&before, &TaskId::new(req.service_id, req.call_id));
+            self.restore_snapshot(before);
+            return Err(error);
+        }
 
         info!(
             service_id = req.service_id,
@@ -397,13 +566,44 @@ impl AggregationService {
 
     /// Mark a task as submitted to chain
     pub fn mark_submitted(&self, service_id: u64, call_id: u64) -> Result<(), ServiceError> {
+        let _guard = self.mutation_lock.lock();
+        let before = self.snapshot()?;
         self.state
             .mark_submitted(service_id, call_id)
-            .map_err(|e| ServiceError::Other(e.to_string()))
+            .map_err(|e| ServiceError::Other(e.to_string()))?;
+        if let Err(error) = self.persist_task(service_id, call_id) {
+            self.restore_persisted_task(&before, &TaskId::new(service_id, call_id));
+            self.restore_snapshot(before);
+            return Err(error);
+        }
+        Ok(())
     }
 
     /// Remove a task
     pub fn remove_task(&self, service_id: u64, call_id: u64) -> bool {
+        let _guard = self.mutation_lock.lock();
+        let before = match self.snapshot() {
+            Ok(before) => before,
+            Err(error) => {
+                warn!(%error, service_id, call_id, "failed to snapshot aggregation task before removal");
+                return false;
+            }
+        };
+        let exists = self.state.get_status(service_id, call_id).is_some();
+        if !exists {
+            return false;
+        }
+        let task_id = TaskId::new(service_id, call_id);
+        if let Err(error) = self.persistence.delete_task(&task_id) {
+            self.restore_persisted_task(&before, &task_id);
+            warn!(%error, service_id, call_id, "failed to remove persisted aggregation task");
+            return false;
+        }
+        if let Err(error) = self.persistence.flush() {
+            self.restore_persisted_task(&before, &task_id);
+            warn!(%error, service_id, call_id, "failed to flush removed aggregation task");
+            return false;
+        }
         self.state.remove_task(service_id, call_id)
     }
 
@@ -421,17 +621,35 @@ impl AggregationService {
 
     /// Manually trigger cleanup
     pub fn cleanup(&self) -> usize {
-        self.state.cleanup()
+        match self.cleanup_with_persistence(CleanupKind::All) {
+            Ok(removed) => removed,
+            Err(error) => {
+                warn!(%error, "failed to persist aggregation cleanup");
+                0
+            }
+        }
     }
 
     /// Cleanup only expired tasks
     pub fn cleanup_expired(&self) -> usize {
-        self.state.cleanup_expired()
+        match self.cleanup_with_persistence(CleanupKind::Expired) {
+            Ok(removed) => removed,
+            Err(error) => {
+                warn!(%error, "failed to persist expired aggregation cleanup");
+                0
+            }
+        }
     }
 
     /// Cleanup only submitted tasks
     pub fn cleanup_submitted(&self) -> usize {
-        self.state.cleanup_submitted()
+        match self.cleanup_with_persistence(CleanupKind::Submitted) {
+            Ok(removed) => removed,
+            Err(error) => {
+                warn!(%error, "failed to persist submitted aggregation cleanup");
+                0
+            }
+        }
     }
 }
 
@@ -483,8 +701,10 @@ pub struct ServiceStats {
 mod tests {
     use super::*;
     use alloy_primitives::keccak256;
+    use ark_ec::AffineRepr;
     use ark_serialize::CanonicalSerialize;
     use blueprint_crypto_core::KeyType;
+    use tempfile::tempdir;
 
     fn serialize_point(point: &impl CanonicalSerialize) -> Vec<u8> {
         let mut bytes = Vec::new();
@@ -703,5 +923,91 @@ mod tests {
         assert!(service.get_status(1, 100).exists);
         assert!(service.remove_task(1, 100));
         assert!(!service.get_status(1, 100).exists);
+    }
+
+    #[test]
+    fn file_persistence_recovers_pending_signatures_after_restart() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("aggregation.json");
+        let config = ServiceConfig::minimal();
+        let signature = ArkBlsBn254Signature(ark_bn254::G1Affine::generator());
+        let public_key = ArkBlsBn254Public(ark_bn254::G2Affine::generator());
+
+        let service = AggregationService::with_persistence(
+            config.clone(),
+            crate::persistence::FilePersistence::new(&path),
+        )
+        .unwrap();
+        service.init_task(7, 11, vec![1, 2, 3], 2, 1).unwrap();
+        service
+            .submit_signature(SubmitSignatureRequest {
+                service_id: 7,
+                call_id: 11,
+                operator_index: 0,
+                output: vec![9, 9],
+                signature: serialize_point(&signature.0),
+                public_key: serialize_point(&public_key.0),
+            })
+            .unwrap();
+        drop(service);
+
+        let recovered = AggregationService::with_persistence(
+            config,
+            crate::persistence::FilePersistence::new(&path),
+        )
+        .unwrap();
+        let status = recovered.get_status(7, 11);
+        assert!(status.exists);
+        assert_eq!(status.signatures_collected, 1);
+        assert!(status.threshold_met);
+        assert!(recovered.get_aggregated_result(7, 11).is_some());
+    }
+
+    #[test]
+    fn file_persistence_records_submit_and_remove_mutations() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("aggregation.json");
+        let config = ServiceConfig::minimal();
+        let service = AggregationService::with_persistence(
+            config.clone(),
+            crate::persistence::FilePersistence::new(&path),
+        )
+        .unwrap();
+        service.init_task(9, 13, vec![], 1, 1).unwrap();
+        service.mark_submitted(9, 13).unwrap();
+        drop(service);
+
+        let recovered = AggregationService::with_persistence(
+            config.clone(),
+            crate::persistence::FilePersistence::new(&path),
+        )
+        .unwrap();
+        assert!(recovered.get_status(9, 13).submitted);
+        assert!(recovered.remove_task(9, 13));
+        drop(recovered);
+
+        let final_service = AggregationService::with_persistence(
+            config,
+            crate::persistence::FilePersistence::new(&path),
+        )
+        .unwrap();
+        assert!(!final_service.get_status(9, 13).exists);
+    }
+
+    #[test]
+    fn file_persistence_rejects_corrupt_state_on_startup() {
+        let directory = tempdir().unwrap();
+        let path = directory.path().join("aggregation.json");
+        std::fs::write(&path, b"not-json").unwrap();
+
+        let result = AggregationService::with_persistence(
+            ServiceConfig::minimal(),
+            crate::persistence::FilePersistence::new(path),
+        );
+
+        assert!(matches!(
+            result,
+            Err(ServiceError::Other(message)) if message.contains("persistence error")
+        ));
     }
 }

--- a/crates/tangle-aggregation-svc/src/state.rs
+++ b/crates/tangle-aggregation-svc/src/state.rs
@@ -1,5 +1,6 @@
 //! In-memory aggregation state management
 
+use crate::persistence::{PersistedTaskState, PersistenceError};
 use crate::types::{Bn254SignatureScheme, TaskId};
 use alloy_primitives::U256;
 use blueprint_crypto_bn254::{ArkBlsBn254Public, ArkBlsBn254Signature};
@@ -328,6 +329,33 @@ impl AggregationState {
         Self {
             tasks: Arc::new(RwLock::new(HashMap::new())),
         }
+    }
+
+    pub(crate) fn snapshot(&self) -> Result<Vec<PersistedTaskState>, PersistenceError> {
+        self.tasks
+            .read()
+            .values()
+            .map(PersistedTaskState::try_from)
+            .collect()
+    }
+
+    pub(crate) fn restore(
+        &self,
+        persisted: Vec<PersistedTaskState>,
+    ) -> Result<(), PersistenceError> {
+        let mut recovered = HashMap::with_capacity(persisted.len());
+        for persisted in persisted {
+            let task = TaskState::try_from(persisted)?;
+            let task_id = TaskId::new(task.service_id, task.call_id);
+            if recovered.insert(task_id, task).is_some() {
+                return Err(PersistenceError::Serialization(format!(
+                    "duplicate persisted task {}/{}",
+                    task_id.service_id, task_id.call_id
+                )));
+            }
+        }
+        *self.tasks.write() = recovered;
+        Ok(())
     }
 
     /// Initialize a new aggregation task (simple API)


### PR DESCRIPTION
## Summary

- Add `AggregationService::with_persistence` using the existing `PersistenceBackend` API.
- Serialize and recover task messages, thresholds, stakes, signatures, signer bitmaps, timestamps, and submission state.
- Persist initialization, signature submission, submission marking, removal, and cleanup mutations.
- Fail closed on unreadable or malformed persisted state.

## Change Class

- Selected class: Class D
- Why this class: Persisted signatures and submission state control an aggregation protocol outcome and its on-chain handoff.

## Behavior Contract

- `AggregationService::new` keeps the existing in-memory behavior.
- `AggregationService::with_persistence` loads all tasks before returning and returns an error for unreadable or invalid state.
- Persisted mutations flush before the public mutation returns success.
- A failed persistence mutation restores the in-memory task and attempts to restore the previous backend record.
- Cleanup restores removed records when a backend delete or flush fails.

## Risk And Scope

- Scope is limited to `crates/tangle-aggregation-svc`.
- Existing public service methods keep their signatures; the new constructor returns `Result` so startup cannot silently discard state.
- `FilePersistence` remains the existing JSON backend with atomic temp-file replacement.
- Rollback: revert this commit and continue using `AggregationService::new`; persisted files remain untouched by the revert.
- The service serializes the complete in-memory task snapshot before each persisted mutation. Deployments with high task volume should use a backend suited to their write rate.

## Verification

```text
cargo fmt --package blueprint-tangle-aggregation-svc -- --check
cargo test -p blueprint-tangle-aggregation-svc --tests
cargo clippy -p blueprint-tangle-aggregation-svc --all-targets -- -D warnings
git diff --check
```

- Unit tests: 47 passed.
- Integration tests: 15 passed.
- Clippy completed successfully; the workspace emits its existing renamed-lint warnings.

## Harness Evidence

- `file_persistence_recovers_pending_signatures_after_restart` proves a pending signature and aggregate survive service reconstruction.
- `file_persistence_records_submit_and_remove_mutations` proves submission and removal survive reconstruction.
- `file_persistence_rejects_corrupt_state_on_startup` proves malformed state fails closed.
- Existing integration coverage includes concurrent submissions and task lifecycle behavior.

## Checklist

- [x] Behavior contract documented.
- [x] Negative-path startup and persistence behavior tested.
- [x] Public API compatibility reviewed.
- [x] Crate-scoped format, tests, clippy, and diff checks pass.
- [x] No autoresearch files changed.
