### PR TITLE
fix(tangle): propagate aggregate submission failures

### DIFF
--- a/crates/tangle-extra/src/aggregating_consumer.rs
+++ b/crates/tangle-extra/src/aggregating_consumer.rs
@@ -1012,14 +1012,17 @@ async fn submit_aggregated_result(
 
     if response.threshold_met {
         // Threshold already met, try to submit immediately
-        if let Err(e) =
-            try_submit_aggregated_to_chain(client.clone(), &agg, service_id, call_id).await
-        {
-            blueprint_core::debug!(
-                target: "tangle-aggregating-consumer",
-                "Failed to submit aggregated result (likely already submitted): {}",
-                e
-            );
+        match try_submit_aggregated_to_chain(client.clone(), &agg, service_id, call_id).await {
+            Ok(()) => {}
+            Err(error) if is_job_already_completed(&error) => {
+                blueprint_core::debug!(
+                    target: "tangle-aggregating-consumer",
+                    service_id,
+                    call_id,
+                    "Aggregated result was already submitted by another operator"
+                );
+            }
+            Err(error) => return Err(error),
         }
     } else if agg.wait_for_threshold {
         // Wait for threshold to be met, then submit
@@ -1032,14 +1035,19 @@ async fn submit_aggregated_result(
         let result = wait_for_threshold_any_service(&agg, service_id, call_id).await?;
 
         // Try to submit to chain (race with other operators)
-        if let Err(e) =
-            submit_aggregated_to_chain_with_result(client, &agg, service_id, call_id, result).await
+        match submit_aggregated_to_chain_with_result(client, &agg, service_id, call_id, result)
+            .await
         {
-            blueprint_core::debug!(
-                target: "tangle-aggregating-consumer",
-                "Failed to submit aggregated result (likely already submitted by another operator): {}",
-                e
-            );
+            Ok(()) => {}
+            Err(error) if is_job_already_completed(&error) => {
+                blueprint_core::debug!(
+                    target: "tangle-aggregating-consumer",
+                    service_id,
+                    call_id,
+                    "Aggregated result was already submitted by another operator"
+                );
+            }
+            Err(error) => return Err(error),
         }
     }
 
@@ -1087,7 +1095,7 @@ async fn wait_for_threshold_any_service(
     ))
 }
 
-/// Try to submit the aggregated result to chain, handling "already submitted" gracefully
+/// Try to submit the aggregated result to chain.
 #[cfg(feature = "aggregation")]
 async fn try_submit_aggregated_to_chain(
     client: Arc<TangleClient>,
@@ -1108,6 +1116,21 @@ async fn try_submit_aggregated_to_chain(
     Err(AggregatingConsumerError::Client(
         "Aggregated result not available from any service".to_string(),
     ))
+}
+
+/// Return true only for the idempotent aggregate-submission race.
+///
+/// The RPC provider may expose the Solidity custom error by name or only by
+/// selector. All other submission failures must reach the caller.
+#[cfg(feature = "aggregation")]
+const JOB_ALREADY_COMPLETED_SELECTOR: &str = "0x0a55512f";
+
+#[cfg(feature = "aggregation")]
+fn is_job_already_completed(error: &AggregatingConsumerError) -> bool {
+    let message = error.to_string().to_ascii_lowercase();
+    message.contains("jobalreadycompleted")
+        || message.contains("job already completed")
+        || message.contains(JOB_ALREADY_COMPLETED_SELECTOR)
 }
 
 /// Submit the aggregated result to the blockchain with a pre-fetched result
@@ -1396,6 +1419,30 @@ mod tests {
             Poll::Ready(Ok(()))
         ));
         assert!(state.is_waiting());
+    }
+
+    #[cfg(feature = "aggregation")]
+    #[test]
+    fn only_job_already_completed_is_an_idempotent_aggregate_submission_error() {
+        let by_selector = AggregatingConsumerError::Aggregation(
+            crate::aggregation::AggregationError::ContractError(
+                "execution reverted: custom error 0x0a55512f".to_string(),
+            ),
+        );
+        let by_name = AggregatingConsumerError::Aggregation(
+            crate::aggregation::AggregationError::ContractError(
+                "execution reverted: JobAlreadyCompleted".to_string(),
+            ),
+        );
+        let pubkey_mismatch = AggregatingConsumerError::Aggregation(
+            crate::aggregation::AggregationError::ContractError(
+                "execution reverted: custom error 0x437f07c7".to_string(),
+            ),
+        );
+
+        assert!(super::is_job_already_completed(&by_selector));
+        assert!(super::is_job_already_completed(&by_name));
+        assert!(!super::is_job_already_completed(&pubkey_mismatch));
     }
 
     // ═══════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
