### PR TITLE
fix(aggregation): release waiting operators after submission

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4017,6 +4017,7 @@ dependencies = [
  "ark-bn254 0.6.0",
  "ark-ff 0.6.0",
  "ark-serialize 0.6.0",
+ "axum",
  "blueprint-anvil-testing-utils",
  "blueprint-chain-setup-anvil",
  "blueprint-client-tangle",

--- a/crates/tangle-aggregation-svc/src/client.rs
+++ b/crates/tangle-aggregation-svc/src/client.rs
@@ -56,6 +56,18 @@ pub enum ClientError {
     /// Threshold not met
     #[error("Threshold not met: {collected}/{required}")]
     ThresholdNotMet { collected: usize, required: usize },
+    /// Another operator already submitted this task to the chain.
+    #[error("Aggregation task was already submitted to the chain")]
+    AlreadySubmitted,
+}
+
+/// Outcome of waiting for an aggregation task.
+#[derive(Debug)]
+pub enum ThresholdWaitResult {
+    /// The caller can submit this aggregate to the chain.
+    Aggregated(AggregatedResultResponse),
+    /// Another operator already submitted the task.
+    Submitted,
 }
 
 /// HTTP client for the aggregation service
@@ -242,6 +254,27 @@ impl AggregationServiceClient {
         Ok(result)
     }
 
+    /// Return an aggregate or learn that another operator submitted it.
+    pub async fn get_aggregated_or_submitted(
+        &self,
+        service_id: u64,
+        call_id: u64,
+    ) -> Result<ThresholdWaitResult, ClientError> {
+        if let Some(result) = self.get_aggregated(service_id, call_id).await? {
+            return Ok(ThresholdWaitResult::Aggregated(result));
+        }
+
+        let status = self.get_status(service_id, call_id).await?;
+        if status.submitted {
+            return Ok(ThresholdWaitResult::Submitted);
+        }
+
+        Err(ClientError::ThresholdNotMet {
+            collected: status.signatures_collected,
+            required: status.threshold_required,
+        })
+    }
+
     /// Mark a task as submitted to the chain
     pub async fn mark_submitted(&self, service_id: u64, call_id: u64) -> Result<(), ClientError> {
         let url = format!("{}/v1/tasks/mark-submitted", self.base_url);
@@ -291,12 +324,36 @@ impl AggregationServiceClient {
         poll_interval: Duration,
         timeout: Duration,
     ) -> Result<AggregatedResultResponse, ClientError> {
+        match self
+            .wait_for_threshold_or_submitted(service_id, call_id, poll_interval, timeout)
+            .await?
+        {
+            ThresholdWaitResult::Aggregated(result) => Ok(result),
+            ThresholdWaitResult::Submitted => Err(ClientError::AlreadySubmitted),
+        }
+    }
+
+    /// Wait for an aggregate or learn that another operator submitted it.
+    ///
+    /// A submitted task no longer exposes aggregate bytes. Waiting only on the
+    /// aggregate endpoint would therefore wait until timeout after a successful
+    /// submission by another operator.
+    pub async fn wait_for_threshold_or_submitted(
+        &self,
+        service_id: u64,
+        call_id: u64,
+        poll_interval: Duration,
+        timeout: Duration,
+    ) -> Result<ThresholdWaitResult, ClientError> {
         let start = std::time::Instant::now();
 
         loop {
             if start.elapsed() > timeout {
                 // Get current status for error message
                 let status = self.get_status(service_id, call_id).await?;
+                if status.submitted {
+                    return Ok(ThresholdWaitResult::Submitted);
+                }
                 return Err(ClientError::ThresholdNotMet {
                     collected: status.signatures_collected,
                     required: status.threshold_required,
@@ -305,7 +362,12 @@ impl AggregationServiceClient {
 
             // Check if aggregated result is available
             if let Some(result) = self.get_aggregated(service_id, call_id).await? {
-                return Ok(result);
+                return Ok(ThresholdWaitResult::Aggregated(result));
+            }
+
+            let status = self.get_status(service_id, call_id).await?;
+            if status.submitted {
+                return Ok(ThresholdWaitResult::Submitted);
             }
 
             // Wait before next poll
@@ -317,6 +379,8 @@ impl AggregationServiceClient {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::{api, AggregationService, ServiceConfig};
+    use std::sync::Arc;
 
     #[test]
     fn test_client_url_normalization() {
@@ -325,5 +389,41 @@ mod tests {
 
         let client = AggregationServiceClient::new("http://localhost:8080");
         assert_eq!(client.base_url, "http://localhost:8080");
+    }
+
+    #[tokio::test]
+    async fn waiting_operator_observes_submitted_task_without_aggregate_replay() {
+        let service = Arc::new(AggregationService::new(ServiceConfig::default()));
+        service.init_task(1, 1, vec![1], 2, 2).unwrap();
+        service.mark_submitted(1, 1).unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server = tokio::spawn(async move {
+            axum::serve(listener, api::router(service)).await.unwrap();
+        });
+
+        let client = AggregationServiceClient::new(format!("http://{address}"));
+        assert!(matches!(
+            client.get_aggregated_or_submitted(1, 1).await.unwrap(),
+            ThresholdWaitResult::Submitted
+        ));
+
+        let result = tokio::time::timeout(
+            Duration::from_millis(250),
+            client.wait_for_threshold_or_submitted(
+                1,
+                1,
+                Duration::from_millis(5),
+                Duration::from_secs(30),
+            ),
+        )
+        .await
+        .expect("submitted state should complete promptly")
+        .unwrap();
+
+        assert!(matches!(result, ThresholdWaitResult::Submitted));
+        server.abort();
+        let _ = server.await;
     }
 }

--- a/crates/tangle-aggregation-svc/src/lib.rs
+++ b/crates/tangle-aggregation-svc/src/lib.rs
@@ -55,7 +55,7 @@ pub mod state;
 pub mod types;
 
 #[cfg(feature = "client")]
-pub use client::{AggregationServiceClient, ClientError};
+pub use client::{AggregationServiceClient, ClientError, ThresholdWaitResult};
 pub use persistence::{
     FilePersistence, NoPersistence, PersistedTaskState, PersistedThresholdType, PersistenceBackend,
     PersistenceError,

--- a/crates/tangle-aggregation-svc/src/persistence.rs
+++ b/crates/tangle-aggregation-svc/src/persistence.rs
@@ -80,6 +80,9 @@ pub struct PersistedTaskState {
     pub total_stake: u64,
     /// Whether this task has been submitted to chain
     pub submitted: bool,
+    /// When this task was submitted to chain (unix timestamp millis)
+    #[serde(default)]
+    pub submitted_at_ms: Option<u64>,
     /// When this task was created (unix timestamp millis)
     pub created_at_ms: u64,
     /// When this task expires (unix timestamp millis, None = never)
@@ -140,6 +143,7 @@ impl TryFrom<&TaskState> for PersistedTaskState {
             operator_stakes: task.operator_stakes.clone(),
             total_stake: task.total_stake,
             submitted: task.submitted,
+            submitted_at_ms: task.submitted_at.map(instant_to_millis),
             created_at_ms: instant_to_millis(task.created_at),
             expires_at_ms: task.expires_at.map(instant_to_millis),
         })
@@ -205,6 +209,10 @@ impl TryFrom<PersistedTaskState> for TaskState {
         }
 
         task.submitted = persisted.submitted;
+        task.submitted_at = persisted
+            .submitted_at_ms
+            .map(millis_to_instant)
+            .or_else(|| task.submitted.then_some(Instant::now()));
         task.created_at = millis_to_instant(persisted.created_at_ms);
         task.expires_at = persisted.expires_at_ms.map(millis_to_instant);
         Ok(task)
@@ -488,6 +496,7 @@ mod tests {
             operator_stakes: HashMap::from([(0, 100), (1, 100), (2, 100), (3, 100), (4, 100)]),
             total_stake: 500,
             submitted: false,
+            submitted_at_ms: None,
             created_at_ms: 1700000000000,
             expires_at_ms: Some(1700001000000),
         }

--- a/crates/tangle-aggregation-svc/src/service.rs
+++ b/crates/tangle-aggregation-svc/src/service.rs
@@ -50,6 +50,8 @@ pub struct ServiceConfig {
     pub cleanup_interval: Option<Duration>,
     /// Whether to auto-cleanup submitted tasks
     pub auto_cleanup_submitted: bool,
+    /// How long submitted tasks remain observable before cleanup
+    pub submitted_task_retention: Duration,
 }
 
 impl Default for ServiceConfig {
@@ -60,6 +62,7 @@ impl Default for ServiceConfig {
             default_task_ttl: Some(Duration::from_secs(3600)), // 1 hour default
             cleanup_interval: Some(Duration::from_secs(60)),   // Cleanup every minute
             auto_cleanup_submitted: true,
+            submitted_task_retention: Duration::from_secs(120),
         }
     }
 }
@@ -73,6 +76,7 @@ impl ServiceConfig {
             default_task_ttl: None,
             cleanup_interval: None,
             auto_cleanup_submitted: false,
+            submitted_task_retention: Duration::ZERO,
         }
     }
 }
@@ -201,9 +205,13 @@ impl AggregationService {
         let _guard = self.mutation_lock.lock();
         let before = self.snapshot()?;
         let removed = match kind {
-            CleanupKind::All => self.state.cleanup(),
+            CleanupKind::All => self
+                .state
+                .cleanup_with_submitted_retention(self.config.submitted_task_retention),
             CleanupKind::Expired => self.state.cleanup_expired(),
-            CleanupKind::Submitted => self.state.cleanup_submitted(),
+            CleanupKind::Submitted => self
+                .state
+                .cleanup_submitted_after(self.config.submitted_task_retention),
         };
         if removed == 0 {
             return Ok(0);
@@ -761,6 +769,7 @@ mod tests {
         assert!(config.default_task_ttl.is_some());
         assert!(config.cleanup_interval.is_some());
         assert!(config.auto_cleanup_submitted);
+        assert_eq!(config.submitted_task_retention, Duration::from_secs(120));
     }
 
     #[test]
@@ -771,6 +780,7 @@ mod tests {
         assert!(config.default_task_ttl.is_none());
         assert!(config.cleanup_interval.is_none());
         assert!(!config.auto_cleanup_submitted);
+        assert_eq!(config.submitted_task_retention, Duration::ZERO);
     }
 
     #[test]
@@ -872,6 +882,18 @@ mod tests {
 
         let status = service.get_status(1, 100);
         assert!(status.submitted);
+    }
+
+    #[test]
+    fn submitted_cleanup_honors_observation_retention() {
+        let mut config = ServiceConfig::minimal();
+        config.submitted_task_retention = Duration::from_secs(60);
+        let service = AggregationService::new(config);
+        service.init_task(1, 100, vec![], 1, 1).unwrap();
+        service.mark_submitted(1, 100).unwrap();
+
+        assert_eq!(service.cleanup_submitted(), 0);
+        assert!(service.get_status(1, 100).submitted);
     }
 
     #[test]

--- a/crates/tangle-aggregation-svc/src/state.rs
+++ b/crates/tangle-aggregation-svc/src/state.rs
@@ -71,6 +71,8 @@ pub struct TaskState {
     pub total_stake: u64,
     /// Whether this task has been submitted to chain
     pub submitted: bool,
+    /// When this task was submitted to chain
+    pub submitted_at: Option<Instant>,
     /// When this task was created
     pub created_at: Instant,
     /// When this task expires (None = never)
@@ -161,6 +163,7 @@ impl TaskState {
             operator_stakes: stakes,
             total_stake,
             submitted: false,
+            submitted_at: None,
             created_at: now,
             expires_at,
         }
@@ -540,6 +543,7 @@ impl AggregationState {
 
         let task = tasks.get_mut(&task_id).ok_or("Task not found")?;
         task.submitted = true;
+        task.submitted_at = Some(Instant::now());
         Ok(())
     }
 
@@ -561,18 +565,39 @@ impl AggregationState {
     /// Cleanup submitted tasks
     /// Returns the number of tasks removed
     pub fn cleanup_submitted(&self) -> usize {
+        self.cleanup_submitted_after(Duration::ZERO)
+    }
+
+    /// Cleanup submitted tasks after they have been observable for a grace period.
+    pub fn cleanup_submitted_after(&self, retention: Duration) -> usize {
         let mut tasks = self.tasks.write();
         let before = tasks.len();
-        tasks.retain(|_, task| !task.submitted);
+        tasks.retain(|_, task| {
+            !task.submitted
+                || task
+                    .submitted_at
+                    .is_some_and(|submitted_at| submitted_at.elapsed() < retention)
+        });
         before - tasks.len()
     }
 
     /// Cleanup both expired and submitted tasks
     /// Returns the number of tasks removed
     pub fn cleanup(&self) -> usize {
+        self.cleanup_with_submitted_retention(Duration::ZERO)
+    }
+
+    /// Cleanup expired tasks and submitted tasks past their observation grace period.
+    pub fn cleanup_with_submitted_retention(&self, retention: Duration) -> usize {
         let mut tasks = self.tasks.write();
         let before = tasks.len();
-        tasks.retain(|_, task| !task.is_expired() && !task.submitted);
+        tasks.retain(|_, task| {
+            !task.is_expired()
+                && (!task.submitted
+                    || task
+                        .submitted_at
+                        .is_some_and(|submitted_at| submitted_at.elapsed() < retention))
+        });
         before - tasks.len()
     }
 
@@ -1056,6 +1081,22 @@ mod tests {
         assert_eq!(removed, 1);
         assert_eq!(state.task_count(), 1);
         assert!(state.get_status(1, 101).is_some());
+    }
+
+    #[test]
+    fn test_submitted_task_remains_observable_during_retention() {
+        let state = AggregationState::new();
+
+        state.init_task(1, 100, vec![], 1, 1).unwrap();
+        state.mark_submitted(1, 100).unwrap();
+
+        assert_eq!(state.cleanup_submitted_after(Duration::from_secs(60)), 0);
+        assert!(state
+            .get_status(1, 100)
+            .is_some_and(|status| status.submitted));
+
+        assert_eq!(state.cleanup_submitted_after(Duration::ZERO), 1);
+        assert!(state.get_status(1, 100).is_none());
     }
 
     #[test]

--- a/crates/tangle-aggregation-svc/src/state.rs
+++ b/crates/tangle-aggregation-svc/src/state.rs
@@ -592,11 +592,12 @@ impl AggregationState {
         let mut tasks = self.tasks.write();
         let before = tasks.len();
         tasks.retain(|_, task| {
-            !task.is_expired()
-                && (!task.submitted
-                    || task
-                        .submitted_at
-                        .is_some_and(|submitted_at| submitted_at.elapsed() < retention))
+            if task.submitted {
+                task.submitted_at
+                    .is_some_and(|submitted_at| submitted_at.elapsed() < retention)
+            } else {
+                !task.is_expired()
+            }
         });
         before - tasks.len()
     }
@@ -1097,6 +1098,32 @@ mod tests {
 
         assert_eq!(state.cleanup_submitted_after(Duration::ZERO), 1);
         assert!(state.get_status(1, 100).is_none());
+    }
+
+    #[test]
+    fn submitted_retention_overrides_task_expiry() {
+        let state = AggregationState::new();
+        state
+            .init_task_with_config(
+                1,
+                100,
+                vec![],
+                1,
+                TaskConfig {
+                    ttl: Some(Duration::ZERO),
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        state.mark_submitted(1, 100).unwrap();
+
+        assert_eq!(
+            state.cleanup_with_submitted_retention(Duration::from_secs(60)),
+            0
+        );
+        assert!(state
+            .get_status(1, 100)
+            .is_some_and(|status| status.submitted));
     }
 
     #[test]

--- a/crates/tangle-extra/Cargo.toml
+++ b/crates/tangle-extra/Cargo.toml
@@ -49,6 +49,7 @@ tracing.workspace = true
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros", "time"] }
+axum = { workspace = true, features = ["json", "tokio", "http1", "http2"] }
 alloy-provider = { workspace = true }
 alloy-signer-local = { workspace = true }
 alloy-network = { workspace = true }

--- a/crates/tangle-extra/src/aggregating_consumer.rs
+++ b/crates/tangle-extra/src/aggregating_consumer.rs
@@ -1113,6 +1113,24 @@ async fn wait_for_threshold_any_service(
         tokio::time::sleep(poll_interval).await;
     }
 
+    // A submission can race with the final loop condition. Check completion
+    // once more before reporting a timeout.
+    for client in &agg.clients {
+        match client.get_status(service_id, call_id).await {
+            Ok(status) if status.submitted => {
+                return Ok(ThresholdWaitResult::Submitted);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                blueprint_core::trace!(
+                    target: "tangle-aggregating-consumer",
+                    "Error polling final aggregation status: {}",
+                    e
+                );
+            }
+        }
+    }
+
     Err(AggregatingConsumerError::Client(
         "Timeout waiting for aggregation threshold".to_string(),
     ))
@@ -1475,6 +1493,49 @@ mod tests {
         assert!(super::is_job_already_completed(&by_selector));
         assert!(super::is_job_already_completed(&by_name));
         assert!(!super::is_job_already_completed(&pubkey_mismatch));
+    }
+
+    #[cfg(feature = "aggregation")]
+    #[tokio::test]
+    async fn wait_for_threshold_checks_submission_at_deadline() {
+        use blueprint_crypto_bn254::ArkBlsBn254;
+        use blueprint_crypto_core::KeyType;
+        use blueprint_tangle_aggregation_svc::{
+            AggregationService, ServiceConfig, ThresholdWaitResult, api,
+        };
+        use std::sync::Arc;
+        use std::time::Duration;
+
+        let service = Arc::new(AggregationService::new(ServiceConfig::minimal()));
+        service.init_task(1, 1, vec![1], 2, 2).unwrap();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let server_service = Arc::clone(&service);
+        let server = tokio::spawn(async move {
+            axum::serve(listener, api::router(server_service))
+                .await
+                .unwrap();
+        });
+
+        let submitter = Arc::clone(&service);
+        let marker = tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(20)).await;
+            submitter.mark_submitted(1, 1).unwrap();
+        });
+
+        let secret = ArkBlsBn254::generate_with_seed(Some(&[1u8; 32])).unwrap();
+        let mut config =
+            super::AggregationServiceConfig::new(format!("http://{address}"), secret, 0);
+        config.threshold_timeout = Duration::from_millis(50);
+        config.poll_interval = Duration::from_millis(75);
+
+        let result = super::wait_for_threshold_any_service(&config, 1, 1).await;
+        assert!(matches!(result, Ok(ThresholdWaitResult::Submitted)));
+
+        marker.await.unwrap();
+        server.abort();
+        let _ = server.await;
     }
 
     // ═══════════════════════════════════════════════════════════════════════════

--- a/crates/tangle-extra/src/aggregating_consumer.rs
+++ b/crates/tangle-extra/src/aggregating_consumer.rs
@@ -36,7 +36,7 @@ use blueprint_std::sync::{Arc, Mutex};
 use blueprint_std::time::Duration;
 use blueprint_std::vec::Vec;
 #[cfg(feature = "aggregation")]
-use blueprint_tangle_aggregation_svc::{OperatorStake, ThresholdConfig};
+use blueprint_tangle_aggregation_svc::{OperatorStake, ThresholdConfig, ThresholdWaitResult};
 use core::pin::Pin;
 use core::task::{Context, Poll};
 use futures_util::Sink;
@@ -1033,6 +1033,15 @@ async fn submit_aggregated_result(
 
         // Try to get result from any service
         let result = wait_for_threshold_any_service(&agg, service_id, call_id).await?;
+        let ThresholdWaitResult::Aggregated(result) = result else {
+            blueprint_core::debug!(
+                target: "tangle-aggregating-consumer",
+                service_id,
+                call_id,
+                "Another operator already submitted the aggregated result"
+            );
+            return Ok(());
+        };
 
         // Try to submit to chain (race with other operators)
         match submit_aggregated_to_chain_with_result(client, &agg, service_id, call_id, result)
@@ -1060,7 +1069,7 @@ async fn wait_for_threshold_any_service(
     agg: &AggregationServiceConfig,
     service_id: u64,
     call_id: u64,
-) -> Result<blueprint_tangle_aggregation_svc::AggregatedResultResponse, AggregatingConsumerError> {
+) -> Result<ThresholdWaitResult, AggregatingConsumerError> {
     use blueprint_std::time::Instant;
 
     let start = Instant::now();
@@ -1072,7 +1081,7 @@ async fn wait_for_threshold_any_service(
         for client in &agg.clients {
             match client.get_aggregated(service_id, call_id).await {
                 Ok(Some(result)) => {
-                    return Ok(result);
+                    return Ok(ThresholdWaitResult::Aggregated(result));
                 }
                 Ok(None) => {
                     // Threshold not yet met on this service
@@ -1081,6 +1090,20 @@ async fn wait_for_threshold_any_service(
                     blueprint_core::trace!(
                         target: "tangle-aggregating-consumer",
                         "Error polling aggregation service: {}",
+                        e
+                    );
+                }
+            }
+
+            match client.get_status(service_id, call_id).await {
+                Ok(status) if status.submitted => {
+                    return Ok(ThresholdWaitResult::Submitted);
+                }
+                Ok(_) => {}
+                Err(e) => {
+                    blueprint_core::trace!(
+                        target: "tangle-aggregating-consumer",
+                        "Error polling aggregation status: {}",
                         e
                     );
                 }
@@ -1105,11 +1128,18 @@ async fn try_submit_aggregated_to_chain(
 ) -> Result<(), AggregatingConsumerError> {
     // Try to get result from any service
     for service_client in &agg.clients {
-        if let Ok(Some(result)) = service_client.get_aggregated(service_id, call_id).await {
-            return submit_aggregated_to_chain_with_result(
-                client, agg, service_id, call_id, result,
-            )
-            .await;
+        match service_client
+            .get_aggregated_or_submitted(service_id, call_id)
+            .await
+        {
+            Ok(ThresholdWaitResult::Submitted) => return Ok(()),
+            Ok(ThresholdWaitResult::Aggregated(result)) => {
+                return submit_aggregated_to_chain_with_result(
+                    client, agg, service_id, call_id, result,
+                )
+                .await;
+            }
+            Err(_) => {}
         }
     }
 

--- a/crates/tangle-extra/src/strategy.rs
+++ b/crates/tangle-extra/src/strategy.rs
@@ -320,6 +320,7 @@ pub enum StrategyError {
     Timeout,
 
     /// Another operator already submitted this task to the chain.
+    /// Treat this as an idempotent no-op and do not submit the aggregate again.
     #[error("Aggregation task was already submitted to the chain")]
     AlreadySubmitted,
 

--- a/crates/tangle-extra/src/strategy.rs
+++ b/crates/tangle-extra/src/strategy.rs
@@ -319,6 +319,10 @@ pub enum StrategyError {
     #[error("Aggregation timed out")]
     Timeout,
 
+    /// Another operator already submitted this task to the chain.
+    #[error("Aggregation task was already submitted to the chain")]
+    AlreadySubmitted,
+
     /// Serialization error
     #[error("Serialization error: {0}")]
     Serialization(String),
@@ -403,7 +407,7 @@ async fn aggregate_via_http(
 ) -> Result<AggregatedSignatureResult, StrategyError> {
     use blueprint_crypto_core::{BytesEncoding, KeyType};
     use blueprint_tangle_aggregation_svc::{
-        SubmitSignatureRequest, ThresholdConfig, create_signing_message,
+        SubmitSignatureRequest, ThresholdConfig, ThresholdWaitResult, create_signing_message,
     };
 
     blueprint_core::debug!(
@@ -461,29 +465,28 @@ async fn aggregate_via_http(
 
     // Wait for threshold if configured
     let result = if config.wait_for_threshold {
-        if response.threshold_met {
-            config
-                .client
-                .get_aggregated(service_id, call_id)
-                .await?
-                .ok_or_else(|| StrategyError::Bls("Aggregated result not available".into()))?
-        } else {
-            config
-                .client
-                .wait_for_threshold(
-                    service_id,
-                    call_id,
-                    config.poll_interval,
-                    config.threshold_timeout,
-                )
-                .await?
+        match config
+            .client
+            .wait_for_threshold_or_submitted(
+                service_id,
+                call_id,
+                config.poll_interval,
+                config.threshold_timeout,
+            )
+            .await?
+        {
+            ThresholdWaitResult::Aggregated(result) => result,
+            ThresholdWaitResult::Submitted => return Err(StrategyError::AlreadySubmitted),
         }
     } else if response.threshold_met {
-        config
+        match config
             .client
-            .get_aggregated(service_id, call_id)
+            .get_aggregated_or_submitted(service_id, call_id)
             .await?
-            .ok_or_else(|| StrategyError::Bls("Aggregated result not available".into()))?
+        {
+            ThresholdWaitResult::Aggregated(result) => result,
+            ThresholdWaitResult::Submitted => return Err(StrategyError::AlreadySubmitted),
+        }
     } else {
         // Return early - threshold not met and not waiting
         return Err(StrategyError::ThresholdNotMet {


### PR DESCRIPTION
## Summary

- Fix the two-operator aggregation race that leaves a waiting result consumer blocked after another operator submits the aggregate.
- The affected flow is the Blueprint operator result sink and the reusable HTTP aggregation strategy.

## Change Class

- Selected class: Class C
- Why this class: The fix changes coordinated behavior across the aggregation-service client and Tangle result consumer.

## Behavior Contract

- Current behavior: `/v1/tasks/aggregate` hides submitted tasks, so a waiting operator polls until timeout after another operator submits.
- Intended behavior: A waiting operator observes `submitted=true`, completes its result task as an idempotent no-op, and processes the next result.
- Invariants that must hold: Only one aggregate submission reaches the chain; aggregate bytes remain unavailable after submission; all other submission errors still propagate.
- Failure mode choice (`fail-closed` or `fail-open`) and rationale: Fail-closed for aggregate data and chain submission; submitted state is the explicit successful terminal state.

## Risk And Scope

- Security impact: None. The change does not alter signatures, quorum checks, signed messages, or contract calls.
- Compatibility impact (APIs, metadata format, configs): Adds client wait-result APIs and a typed `AlreadySubmitted` error; existing aggregate payloads and configuration formats remain unchanged.
- Migration notes (if any): None.
- Rollback plan: Revert commit `1d73b439583e07252f9a0d4f6accbf392d57f609`.

## Verification

- `cargo fmt --all -- --check` — pass.
- `cargo test -p blueprint-tangle-aggregation-svc --features client` — 49 unit tests and 15 integration tests pass.
- `cargo test -p blueprint-tangle-extra --features aggregation` — 106 unit tests, 3 aggregation E2E tests, 5 Anvil tests, and 1 producer test pass.
- `cargo clippy -p blueprint-tangle-aggregation-svc --features client --all-targets -- -D warnings` — pass.
- `cargo clippy -p blueprint-tangle-extra --features aggregation --all-targets -- -D warnings` — pass.

## Harness Evidence

- Reproducer added/updated: `client::tests::waiting_operator_observes_submitted_task_without_aggregate_replay`. It serves the real Axum aggregation API, marks a task submitted, and verifies both wait and aggregate-or-submitted paths.
- Negative-path coverage added: The test confirms no aggregate bytes replay after submission.
- Key assertions that prove the fix: The waiting call returns `ThresholdWaitResult::Submitted` under 250 ms with a 30 s wait budget.
- Original artifact: `/tmp/autoresearch-lifecycle-20260814T112021Z-1744846` recorded `call_id=5` at `1/2` signatures and `submitted=false` for the waiting service, followed by `timed out waiting for AggregatedResultSubmitted`.

## Checklist

- [x] I followed the harness engineering playbook.
- [x] I followed the harness engineering specification.
- [x] I used the harness review checklist while implementing and reviewing.
- [x] I added or updated tests that reproduce the original issue.
- [x] I added or updated negative-path tests for invalid, missing, or conflicting input.
- [x] I documented behavior or interface changes in docs or examples when needed.
- [x] I evaluated compatibility and migration impact explicitly.
- [x] I validated local formatting, Clippy, and relevant tests.