### PR TITLE
ci: make Playproof bootstrap failures inspectable

### DIFF
--- a/.github/workflows/bootstrap-playproof-repository.yml
+++ b/.github/workflows/bootstrap-playproof-repository.yml
@@ -9,10 +9,11 @@ on:
 
 permissions:
   contents: read
+  issues: write
 
 concurrency:
   group: bootstrap-playproof-repository
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   bootstrap:
@@ -158,3 +159,15 @@ jobs:
           test "$default_branch" = main
           test "$parent_count" -eq 0
           echo "Playproof public root: $root_sha"
+
+      - name: Publish inspectable run receipt
+        if: always()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          JOB_STATUS: ${{ job.status }}
+          RUN_ID: ${{ github.run_id }}
+          RUN_ATTEMPT: ${{ github.run_attempt }}
+        run: |
+          gh issue create --repo tangle-network/blueprint \
+            --title "Playproof bootstrap ${JOB_STATUS}: run ${RUN_ID}.${RUN_ATTEMPT}" \
+            --body "Bootstrap status: **${JOB_STATUS}**\n\nRun: https://github.com/tangle-network/blueprint/actions/runs/${RUN_ID}/attempts/${RUN_ATTEMPT}\n\nCommit: ${GITHUB_SHA}\n\nThis receipt is generated even when an earlier bootstrap step fails."


### PR DESCRIPTION
## Summary

- Makes the one-shot Playproof bootstrap cancel an opaque older attempt when a newer workflow revision lands.
- Adds an always-run issue receipt containing the exact Actions run URL and job outcome, so any failure is immediately inspectable through the connected GitHub tools.

## Change Class

- Selected class: Class A
- Why this class: temporary GitHub Actions observability only; no Blueprint crate or runtime behavior changes.

## Behavior Contract

- Current behavior: a failed bootstrap can leave only the absence of `tangle-network/playproof`, with no run ID available through the current connector surface.
- Intended behavior: every bootstrap attempt creates a success/failure receipt linking the exact workflow attempt.
- Invariants that must hold: repository creation remains fail-closed; no secrets enter the issue; newer diagnostic runs cancel opaque older attempts.
- Failure mode choice (`fail-closed` or `fail-open`) and rationale: fail-closed for repository publication; the status receipt uses `if: always()` and reports only metadata.

## Risk And Scope

- Security impact: none; the issue contains run ID, commit SHA, and job status only.
- Compatibility impact: none.
- Migration notes: temporary workflow removed after successful public bootstrap.
- Rollback plan: revert this workflow-only commit.

## Verification

```bash
# GitHub validates workflow syntax and PR policy.
# The push-to-main run emits an issue receipt even on failure.
```

## Harness Evidence

- Reproducer added/updated: exact Actions run URL emitted for every attempt.
- Negative-path coverage added: `if: always()` receipt executes after earlier-step failure.
- Key assertions: job status and run attempt are sourced from GitHub contexts; no secret values are included.

## Checklist

- [x] Reviewed the workflow against the harness engineering guidance.
- [x] Added a negative-path receipt.
- [x] Evaluated security and rollback impact.
- [x] Change is isolated to `.github/workflows/**`.