## Summary

- Propagate aggregate-result submission failures from `AggregatingConsumer`.
- Treat only the on-chain `JobAlreadyCompleted(uint64,uint64)` race as an idempotent success.
- Preserve the operator error for invalid keys, threshold failures, transport failures, and every other revert.

## Change Class

- Selected class: Class D
- Why this class: This changes failure handling for protocol result submission and prevents invalid results from being reported as successful.

## Behavior Contract

- Current behavior: Every aggregate submission error is logged as likely caused by another operator and then discarded.
- Intended behavior: A proven `JobAlreadyCompleted` error is benign; every other error returns to the job consumer.
- Invariants that must hold: A result is never acknowledged when the chain rejected its aggregate; duplicate completion remains idempotent; error selectors remain visible to the caller.
- Failure mode choice (`fail-closed` or `fail-open`) and rationale: Fail closed because hiding a rejected result can leave the service instance incomplete while reporting success.

## Risk and Scope

- Security impact: Invalid aggregate submissions are no longer silently accepted by the operator workflow.
- Compatibility impact (APIs, metadata format, configs): No public API, metadata, or configuration changes.
- Migration notes (if any): None.
- Rollback plan: Revert this commit; the change is isolated to the aggregation consumer.

## Verification

- `cargo fmt --all -- --check` — passed.
- `cargo test -p blueprint-tangle-extra aggregating_consumer::tests::failed_submission_resets_state_for_next_job -- --exact --nocapture` — passed.
- `cargo test -p blueprint-tangle-extra --features aggregation aggregating_consumer::tests::only_job_already_completed_is_an_idempotent_aggregate_submission_error -- --exact --nocapture` — passed.
- `cargo check -p blueprint-tangle-extra --features aggregation --lib` — passed.
- `cargo clippy -p blueprint-tangle-extra --features aggregation --all-targets -- -D warnings` — passed.

## Harness Evidence

- Reproducer added/updated: A focused unit test models RPC errors returned by the aggregate submission path.
- Negative-path coverage added: The test distinguishes `JobAlreadyCompleted` (`0x0a55512f`) from `AggregatedPubkeyMismatch` (`0x437f07c7`).
- Key assertions that prove the fix: The duplicate selector and named error are suppressed; the pubkey mismatch is returned to the caller.

## Checklist

- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md`](/docs/engineering/HARNESS_ENGINEERING_PLAYBOOK.md).
- [x] I followed [`docs/engineering/HARNESS_ENGINEERING_SPEC.md`](/docs/engineering/HARNESS_ENGINEERING_SPEC.md).
- [x] I used [`docs/engineering/HARNESS_REVIEW_CHECKLIST.md`](/docs/engineering/HARNESS_REVIEW_CHECKLIST.md) while implementing/reviewing.
- [x] I added or updated tests that reproduce the original issue.
- [x] I added or updated negative-path tests for invalid/missing/conflicting input.
- [x] I documented behavior or interface changes in docs/examples when needed.
- [x] I evaluated compatibility/migration impact explicitly.
- [x] I validated local formatting, clippy, and relevant tests.
